### PR TITLE
[Refactor] 헤더·푸터·드롭다운 정리 (#29)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "prettier-plugin-tailwindcss": "^0.7.2",
         "tailwind-merge": "^3.5.0",
         "tailwindcss": "^4",
-        "typescript": "^5",
+        "typescript": "5.9.3",
         "typescript-eslint": "^8.56.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "prettier-plugin-tailwindcss": "^0.7.2",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4",
-    "typescript": "^5",
+    "typescript": "5.9.3",
     "typescript-eslint": "^8.56.1"
   },
   "lint-staged": {

--- a/src/app/test/page.tsx
+++ b/src/app/test/page.tsx
@@ -1,15 +1,8 @@
 'use client'
 
-import { useState, useEffect, Suspense } from 'react'
+import { useState, Suspense } from 'react'
 import { useSearchParams, usePathname } from 'next/navigation'
-import {
-  DropdownMenu,
-  DropdownItem,
-  dropdownMenuDefault,
-  dropdownMenuPositionLeft,
-  dropdownItemDefault,
-  dropdownItemHover,
-} from '@/components/common/Dropdown'
+import { Dropdown } from '@/components/common/Dropdown'
 import Modal from '@/components/common/Modal'
 import Input from '@/components/common/Input'
 
@@ -22,19 +15,8 @@ const SORT_OPTIONS = [
 const sectionTitle =
   'text-sm font-bold text-neutral-500 uppercase tracking-wider mb-2'
 const card = 'rounded-xl border border-neutral-200 bg-white p-6 shadow-sm'
-const triggerButton =
-  'inline-flex items-center gap-1 rounded-lg border border-neutral-300 bg-white px-4 py-2 text-sm font-medium text-neutral-700 shadow-sm hover:bg-neutral-50'
-
-const itemWithSubtitle = 'block w-full px-4 py-3 text-left group'
-const itemTitle =
-  'text-sm font-bold text-neutral-900 group-hover:text-violet-700'
-const itemSubtitle =
-  'mt-0.5 text-xs text-neutral-500 group-hover:text-violet-700'
 
 function TestPageContent() {
-  const [openBasic, setOpenBasic] = useState(false)
-  const [openWithSubtitle, setOpenWithSubtitle] = useState(false)
-  const [openWithCheck, setOpenWithCheck] = useState(false)
   const [openModal, setOpenModal] = useState(false)
 
   // Input 전용 상태
@@ -50,10 +32,7 @@ function TestPageContent() {
     SORT_OPTIONS.find((o) => o.value === currentSort)?.label ?? '최신순'
 
   const [prevSort, setPrevSort] = useState(currentSort)
-  if (currentSort !== prevSort) {
-    setPrevSort(currentSort)
-    setOpenWithCheck(false)
-  }
+  if (currentSort !== prevSort) setPrevSort(currentSort)
 
   return (
     <div className="min-h-screen bg-neutral-50 py-12">
@@ -66,132 +45,6 @@ function TestPageContent() {
         </p>
 
         <div className="grid grid-cols-1 gap-10 md:grid-cols-3">
-          {/* 1. 기본 스타일 (단순 링크, 왼쪽 정렬) */}
-          <section className={card}>
-            <h2 className={sectionTitle}>1. 기본 스타일</h2>
-            <p className="mb-4 text-sm text-neutral-600">
-              단순 텍스트 링크, 왼쪽 정렬. 구분선(dividerAbove) 사용.
-            </p>
-            <div className="relative inline-block">
-              <button
-                type="button"
-                className={triggerButton}
-                onClick={() => setOpenBasic((p) => !p)}
-                aria-expanded={openBasic}
-                aria-haspopup="true"
-              >
-                메뉴 열기
-              </button>
-              {openBasic && (
-                <DropdownMenu
-                  className={`${dropdownMenuDefault} ${dropdownMenuPositionLeft} min-w-[200px]`}
-                >
-                  <DropdownItem
-                    href="#"
-                    defaultClassName={dropdownItemDefault}
-                    hoverClassName={dropdownItemHover}
-                  >
-                    전체 향
-                  </DropdownItem>
-                  <DropdownItem
-                    href="#"
-                    defaultClassName={dropdownItemDefault}
-                    hoverClassName={dropdownItemHover}
-                    dividerAbove
-                  >
-                    신규 향
-                  </DropdownItem>
-                  <DropdownItem
-                    href="#"
-                    defaultClassName={dropdownItemDefault}
-                    hoverClassName={dropdownItemHover}
-                    dividerAbove
-                  >
-                    인기 향
-                  </DropdownItem>
-                </DropdownMenu>
-              )}
-            </div>
-          </section>
-
-          {/* 2. 제목 + 부제목 스타일 */}
-          <section className={card}>
-            <h2 className={sectionTitle}>2. 제목 + 부제목</h2>
-            <p className="mb-4 text-sm text-neutral-600">
-              항목마다 제목과 부제목 두 줄. 넓은 패널 권장.
-            </p>
-            <div className="relative inline-block">
-              <button
-                type="button"
-                className={triggerButton}
-                onClick={() => setOpenWithSubtitle((p) => !p)}
-                aria-expanded={openWithSubtitle}
-                aria-haspopup="true"
-              >
-                나의 향기 찾기
-              </button>
-              {openWithSubtitle && (
-                <DropdownMenu
-                  className={`${dropdownMenuDefault} ${dropdownMenuPositionLeft} min-w-[280px]`}
-                >
-                  <DropdownItem
-                    href="/find-my-scent/ai-visual"
-                    defaultClassName={itemWithSubtitle}
-                    hoverClassName={dropdownItemHover}
-                  >
-                    <span className={itemTitle}>AI 비주얼 추천</span>
-                    <p className={itemSubtitle}>이미지로 나에게 맞는 향 찾기</p>
-                  </DropdownItem>
-                  <DropdownItem
-                    href="/find-my-scent/quiz"
-                    defaultClassName={itemWithSubtitle}
-                    hoverClassName={dropdownItemHover}
-                    dividerAbove
-                  >
-                    <span className={itemTitle}>퀴즈 기반 추천</span>
-                    <p className={itemSubtitle}>
-                      몇 가지 질문으로 맞춤 향 추천
-                    </p>
-                  </DropdownItem>
-                </DropdownMenu>
-              )}
-            </div>
-          </section>
-
-          {/* 3. 선택 항목 체크 표시 */}
-          <section className={card}>
-            <h2 className={sectionTitle}>3. 선택 항목 체크 표시</h2>
-            <p className="mb-4 text-sm text-neutral-600">
-              선택된 항목만 우측에 체크 표시. 항목 클릭 시 URL 반영 후 닫힘.
-            </p>
-            <div className="relative inline-block">
-              <button
-                type="button"
-                className={triggerButton}
-                onClick={() => setOpenWithCheck((p) => !p)}
-                aria-expanded={openWithCheck}
-                aria-haspopup="true"
-              >
-                정렬: {currentSortLabel}
-              </button>
-              {openWithCheck && (
-                <DropdownMenu
-                  className={`${dropdownMenuDefault} ${dropdownMenuPositionLeft} min-w-[180px]`}
-                >
-                  {SORT_OPTIONS.map((opt, index) => (
-                    <DropdownItem
-                      key={opt.value}
-                      href={`${pathname}?sort=${opt.value}`}
-                      dividerAbove={index > 0}
-                      selected={currentSort === opt.value}
-                    >
-                      {opt.label}
-                    </DropdownItem>
-                  ))}
-                </DropdownMenu>
-              )}
-            </div>
-          </section>
           {/* 인풋 섹션 추가 */}
           <section className={card}>
             <h2 className={sectionTitle}>5. 인풋 테스트</h2>

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -1,106 +1,198 @@
 'use client'
 
-import React from 'react'
+import React, { useState, useRef } from 'react'
 import Link from 'next/link'
+import { cn } from '@/lib/cn'
+import PenIcon from '@/assets/icons/pen.svg'
+import HeartIcon from '@/assets/icons/heart.svg'
+import AdminIcon from '@/assets/icons/admin.svg'
+import ExitIcon from '@/assets/icons/exit.svg'
 
-// Dropdown 공통 컴포넌트
+// ─── 타입 ─────────────────────────────────────────────────────────────────
+/** 드롭다운 한 개 항목 (variant에 따라 label만 / title+subtitle / icon+label) */
+export type DropdownItemProp = {
+  href: string
+  label: string
+  title?: string
+  subtitle?: string
+  icon?: 'pencil' | 'heart' | 'gear' | 'logout'
+  dividerAbove?: boolean
+}
 
-// 스타일: 디폴트(기본) vs 호버 시 구분
+/** variant: default(단순) | withSubtitle(제목+부제목) | profile(아이콘+라벨) */
+export type DropdownVariant = 'default' | 'withSubtitle' | 'profile'
+
+// ─── 스타일 상수 ─────────────────────────────────────────────────────────
 const style = {
   default: {
+    // 기본 스타일
     border: 'border-neutral-200',
     panelBg: 'bg-white',
     itemText: 'text-neutral-700',
   },
   hover: {
+    // 호버 스타일
     bg: 'hover:bg-violet-100',
     text: 'hover:text-violet-700',
   },
 } as const
 
-// 기본 스타일
-export const dropdownMenuDefault = `rounded-lg border ${style.default.border} ${style.default.panelBg} py-2 shadow-lg`
-export const dropdownMenuPositionLeft = 'absolute left-0 top-full mt-0.5'
-export const dropdownMenuPositionRight = 'absolute right-0 top-full mt-2'
-// 디폴트 스타일
-export const dropdownItemDefault = `block w-full px-4 py-3 text-left text-sm ${style.default.itemText}`
-// 호버 스타일
-export const dropdownItemHover = `${style.hover.bg} ${style.hover.text}`
-export const dropdownDivider = `border-t ${style.default.border}`
-export const dropdownMenuProfile = `absolute right-0 top-full mt-2 min-w-[200px] overflow-hidden rounded-xl border ${style.default.border} ${style.default.panelBg} shadow-lg`
-/** 선택된 항목에 체크 표시 시 사용할 아이템 래퍼 스타일 (flex, 우측 체크용) */
-export const dropdownItemWithCheck = 'flex items-center justify-between gap-2'
+// ─── 메뉴 스타일 ─────────────────────────────────────────────────────────
+const menuBase = cn(
+  'rounded-lg border py-2 shadow-lg', // 기본 스타일
+  style.default.border, // 테두리 스타일
+  style.default.panelBg // 배경 스타일
+)
+const menuPosition = 'absolute left-0 top-full mt-0.5'
+const itemBase = cn(
+  'block w-full min-w-0 whitespace-nowrap px-4 py-3 text-left text-sm', // 아이템 기본 스타일
+  style.default.itemText // 아이템 텍스트 스타일
+)
+const itemHover = cn(style.hover.bg, style.hover.text)
+const divider = cn('border-t', style.default.border)
+const PROFILE_ICON_CLASS = 'size-4 shrink-0'
 
-function CheckIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      className={className}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      aria-hidden
-    >
-      <path strokeLinecap="round" strokeLinejoin="round" d="M5 12l5 5L20 7" />
-    </svg>
-  )
+const profileIcons: Record<
+  string,
+  React.ComponentType<{ className?: string }>
+> = {
+  pencil: PenIcon,
+  heart: HeartIcon,
+  gear: AdminIcon,
+  logout: ExitIcon,
 }
 
-export function DropdownMenu({
-  children,
-  className,
-  role = 'menu',
+// ─── 통합 드롭다운 (스타일·열기/닫기·백드롭 내장) ─────────────────────────
+const triggerButton =
+  'inline-flex items-center gap-0.5 rounded-md px-3 py-2 text-sm font-medium text-neutral-700 hover:bg-violet-50 hover:text-violet-800'
+const triggerButtonProfile =
+  'flex size-9 items-center justify-center rounded-full overflow-hidden shrink-0 transition-opacity hover:opacity-90'
+const itemWithSubtitle = 'block w-full px-4 py-3 text-left group'
+const itemTitle =
+  'text-sm font-bold text-neutral-900 group-hover:text-violet-700'
+const itemSubtitle =
+  'mt-0.5 text-xs text-neutral-500 group-hover:text-violet-700'
+const itemProfile =
+  'flex items-center gap-3 px-4 py-2.5 text-sm text-neutral-800'
+
+export function Dropdown({
+  trigger,
+  items,
+  variant = 'default',
+  menuMinWidth,
+  'aria-label': ariaLabel,
 }: {
-  children: React.ReactNode
-  className: string
-  role?: 'menu'
+  /** 버튼 내용. (isOpen) => ReactNode 이면 열림 상태에 따라 아이콘 등 변경 가능 */
+  trigger: React.ReactNode | ((isOpen: boolean) => React.ReactNode)
+  items: DropdownItemProp[]
+  variant?: DropdownVariant
+  menuMinWidth?: string
+  'aria-label'?: string
 }) {
+  const [open, setOpen] = useState(false)
+  const backdropRef = useRef<HTMLDivElement>(null)
+
+  const toggle = () => {
+    setOpen((prev) => {
+      if (!prev) setTimeout(() => backdropRef.current?.focus(), 0)
+      return !prev
+    })
+  }
+  const close = () => setOpen(false)
+
+  const isTriggerFn = typeof trigger === 'function'
+  const triggerContent = isTriggerFn
+    ? (trigger as (isOpen: boolean) => React.ReactNode)(open)
+    : trigger
+
+  const menuClassName = cn(menuBase, menuPosition, menuMinWidth)
+
+  const renderItem = (item: DropdownItemProp, index: number) => {
+    const dividerAbove = item.dividerAbove ?? index > 0
+    const baseItemClass = cn(itemBase, itemHover)
+
+    if (
+      variant === 'withSubtitle' &&
+      item.title != null &&
+      item.subtitle != null
+    ) {
+      return (
+        <li key={item.href} role="none" className={cn(dividerAbove && divider)}>
+          <Link
+            href={item.href}
+            className={cn(itemWithSubtitle, itemHover)}
+            role="menuitem"
+            onClick={close}
+          >
+            <span className={itemTitle}>{item.title}</span>
+            <p className={itemSubtitle}>{item.subtitle}</p>
+          </Link>
+        </li>
+      )
+    }
+
+    if (variant === 'profile' && item.icon) {
+      const Icon = profileIcons[item.icon]
+      return (
+        <li key={item.href} role="none" className={cn(dividerAbove && divider)}>
+          <Link
+            href={item.href}
+            className={cn(itemProfile, itemHover)}
+            role="menuitem"
+            onClick={close}
+          >
+            {Icon ? <Icon className={PROFILE_ICON_CLASS} /> : null}
+            {item.label}
+          </Link>
+        </li>
+      )
+    }
+
+    // default
+    return (
+      <li key={item.href} role="none" className={cn(dividerAbove && divider)}>
+        <Link
+          href={item.href}
+          className={baseItemClass}
+          role="menuitem"
+          onClick={close}
+        >
+          {item.label}
+        </Link>
+      </li>
+    )
+  }
+
+  const isProfileTrigger = variant === 'profile'
+  const buttonClass = isProfileTrigger ? triggerButtonProfile : triggerButton
+
   return (
-    <ul className={className} role={role}>
-      {children}
-    </ul>
-  )
-}
-
-const checkIconClass = 'size-4 shrink-0 text-violet-600'
-
-export function DropdownItem({
-  href,
-  children,
-  defaultClassName = dropdownItemDefault,
-  hoverClassName = dropdownItemHover,
-  dividerAbove = false,
-  selected = false,
-}: {
-  href: string
-  children: React.ReactNode
-  defaultClassName?: string
-  hoverClassName?: string
-  dividerAbove?: boolean
-  /** true면 우측 끝에 체크 표시 (앞으로 추가할 디자인용) */
-  selected?: boolean
-}) {
-  const linkClassName = selected
-    ? `${defaultClassName} ${dropdownItemWithCheck} ${hoverClassName} !flex`
-    : `${defaultClassName} ${hoverClassName}`
-
-  return (
-    <li role="none" className={dividerAbove ? dropdownDivider : undefined}>
-      <Link
-        href={href}
-        className={linkClassName}
-        role="menuitem"
-        aria-current={selected ? 'true' : undefined}
+    <div className="relative">
+      {open && (
+        <div
+          ref={backdropRef}
+          className="fixed inset-0 z-40"
+          aria-hidden
+          tabIndex={-1}
+          onClick={close}
+          onKeyDown={(e) => e.key === 'Escape' && close()}
+        />
+      )}
+      <button
+        type="button"
+        className={buttonClass}
+        aria-expanded={open}
+        aria-haspopup="true"
+        aria-label={ariaLabel}
+        onClick={toggle}
       >
-        {selected ? (
-          <>
-            <span className="min-w-0">{children}</span>
-            <CheckIcon className={checkIconClass} />
-          </>
-        ) : (
-          children
-        )}
-      </Link>
-    </li>
+        {triggerContent}
+      </button>
+      {open && (
+        <ul className={menuClassName} role="menu">
+          {items.map((item, index) => renderItem(item, index))}
+        </ul>
+      )}
+    </div>
   )
 }

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,25 +1,11 @@
 'use client'
 
 import Link from 'next/link'
-import { usePathname } from 'next/navigation'
-import React, { useState, useRef, useEffect } from 'react'
-import {
-  DropdownMenu,
-  DropdownItem,
-  dropdownMenuDefault,
-  dropdownMenuPositionLeft,
-  dropdownMenuProfile,
-  dropdownItemDefault,
-  dropdownItemHover,
-} from '@/components/common/Dropdown'
+import { Dropdown } from '@/components/common/Dropdown'
 import { headerNavLinks } from '@/constants/headerNavLinks'
 import CloseIcon from '@/assets/icons/close.svg'
 import OpenIcon from '@/assets/icons/open.svg'
 import ProfileIcon from '@/assets/icons/profile.svg'
-import PenIcon from '@/assets/icons/pen.svg'
-import HeartIcon from '@/assets/icons/heart.svg'
-import AdminIcon from '@/assets/icons/admin.svg'
-import ExitIcon from '@/assets/icons/exit.svg'
 
 const styles = {
   header:
@@ -29,132 +15,13 @@ const styles = {
   logo: 'text-xl font-bold tracking-tight bg-gradient-to-r from-violet-600 via-purple-500 to-pink-500 bg-clip-text text-transparent transition-transform hover:scale-[1.02]',
   nav: 'flex items-center gap-1',
   navItemWrapper: 'relative',
-  navTab:
-    'inline-flex items-center gap-0.5 rounded-md px-3 py-2 text-sm font-medium text-neutral-700 hover:bg-violet-50 hover:text-violet-800',
-  chevronWrap: 'ml-0.5 shrink-0',
-  findMyScentItem: 'block w-full px-4 py-3 text-left group',
-  findMyScentTitle:
-    'text-sm font-bold text-neutral-900 group-hover:text-violet-700',
-  findMyScentSubtitle:
-    'mt-0.5 text-xs text-neutral-500 group-hover:text-violet-700',
   rightMenu: 'flex items-center gap-3',
   rightLink: 'text-sm font-medium text-neutral-600 hover:text-violet-700',
   divider: 'h-3.5 w-px bg-neutral-300 shrink-0',
-  profileButtonWrap: 'relative',
-  profileButton:
-    'flex size-9 items-center justify-center rounded-full overflow-hidden shrink-0 transition-opacity hover:opacity-90',
-  profileItemDefault:
-    'flex items-center gap-3 px-4 py-2.5 text-sm text-neutral-800',
+  chevronWrap: 'ml-0.5 shrink-0',
 } as const
-
-const menuClassNames = {
-  perfume: `${dropdownMenuDefault} ${dropdownMenuPositionLeft} min-w-[200px]`,
-  findMyScent: `${dropdownMenuDefault} ${dropdownMenuPositionLeft} min-w-[280px]`,
-} as const
-
-const PROFILE_ICON_CLASS = 'size-4 shrink-0'
-const profileDropdownIcons: Record<
-  string,
-  React.ComponentType<{ className?: string }>
-> = {
-  pencil: PenIcon,
-  heart: HeartIcon,
-  gear: AdminIcon,
-  logout: ExitIcon,
-}
-
-function ProfileDropdownIcon({ type }: { type: string }) {
-  const IconComponent = profileDropdownIcons[type]
-  if (!IconComponent) return null
-  return <IconComponent className={PROFILE_ICON_CLASS} />
-}
 
 export function Header() {
-  const pathname = usePathname()
-  const [openPerfume, setOpenPerfume] = useState(false)
-  const [openFindMyScent, setOpenFindMyScent] = useState(false)
-  const [openProfile, setOpenProfile] = useState(false)
-  const profileWrapRef = useRef<HTMLDivElement>(null)
-
-  const togglePerfume = () => setOpenPerfume((prev) => !prev)
-  const toggleFindMyScent = () => setOpenFindMyScent((prev) => !prev)
-  const toggleProfile = () => setOpenProfile((prev) => !prev)
-
-  // 페이지 이동 시 네비 드롭다운(향, 나의 향기 찾기) 닫기
-  useEffect(() => {
-    setOpenPerfume(false)
-    setOpenFindMyScent(false)
-  }, [pathname])
-
-  useEffect(() => {
-    if (!openProfile) return
-    const handleClickOutside = (e: MouseEvent) => {
-      if (profileWrapRef.current?.contains(e.target as Node)) return
-      setOpenProfile(false)
-    }
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setOpenProfile(false)
-    }
-    document.addEventListener('click', handleClickOutside)
-    document.addEventListener('keydown', handleEscape)
-    return () => {
-      document.removeEventListener('click', handleClickOutside)
-      document.removeEventListener('keydown', handleEscape)
-    }
-  }, [openProfile])
-
-  const Chevron = (isOpen: boolean) =>
-    isOpen ? <CloseIcon className="size-4" /> : <OpenIcon className="size-4" />
-
-  const perfumeDropdown = openPerfume ? (
-    <DropdownMenu className={menuClassNames.perfume}>
-      {headerNavLinks.perfume.map((item, index) => (
-        <DropdownItem
-          key={item.href}
-          href={item.href}
-          defaultClassName={dropdownItemDefault}
-          hoverClassName={dropdownItemHover}
-          dividerAbove={index > 0}
-        >
-          {item.label}
-        </DropdownItem>
-      ))}
-    </DropdownMenu>
-  ) : null
-
-  const findMyScentDropdown = openFindMyScent ? (
-    <DropdownMenu className={menuClassNames.findMyScent}>
-      {headerNavLinks.findMyScent.map((item, index) => (
-        <DropdownItem
-          key={item.href}
-          href={item.href}
-          defaultClassName={styles.findMyScentItem}
-          hoverClassName={dropdownItemHover}
-          dividerAbove={index > 0}
-        >
-          <span className={styles.findMyScentTitle}>{item.title}</span>
-          <p className={styles.findMyScentSubtitle}>{item.subtitle}</p>
-        </DropdownItem>
-      ))}
-    </DropdownMenu>
-  ) : null
-
-  const profileDropdown = openProfile ? (
-    <DropdownMenu className={dropdownMenuProfile}>
-      {headerNavLinks.profile.map((item) => (
-        <DropdownItem
-          key={item.href}
-          href={item.href}
-          defaultClassName={styles.profileItemDefault}
-          hoverClassName={dropdownItemHover}
-        >
-          <ProfileDropdownIcon type={item.icon} />
-          {item.label}
-        </DropdownItem>
-      ))}
-    </DropdownMenu>
-  ) : null
-
   return (
     <header className={styles.header}>
       <div className={styles.container}>
@@ -164,35 +31,53 @@ export function Header() {
 
         <nav className={styles.nav} aria-label="메인 메뉴">
           <div className={styles.navItemWrapper}>
-            <button
-              type="button"
-              className={styles.navTab}
-              aria-expanded={openPerfume}
-              aria-haspopup="true"
-              onClick={togglePerfume}
-            >
-              향
-              <span className={styles.chevronWrap} aria-hidden>
-                {Chevron(openPerfume)}
-              </span>
-            </button>
-            {perfumeDropdown}
+            <Dropdown
+              trigger={(isOpen) => (
+                <>
+                  향
+                  <span className={styles.chevronWrap} aria-hidden>
+                    {isOpen ? (
+                      <CloseIcon className="size-4" />
+                    ) : (
+                      <OpenIcon className="size-4" />
+                    )}
+                  </span>
+                </>
+              )}
+              items={headerNavLinks.perfume.map(({ label, href }) => ({
+                href,
+                label,
+              }))}
+              variant="default"
+              menuMinWidth="min-w-[180px]"
+            />
           </div>
 
           <div className={styles.navItemWrapper}>
-            <button
-              type="button"
-              className={styles.navTab}
-              aria-expanded={openFindMyScent}
-              aria-haspopup="true"
-              onClick={toggleFindMyScent}
-            >
-              나의 향기 찾기
-              <span className={styles.chevronWrap} aria-hidden>
-                {Chevron(openFindMyScent)}
-              </span>
-            </button>
-            {findMyScentDropdown}
+            <Dropdown
+              trigger={(isOpen) => (
+                <>
+                  나의 향기 찾기
+                  <span className={styles.chevronWrap} aria-hidden>
+                    {isOpen ? (
+                      <CloseIcon className="size-4" />
+                    ) : (
+                      <OpenIcon className="size-4" />
+                    )}
+                  </span>
+                </>
+              )}
+              items={headerNavLinks.findMyScent.map(
+                ({ href, title, subtitle }) => ({
+                  href,
+                  label: title,
+                  title,
+                  subtitle,
+                })
+              )}
+              variant="withSubtitle"
+              menuMinWidth="min-w-[280px]"
+            />
           </div>
         </nav>
 
@@ -204,19 +89,17 @@ export function Header() {
           <Link href="/signup" className={styles.rightLink}>
             회원가입
           </Link>
-          <div ref={profileWrapRef} className={styles.profileButtonWrap}>
-            <button
-              type="button"
-              className={styles.profileButton}
-              aria-label="프로필 메뉴"
-              aria-expanded={openProfile}
-              aria-haspopup="true"
-              onClick={toggleProfile}
-            >
-              <ProfileIcon className="size-9" aria-hidden />
-            </button>
-            {profileDropdown}
-          </div>
+          <Dropdown
+            trigger={<ProfileIcon className="size-9" aria-hidden />}
+            items={headerNavLinks.profile.map(({ href, label, icon }) => ({
+              href,
+              label,
+              icon,
+            }))}
+            variant="profile"
+            menuMinWidth="min-w-[200px]"
+            aria-label="프로필 메뉴"
+          />
         </div>
       </div>
     </header>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,13 +1,7 @@
 export { Header } from '@/components/common/Header'
 export { Footer } from '@/components/common/Footer'
-export {
-  DropdownMenu,
-  DropdownItem,
-  dropdownMenuDefault,
-  dropdownMenuPositionLeft,
-  dropdownMenuPositionRight,
-  dropdownMenuProfile,
-  dropdownItemDefault,
-  dropdownItemHover,
-  dropdownDivider,
+export { Dropdown } from '@/components/common/Dropdown'
+export type {
+  DropdownItemProp,
+  DropdownVariant,
 } from '@/components/common/Dropdown'


### PR DESCRIPTION
## ✨ PR 개요
헤더·푸터·드롭다운 공통 컴포넌트를 정리했습니다. 드롭다운은 헤더 메뉴(향, 나의 향기 찾기)와 프로필 아이콘에서만 사용되도록 단일 컴포넌트로 통일하고, 불필요한 variant·position·스타일 export를 제거했습니다. Header/Footer는 단순 문자열 스타일로 정리했습니다.


## 📌 관련 이슈
<!-- Closes #이슈번호 -->
Closes #29

## 🧩 작업 내용 (주요 변경사항)
- 클래스 조합·조건부 처리에 `cn`(clsx + tailwind-merge) 적용.

## 💬 리뷰 포인트
<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항
<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->
- 패키지 버전 변경(typescript `^5` → `5.9.3`)은 npm ci로 인한 lock 정리됬습니다!

## ✅ PR 체크리스트
- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료
