### PR TITLE
[chore] MSW 서버 모킹 설정 추가 (#37)

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,0 +1,18 @@
+/**
+ * Next.js Instrumentation
+ * - 서버(Node) 런타임에서 MSW 설정 시 여기서 setupServer.listen() 호출
+ * - 클라이언트 모킹은 MockProvider에서 setupWorker 사용
+ */
+export async function register() {
+  const useMock = process.env.NEXT_PUBLIC_USE_MOCK_API === 'true'
+
+  if (process.env.NEXT_RUNTIME === 'nodejs' && useMock) {
+    const { server } = await import('./mocks/server')
+
+    server.listen({
+      onUnhandledRequest: 'bypass',
+    })
+
+    console.log('✅ MSW Server Mocking Enabled')
+  }
+}

--- a/src/mocks/server.ts
+++ b/src/mocks/server.ts
@@ -1,0 +1,4 @@
+import { setupServer } from 'msw/node'
+import { handlers } from './handlers'
+
+export const server = setupServer(...handlers)


### PR DESCRIPTION
## ✨ PR 개요
<!-- 어떤 작업을 했는지 간략히 요약 -->
Next.js 서버(Node) 런타임에서 나가는 `fetch` 요청도 MSW로 모킹할 수 있도록, instrumentation과 setupServer를 추가했습니다. 기존에는 클라이언트(Worker)만 설정되어 있었고, 이번에 서버 환경을 추가해 서버/클라이언트 각각 모킹이 가능해집니다.

## 📌 관련 이슈
<!-- Closes #이슈번호 -->
Closes #37 

## 🧩 작업 내용 (주요 변경사항)
- **`src/instrumentation.ts`** 추가
  - Next.js `register()`에서 `NEXT_RUNTIME === 'nodejs'`이고 `NEXT_PUBLIC_USE_MOCK_API === 'true'`일 때만 서버 MSW 활성화
  - `mocks/server`를 동적 import 후 `server.listen({ onUnhandledRequest: 'bypass' })` 호출
- **`src/mocks/server.ts`** 추가
  - `msw/node`의 `setupServer`에 기존 `handlers` 연결 (단품/조합 목록 등 동일 핸들러 사용)

## 💬 리뷰 포인트
<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항
<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->
- 클라이언트 모킹은 기존처럼 `MockProvider` + `mocks/browser.ts`(setupWorker)로 유지됩니다.
- 서버 모킹도 `NEXT_PUBLIC_USE_MOCK_API=true`일 때만 동작합니다.

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [ ] 로컬에서 실행 확인 완료
