### PR TITLE
[Style] globals.css에 기본 색상 팔레트 추가 (#7)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,1 +1,56 @@
-@import 'tailwindcss';
+@import "tailwindcss";
+
+@theme {
+  
+  /* 향조 색 */
+  --color-base: #FEE685;
+  --color-base-bg: #FFFBEB;
+
+  --color-citrus: #FFF085;
+  --color-citrus-bg: #FEF9C2;
+
+  --color-aromatic: #008236;
+  --color-aromatic-bg: #F0FDF4;
+
+  --color-woody: #973C00;
+  --color-woody-bg: #FEF3C6;
+
+  --color-floral: #A3004C;
+  --color-floral-bg: #FCE7F3;
+
+  --color-oriental: #6E11B0;
+  --color-oriental-bg: #F3E8FF;
+
+  --color-animalic: #C10007;
+  --color-animalic-bg: #FEF2F2;
+
+  /* 그라데이션 색상들 */
+  --color-logo: linear-gradient(90deg, #FF73C7 28%, #9400FF 100%);
+  --color-icon-primary: linear-gradient(-45deg, #AD46FF 0%, #F6339A 100%);
+  --color-icon-secondary: linear-gradient(-45deg, #FFA8DA 0%, #F6339A 100%);
+  --color-icon-tertiary: linear-gradient(0deg, #9400FF 0%, #FF73C3 100%);
+
+  --color-main: linear-gradient(90deg, #BFDBFF 0%, #FFB5FB 100%);
+
+  /* 일반 색상들 */
+  --color-box-bg: #FBF0FF;
+  --color-white: #FFFFFF;
+  --color-gray-light: #DDDDDD;
+  --color-gray-white: #F5F5F5;
+  --color-gray-secondary: #99A1AF;
+
+  --color-purple-primary: #9400FF;
+  --color-gray: #909090;
+  --color-black-primary: #414141;
+  --color-black-secondary: #364153;
+
+  --color-danger: #FB2C36;
+  --color-success: #00C950;
+  --color-kakao: #FEE500;
+
+  --background-gray-bg: #F2F2F2;
+}
+
+body {
+  background-color: var(--background-gray-bg);
+}


### PR DESCRIPTION
## ✨ PR 개요
<!-- 어떤 작업을 했는지 간략히 요약 -->
프로젝트 전반에서 일관된 디자인 가이드에 따른 기본 색상을 전역 컬러 팔레트를 globals.css 에 구축했습니다.

## 📌 관련 이슈
<!-- Closes #이슈번호 -->
Closes #7 

## 🧩 작업 내용 (주요 변경사항)
- 7가지 향조와 각각의 매칭 배경색 변수 추가

## 💬 리뷰 포인트
<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->
작성한 변수 명을 figma에 함께 개재하였으니 참고 해주십쇼!

## 📸 스크린샷 (선택)
<img width="815" height="417" alt="image" src="https://github.com/user-attachments/assets/67aa40e3-3de3-4825-bb9f-76cb7c9b54df" />

<img width="864" height="614" alt="image" src="https://github.com/user-attachments/assets/215353d6-abb0-4716-90c8-9b75cc43e738" />

## 🧠 기타 참고사항
<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료
