### PR TITLE
[Refactor] 리뷰반영 - 레이아웃 main 적용, 헤더 네비 링크 상수 분리 (#9)

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,8 +1,8 @@
 export default function AdminPage() {
   return (
-    <main className="mx-auto max-w-6xl px-4 py-8 sm:px-6">
+    <div className="mx-auto max-w-6xl px-4 py-8 sm:px-6">
       <h1 className="text-xl font-semibold text-neutral-900">관리자페이지</h1>
       <p className="mt-2 text-sm text-neutral-500">페이지 준비 중입니다.</p>
-    </main>
+    </div>
   )
 }

--- a/src/app/find-my-scent/ai-visual/page.tsx
+++ b/src/app/find-my-scent/ai-visual/page.tsx
@@ -1,10 +1,10 @@
 export default function AIVisualPage() {
   return (
-    <main className="mx-auto max-w-6xl px-4 py-8 sm:px-6">
+    <div className="mx-auto max-w-6xl px-4 py-8 sm:px-6">
       <h1 className="mb-6 text-2xl font-semibold text-neutral-900">
         AI 비주얼 분석
       </h1>
       <p className="text-neutral-600">AI 비주얼 분석 콘텐츠가 여기에 표시됩니다.</p>
-    </main>
+    </div>
   )
 }

--- a/src/app/find-my-scent/taste-test/page.tsx
+++ b/src/app/find-my-scent/taste-test/page.tsx
@@ -1,10 +1,10 @@
 export default function TasteTestPage() {
   return (
-    <main className="mx-auto max-w-6xl px-4 py-8 sm:px-6">
+    <div className="mx-auto max-w-6xl px-4 py-8 sm:px-6">
       <h1 className="mb-6 text-2xl font-semibold text-neutral-900">
         취향 추천 테스트
       </h1>
       <p className="text-neutral-600">취향 추천 테스트 콘텐츠가 여기에 표시됩니다.</p>
-    </main>
+    </div>
   )
 }

--- a/src/app/find-my-scent/wellness/page.tsx
+++ b/src/app/find-my-scent/wellness/page.tsx
@@ -1,10 +1,10 @@
 export default function WellnessPage() {
   return (
-    <main className="mx-auto max-w-6xl px-4 py-8 sm:px-6">
+    <div className="mx-auto max-w-6xl px-4 py-8 sm:px-6">
       <h1 className="mb-6 text-2xl font-semibold text-neutral-900">
         웰니스 케어 진단
       </h1>
       <p className="text-neutral-600">웰니스 케어 진단 콘텐츠가 여기에 표시됩니다.</p>
-    </main>
+    </div>
   )
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,7 +30,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} flex min-h-screen flex-col antialiased`}
       >
         <Header />
-        <div className="flex-1">{children}</div>
+        <main className="flex-1">{children}</main>
         <Footer />
       </body>
     </html>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,10 +1,10 @@
 export default function LoginPage() {
   return (
-    <main className="mx-auto max-w-6xl px-4 py-8 sm:px-6">
+    <div className="mx-auto max-w-6xl px-4 py-8 sm:px-6">
       <h1 className="mb-6 text-2xl font-semibold text-neutral-900">
         로그인
       </h1>
       <p className="text-neutral-600">페이지 준비 중입니다.</p>
-    </main>
+    </div>
   )
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,10 @@
 export default function Home() {
   return (
-    <main className="mx-auto max-w-6xl px-4 py-8 sm:px-6">
+    <div className="mx-auto max-w-6xl px-4 py-8 sm:px-6">
       <h1 className="mb-6 text-2xl font-semibold text-neutral-900">
       DeepScent
       </h1>
       <p className="text-neutral-600">랜딩 페이지 준비 중입니다.</p>
-    </main>
+    </div>
   )
 }

--- a/src/app/products/combo/page.tsx
+++ b/src/app/products/combo/page.tsx
@@ -1,8 +1,8 @@
 export default function ProductsComboPage() {
   return (
-    <main className="mx-auto max-w-6xl px-4 py-8 sm:px-6">
+    <div className="mx-auto max-w-6xl px-4 py-8 sm:px-6">
       <h1 className="mb-6 text-2xl font-semibold text-neutral-900">조합</h1>
       <p className="text-neutral-600">조합 상품 목록이 여기에 표시됩니다.</p>
-    </main>
+    </div>
   )
 }

--- a/src/app/products/single/page.tsx
+++ b/src/app/products/single/page.tsx
@@ -1,8 +1,8 @@
 export default function ProductsSinglePage() {
   return (
-    <main className="mx-auto max-w-6xl px-4 py-8 sm:px-6">
+    <div className="mx-auto max-w-6xl px-4 py-8 sm:px-6">
       <h1 className="mb-6 text-2xl font-semibold text-neutral-900">단품</h1>
       <p className="text-neutral-600">단품 상품 목록이 여기에 표시됩니다.</p>
-    </main>
+    </div>
   )
 }

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,8 +1,8 @@
 export default function ProfilePage() {
   return (
-    <main className="mx-auto max-w-6xl px-4 py-8 sm:px-6">
+    <div className="mx-auto max-w-6xl px-4 py-8 sm:px-6">
       <h1 className="text-xl font-semibold text-neutral-900">내정보관리</h1>
       <p className="mt-2 text-sm text-neutral-500">페이지 준비 중입니다.</p>
-    </main>
+    </div>
   )
 }

--- a/src/app/profile/storage/page.tsx
+++ b/src/app/profile/storage/page.tsx
@@ -1,8 +1,8 @@
 export default function ProfileStoragePage() {
   return (
-    <main className="mx-auto max-w-6xl px-4 py-12 sm:px-6">
+    <div className="mx-auto max-w-6xl px-4 py-12 sm:px-6">
       <h1 className="text-xl font-semibold text-neutral-900">향기 저장소</h1>
       <p className="mt-2 text-sm text-neutral-500">페이지 준비 중입니다.</p>
-    </main>
+    </div>
   )
 }

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,10 +1,10 @@
 export default function SignupPage() {
   return (
-    <main className="mx-auto max-w-6xl px-4 py-8 sm:px-6">
+    <div className="mx-auto max-w-6xl px-4 py-8 sm:px-6">
       <h1 className="mb-6 text-2xl font-semibold text-neutral-900">
       회원가입
       </h1>
       <p className="text-neutral-600">페이지 준비 중입니다.</p>
-    </main>
+    </div>
   )
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -13,24 +13,7 @@ import {
   dropdownItemHover,
   dropdownDivider,
 } from '@/components/Dropdown'
-
-const navLinks = {
-  perfume: [
-    { label: '단품 상품 리스트', href: '/products/single' },
-    { label: '조합 상품 리스트', href: '/products/combo' },
-  ],
-  findMyScent: [
-    { title: '취향 추천 테스트', subtitle: '취향 정보 기반 향기 추천', href: '/find-my-scent/taste-test' },
-    { title: '웰니스 케어 진단', subtitle: '건강 정보 기반 아로마 테라피', href: '/find-my-scent/wellness' },
-    { title: 'AI 비주얼 분석', subtitle: '사진 기반 향기 추천', href: '/find-my-scent/ai-visual' },
-  ],
-  profile: [
-    { label: '내 정보 수정', href: '/profile', icon: 'pencil' },
-    { label: '향기 저장소', href: '/profile/storage', icon: 'heart' },
-    { label: '관리자 페이지', href: '/admin', icon: 'gear' },
-    { label: '로그아웃', href: '/login', icon: 'logout' },
-  ],
-}
+import { headerNavLinks } from '@/constants/headerNavLinks'
 
 const styles = {
   header: 'sticky top-0 z-50 border-b border-neutral-200 bg-white/95 backdrop-blur',
@@ -87,7 +70,7 @@ export function Header() {
 
   const renderPerfumeDropdown = () => (
     <DropdownMenu className={perfumeMenuClassName}>
-      {navLinks.perfume.map((item, index) => (
+      {headerNavLinks.perfume.map((item, index) => (
         <DropdownItem
           key={item.href}
           href={item.href}
@@ -103,7 +86,7 @@ export function Header() {
 
   const renderFindMyScentDropdown = () => (
     <DropdownMenu className={findMyScentMenuClassName}>
-      {navLinks.findMyScent.map((item, index) => (
+      {headerNavLinks.findMyScent.map((item, index) => (
         <DropdownItem
           key={item.href}
           href={item.href}
@@ -120,7 +103,7 @@ export function Header() {
 
   const renderProfileList = () => (
     <DropdownMenu className={dropdownMenuProfile}>
-      {navLinks.profile.map((item) => (
+      {headerNavLinks.profile.map((item) => (
         <DropdownItem
           key={item.href}
           href={item.href}

--- a/src/constants/headerNavLinks.ts
+++ b/src/constants/headerNavLinks.ts
@@ -1,0 +1,21 @@
+/**
+ * 헤더 네비게이션 링크 데이터
+ * Header 컴포넌트에서 import 해서 사용합니다.
+ */
+export const headerNavLinks = {
+  perfume: [
+    { label: '단품 상품 리스트', href: '/products/single' },
+    { label: '조합 상품 리스트', href: '/products/combo' },
+  ],
+  findMyScent: [
+    { title: '취향 추천 테스트', subtitle: '취향 정보 기반 향기 추천', href: '/find-my-scent/taste-test' },
+    { title: '웰니스 케어 진단', subtitle: '건강 정보 기반 아로마 테라피', href: '/find-my-scent/wellness' },
+    { title: 'AI 비주얼 분석', subtitle: '사진 기반 향기 추천', href: '/find-my-scent/ai-visual' },
+  ],
+  profile: [
+    { label: '내 정보 수정', href: '/profile', icon: 'pencil' },
+    { label: '향기 저장소', href: '/profile/storage', icon: 'heart' },
+    { label: '관리자 페이지', href: '/admin', icon: 'gear' },
+    { label: '로그아웃', href: '/login', icon: 'logout' },
+  ],
+} as const

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,1 +1,1 @@
-export {}
+export { headerNavLinks } from './headerNavLinks'


### PR DESCRIPTION
## ✨ PR 개요
<!-- 어떤 작업을 했는지 간략히 요약 -->
- 리뷰 반영으로 레이아웃·페이지의 `main` 사용을 정리하고, 헤더 네비 링크 데이터를 상수 파일로 분리했습니다.

## 📌 관련 이슈
<!-- Closes #이슈번호 -->
Closes #9 

## 🧩 작업 내용 (주요 변경사항)
- **레이아웃**: 본문 영역을 `div` → `main`으로 변경해, 메인 콘텐츠는 레이아웃에서 한 번만 감싸도록 수정
- **페이지**: 로그인·회원가입·프로필·관리자·상품·나의 향기 찾기 등 11개 페이지에서 중복 `main` 제거, 스타일 유지용 `div`로 교체
- **헤더 네비 링크**: `Header.tsx` 내부 `navLinks` 객체를 `src/constants/headerNavLinks.ts`로 분리, `headerNavLinks` export 후 Header에서 import 해 사용
- **constants**: `constants/index.ts`에 `headerNavLinks` re-export 추가

## 💬 리뷰 포인트
<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->
- 네비 링크 상수를 `constants/headerNavLinks.ts`로 둔 위치와 네이밍이 괜찮은가요?

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항
<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->
- 페이지별 레이아웃·패딩용 `className`(max-w, padding 등)은 아직 기존과 동일하게 유지했습니다.

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료
