### PR TITLE
[Feat] 테스트 등록 페이지 UI 추가 (#40)

### DIFF
--- a/src/app/admin/_components/AdminListCard.tsx
+++ b/src/app/admin/_components/AdminListCard.tsx
@@ -3,7 +3,5 @@
 import React from 'react'
 
 export const AdminListCard = ({ children }: { children: React.ReactNode }) => (
-  <div className="rounded-[20px] bg-white p-8 shadow-[0_2px_10px_rgba(0,0,0,0.05)]">
-    {children}
-  </div>
+  <div className="rounded-[20px] bg-white p-8">{children}</div>
 )

--- a/src/app/admin/_components/AdminPageHeader.tsx
+++ b/src/app/admin/_components/AdminPageHeader.tsx
@@ -3,32 +3,54 @@
 import React from 'react'
 import Button from '@/components/common/Button'
 import AdminTestPlusIcon from '@/assets/icons/adminTestPlus.svg'
+import { cn } from '@/lib/cn'
 
 interface AdminPageHeaderProps {
   title: string
   buttonText?: string
   onButtonClick?: () => void
+  buttonIcon?: 'plus' | 'save' | 'none'
+  leftContent?: React.ReactNode
+  rightContent?: React.ReactNode
+  className?: string
 }
 
 export const AdminPageHeader = ({
   title,
   buttonText,
   onButtonClick,
+  buttonIcon = 'plus',
+  leftContent,
+  rightContent,
+  className,
 }: AdminPageHeaderProps) => (
-  <div className="mb-4 flex items-center justify-between">
-    <h2 className="text-black-primary text-xl font-bold">{title}</h2>
-    {buttonText && (
-      <Button
-        color="primary"
-        size="w139h40"
-        rounded="sm"
-        onClick={onButtonClick}
-      >
-        <div className="flex items-center gap-2">
-          <AdminTestPlusIcon width={20} height={20} />
-          <span>{buttonText}</span>
-        </div>
-      </Button>
-    )}
+  <div className={cn('mb-8 flex items-center justify-between', className)}>
+    <div className="flex flex-col gap-2">
+      {leftContent}
+      <h2 className="text-black-primary text-xl font-bold">{title}</h2>
+    </div>
+
+    <div className="flex items-center gap-2">
+      {rightContent}
+      {buttonText && (
+        <Button
+          color={buttonIcon === 'save' ? 'none' : 'primary'}
+          size="w139h40"
+          rounded="sm"
+          onClick={onButtonClick}
+          className={cn(
+            buttonIcon === 'save' &&
+              'bg-purple-primary text-white hover:bg-purple-700'
+          )}
+        >
+          <div className="flex items-center gap-2">
+            {buttonIcon === 'plus' && (
+              <AdminTestPlusIcon width={20} height={20} />
+            )}
+            <span>{buttonText}</span>
+          </div>
+        </Button>
+      )}
+    </div>
   </div>
 )

--- a/src/app/admin/_components/AdminSelect.tsx
+++ b/src/app/admin/_components/AdminSelect.tsx
@@ -97,7 +97,7 @@ export const AdminSelect = ({
                 aria-selected={opt.value === value}
                 className={cn(
                   'hover:bg-gray-light hover:text-black-primary w-full cursor-pointer px-4 py-3 text-left text-sm transition-colors',
-                  opt.value === value ? 'font-bold' : ''
+                  opt.value === value ? 'bg-gray-light font-bold' : ''
                 )}
                 onClick={() => handleSelect(opt.value)}
               >

--- a/src/app/admin/_components/AdminSidebar.tsx
+++ b/src/app/admin/_components/AdminSidebar.tsx
@@ -31,7 +31,7 @@ export function AdminSidebar() {
       <nav className="rounded-2xl bg-white p-4 shadow-md">
         <ul className="flex flex-col gap-2">
           {ADMIN_SIDEBAR_NAV_LINKS.map((item) => {
-            const isSidebarActive = pathname === item.href
+            const isSidebarActive = pathname.startsWith(item.href)
             return (
               <li key={item.href}>
                 <Link

--- a/src/app/admin/_components/AdminTabGroup.tsx
+++ b/src/app/admin/_components/AdminTabGroup.tsx
@@ -9,6 +9,8 @@ interface AdminTabGroupProps {
   activeTab: string
   onChange: (id: string) => void
   className?: string
+  /** 탭들을 부모 너비에 맞춰 균등하게 배분할지 여부임 */
+  fullWidth?: boolean
 }
 
 /**
@@ -19,9 +21,10 @@ export const AdminTabGroup = ({
   activeTab,
   onChange,
   className,
+  fullWidth = false,
 }: AdminTabGroupProps) => {
   return (
-    <div className={cn('flex gap-4 pb-4', className)}>
+    <div className={cn('flex gap-4 pb-4', fullWidth && 'w-full', className)}>
       {tabs.map((tab) => {
         const isActive = activeTab === tab.id
         return (
@@ -30,9 +33,10 @@ export const AdminTabGroup = ({
             onClick={() => onChange(tab.id)}
             className={cn(
               'cursor-pointer rounded-xl text-sm font-semibold transition-all',
+              fullWidth && 'flex-1',
               isActive
                 ? 'bg-black-primary text-white'
-                : 'bg-gray-light text-black-primary border-none shadow-none'
+                : 'bg-gray-light text-black-primary border-none shadow-none hover:bg-neutral-200'
             )}
           >
             {tab.label}

--- a/src/app/admin/test/create/_components/QuestionForm.tsx
+++ b/src/app/admin/test/create/_components/QuestionForm.tsx
@@ -243,12 +243,17 @@ export const QuestionForm = ({
                   <AdminSelect
                     width="w-[171px]"
                     options={availableOptions}
-                    value={option.answer_option_text}
-                    onChange={(val: string) =>
+                    value={option.answer_option_key}
+                    onChange={(val: string) => {
+                      const selectedPreset = availableOptions.find(
+                        (o) => o.value === val
+                      )
                       onUpdateOption(option.answer_option_key, {
-                        answer_option_text: val,
+                        answer_option_key: val,
+                        answer_option_text:
+                          selectedPreset?.label || option.answer_option_text,
                       })
-                    }
+                    }}
                   />
                 </div>
                 <button

--- a/src/app/admin/test/create/_components/QuestionForm.tsx
+++ b/src/app/admin/test/create/_components/QuestionForm.tsx
@@ -16,8 +16,8 @@ interface QuestionFormProps {
   onUpdate: (updates: Partial<Question>) => void
   onRemove: () => void
   onAddOption: () => void
-  onRemoveOption: (optKey: string) => void
-  onUpdateOption: (optKey: string, updates: Partial<Option>) => void
+  onRemoveOption: (optUid: string) => void
+  onUpdateOption: (optUid: string, updates: Partial<Option>) => void
   onReorderOptions: (options: Option[]) => void
 }
 
@@ -204,7 +204,7 @@ export const QuestionForm = ({
           >
             {question.options.map((option, oIdx) => (
               <Reorder.Item
-                key={option.answer_option_key}
+                key={option.key}
                 value={option}
                 className="flex items-center gap-3 bg-white"
                 initial={false}
@@ -233,7 +233,7 @@ export const QuestionForm = ({
                     type="text"
                     value={option.answer_option_text}
                     onChange={(e) =>
-                      onUpdateOption(option.answer_option_key, {
+                      onUpdateOption(option.key, {
                         answer_option_text: e.target.value,
                       })
                     }
@@ -245,19 +245,14 @@ export const QuestionForm = ({
                     options={availableOptions}
                     value={option.answer_option_key}
                     onChange={(val: string) => {
-                      const selectedPreset = availableOptions.find(
-                        (o) => o.value === val
-                      )
-                      onUpdateOption(option.answer_option_key, {
+                      onUpdateOption(option.key, {
                         answer_option_key: val,
-                        answer_option_text:
-                          selectedPreset?.label || option.answer_option_text,
                       })
                     }}
                   />
                 </div>
                 <button
-                  onClick={() => onRemoveOption(option.answer_option_key)}
+                  onClick={() => onRemoveOption(option.key)}
                   className="hover:text-danger cursor-pointer text-gray-300"
                 >
                   <TrashIcon width={16} height={16} />

--- a/src/app/admin/test/create/_components/QuestionForm.tsx
+++ b/src/app/admin/test/create/_components/QuestionForm.tsx
@@ -1,0 +1,267 @@
+import { Reorder } from 'motion/react'
+import { AdminSelect } from '@/app/admin/_components'
+import TrashIcon from '@/assets/icons/trash.svg'
+import {
+  STANDARD_OPTIONS,
+  ALL_PRESETS,
+  CATEGORIZED_PRESET_OPTIONS,
+} from '../_constants/presets'
+import { Question, Option } from '../_types'
+import { cn } from '@/lib/cn'
+
+interface QuestionFormProps {
+  testType: string
+  question: Question
+  index: number
+  onUpdate: (updates: Partial<Question>) => void
+  onRemove: () => void
+  onAddOption: () => void
+  onRemoveOption: (optKey: string) => void
+  onUpdateOption: (optKey: string, updates: Partial<Option>) => void
+  onReorderOptions: (options: Option[]) => void
+}
+
+export const QuestionForm = ({
+  testType,
+  question,
+  index,
+  onUpdate,
+  onRemove,
+  onAddOption,
+  onRemoveOption,
+  onUpdateOption,
+  onReorderOptions,
+}: QuestionFormProps) => {
+  // 템플릿에 정의된 질문 키별 표준 옵션들
+  const availableOptions = STANDARD_OPTIONS[question.question_key] || []
+
+  // 현재 테스트 유형에 맞는 프리셋 옵션들
+  const presetOptions = CATEGORIZED_PRESET_OPTIONS[testType] || []
+
+  // 프리셋 선택 핸들러
+  const handlePresetChange = (presetId: string) => {
+    if (presetId === 'custom') return
+
+    const preset = ALL_PRESETS.find((p) => p.question_key === presetId)
+    if (preset) {
+      onUpdate({
+        question_key: preset.question_key,
+        question_text: preset.question_text,
+        selection_type: preset.selection_type,
+        is_required: preset.is_required,
+        options: preset.options,
+      })
+    }
+  }
+
+  return (
+    <div className="border-gray-light rounded-[20px] border bg-white p-6 shadow-sm">
+      <div className="mb-6 flex items-center gap-4">
+        <div className="flex h-10 w-6 cursor-grab items-center justify-center text-gray-300 hover:text-gray-400 active:cursor-grabbing">
+          <svg width="12" height="18" viewBox="0 0 12 18" fill="currentColor">
+            <circle cx="2" cy="2" r="1.5" />
+            <circle cx="2" cy="7" r="1.5" />
+            <circle cx="2" cy="12" r="1.5" />
+            <circle cx="2" cy="17" r="1.5" />
+            <circle cx="6" cy="2" r="1.5" />
+            <circle cx="6" cy="7" r="1.5" />
+            <circle cx="6" cy="12" r="1.5" />
+            <circle cx="6" cy="17" r="1.5" />
+          </svg>
+        </div>
+
+        <div className="bg-black-primary flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-sm font-bold text-white">
+          {index + 1}
+        </div>
+
+        <div className="flex flex-1 flex-col gap-1.5">
+          <input
+            type="text"
+            value={question.question_text}
+            onChange={(e) => onUpdate({ question_text: e.target.value })}
+            placeholder="질문을 입력하세요"
+            className="border-gray-light focus:border-black-primary w-full border-b py-2 text-lg font-medium outline-none"
+          />
+        </div>
+
+        <button
+          type="button"
+          onClick={onRemove}
+          className="hover:text-danger cursor-pointer"
+          aria-label="질문 삭제"
+        >
+          <TrashIcon width={20} height={20} />
+        </button>
+      </div>
+
+      <div
+        className="mb-6 flex items-center gap-10 pl-10"
+        style={{ marginBottom: '24px' }}
+      >
+        <div className="flex items-center gap-2">
+          <div className="flex items-center gap-1.5">
+            <span className="text-md text-gray font-bold">유형</span>
+            <div className="min-w-[160px]">
+              <AdminSelect
+                width="w-full"
+                options={presetOptions}
+                value={
+                  ALL_PRESETS.some(
+                    (p) => p.question_key === question.question_key
+                  )
+                    ? question.question_key
+                    : ''
+                }
+                onChange={handlePresetChange}
+              />
+            </div>
+            {!ALL_PRESETS.some(
+              (p) => p.question_key === question.question_key
+            ) && (
+              <span className="rounded border border-gray-200 bg-gray-50 px-2 py-0.5 text-[10px] font-bold text-gray-400">
+                {question.question_key}
+              </span>
+            )}
+          </div>
+        </div>
+
+        {question.selection_type !== 'PHOTO' && (
+          <div className="flex items-center gap-4">
+            <label className="text-success text-[11px] font-bold tracking-tight uppercase">
+              선택형태
+            </label>
+            <div className="flex gap-1">
+              {[
+                { label: '단일선택', value: 'SINGLE' },
+                { label: '다중선택', value: 'MULTI' },
+              ].map((opt) => (
+                <button
+                  key={opt.value}
+                  type="button"
+                  onClick={() => onUpdate({ selection_type: opt.value as any })}
+                  className={cn(
+                    'cursor-pointer rounded-lg border px-3 py-1.5 text-xs font-bold',
+                    question.selection_type === opt.value
+                      ? 'bg-success border-success text-white'
+                      : 'border-gray-light bg-white text-gray-400'
+                  )}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <div className="flex items-center gap-4">
+          <label className="text-danger text-[11px] font-bold">필수여부</label>
+          <div className="flex gap-1">
+            {[
+              { label: '필수', value: true },
+              { label: '선택', value: false },
+            ].map((opt) => (
+              <button
+                key={String(opt.value)}
+                type="button"
+                onClick={() => onUpdate({ is_required: opt.value })}
+                className={cn(
+                  'cursor-pointer rounded-lg border px-3 py-1.5 text-xs font-bold',
+                  question.is_required === opt.value
+                    ? 'bg-danger border-danger text-white'
+                    : 'border-gray-light text-gray bg-white'
+                )}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {question.selection_type === 'PHOTO' ? (
+        <div className="border-gray-light mt-4 rounded-xl border border-dashed bg-gray-50/50 p-10 text-center">
+          <p className="text-gray text-sm">
+            사용자가 사진을 업로드할 수 있는 영역입니다.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <label className="text-gray text-xs font-bold">답변 선택지</label>
+            <button
+              onClick={onAddOption}
+              className="text-black-primary cursor-pointer text-xs font-bold underline"
+            >
+              선택지 추가
+            </button>
+          </div>
+
+          <Reorder.Group
+            axis="y"
+            values={question.options}
+            onReorder={onReorderOptions}
+            className="space-y-2"
+          >
+            {question.options.map((option, oIdx) => (
+              <Reorder.Item
+                key={option.answer_option_key}
+                value={option}
+                className="flex items-center gap-3 bg-white"
+                initial={false}
+                transition={{ duration: 0 }}
+              >
+                <div className="flex h-10 w-6 cursor-grab items-center justify-center text-gray-300 hover:text-gray-400 active:cursor-grabbing">
+                  <svg
+                    width="12"
+                    height="18"
+                    viewBox="0 0 12 18"
+                    fill="currentColor"
+                  >
+                    <circle cx="2" cy="2" r="1.5" />
+                    <circle cx="2" cy="7" r="1.5" />
+                    <circle cx="2" cy="12" r="1.5" />
+                    <circle cx="2" cy="17" r="1.5" />
+                    <circle cx="6" cy="2" r="1.5" />
+                    <circle cx="6" cy="7" r="1.5" />
+                    <circle cx="6" cy="12" r="1.5" />
+                    <circle cx="6" cy="17" r="1.5" />
+                  </svg>
+                </div>
+
+                <div className="flex flex-1 items-center gap-2">
+                  <input
+                    type="text"
+                    value={option.answer_option_text}
+                    onChange={(e) =>
+                      onUpdateOption(option.answer_option_key, {
+                        answer_option_text: e.target.value,
+                      })
+                    }
+                    placeholder={`선택지 ${oIdx + 1}`}
+                    className="border-gray-light flex-1 rounded-xl border bg-gray-50/50 px-4 py-3 text-sm outline-none focus:border-violet-300 focus:bg-white"
+                  />
+                  <AdminSelect
+                    width="w-[171px]"
+                    options={availableOptions}
+                    value={option.answer_option_text}
+                    onChange={(val: string) =>
+                      onUpdateOption(option.answer_option_key, {
+                        answer_option_text: val,
+                      })
+                    }
+                  />
+                </div>
+                <button
+                  onClick={() => onRemoveOption(option.answer_option_key)}
+                  className="hover:text-danger cursor-pointer text-gray-300"
+                >
+                  <TrashIcon width={16} height={16} />
+                </button>
+              </Reorder.Item>
+            ))}
+          </Reorder.Group>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/admin/test/create/_constants/presets.ts
+++ b/src/app/admin/test/create/_constants/presets.ts
@@ -518,7 +518,7 @@ export const STANDARD_OPTIONS: Record<
       if (q.options.length > 0 && !acc[q.question_key]) {
         acc[q.question_key] = q.options.map((o) => ({
           label: o.answer_option_text,
-          value: o.answer_option_text,
+          value: o.answer_option_key,
         }))
       }
       return acc

--- a/src/app/admin/test/create/_constants/presets.ts
+++ b/src/app/admin/test/create/_constants/presets.ts
@@ -1,0 +1,527 @@
+import { Question } from '../_types'
+
+export const DEFAULT_TEMPLATES: Record<string, Question[]> = {
+  PREFERENCE: [
+    {
+      key: 'taste-mood',
+      question_key: 'mood',
+      question_text: '무드',
+      selection_type: 'SINGLE',
+      is_required: true,
+      sort_order: 1,
+      options: [
+        {
+          answer_option_key: 'calm',
+          answer_option_text: '차분',
+          sort_order: 1,
+        },
+        {
+          answer_option_key: 'vital',
+          answer_option_text: '활기',
+          sort_order: 2,
+        },
+        {
+          answer_option_key: 'cozy',
+          answer_option_text: '포근',
+          sort_order: 3,
+        },
+        {
+          answer_option_key: 'focused',
+          answer_option_text: '집중',
+          sort_order: 4,
+        },
+      ],
+    },
+    {
+      key: 'taste-season',
+      question_key: 'season',
+      question_text: '계절감',
+      selection_type: 'SINGLE',
+      is_required: true,
+      sort_order: 2,
+      options: [
+        {
+          answer_option_key: 'spring',
+          answer_option_text: '봄',
+          sort_order: 1,
+        },
+        {
+          answer_option_key: 'summer',
+          answer_option_text: '여름',
+          sort_order: 2,
+        },
+        {
+          answer_option_key: 'autumn',
+          answer_option_text: '가을',
+          sort_order: 3,
+        },
+        {
+          answer_option_key: 'winter',
+          answer_option_text: '겨울',
+          sort_order: 4,
+        },
+      ],
+    },
+    {
+      key: 'taste-space',
+      question_key: 'space',
+      question_text: '공간감',
+      selection_type: 'SINGLE',
+      is_required: true,
+      sort_order: 3,
+      options: [
+        {
+          answer_option_key: 'forest',
+          answer_option_text: '숲',
+          sort_order: 1,
+        },
+        { answer_option_key: 'sea', answer_option_text: '바다', sort_order: 2 },
+        {
+          answer_option_key: 'city',
+          answer_option_text: '도시',
+          sort_order: 3,
+        },
+        {
+          answer_option_key: 'village',
+          answer_option_text: '시골',
+          sort_order: 4,
+        },
+      ],
+    },
+    {
+      key: 'taste-gender',
+      question_key: 'gender',
+      question_text: '성별',
+      selection_type: 'SINGLE',
+      is_required: true,
+      sort_order: 4,
+      options: [
+        { answer_option_key: 'male', answer_option_text: '남', sort_order: 1 },
+        {
+          answer_option_key: 'female',
+          answer_option_text: '여',
+          sort_order: 2,
+        },
+        {
+          answer_option_key: 'neutral',
+          answer_option_text: '중성',
+          sort_order: 3,
+        },
+      ],
+    },
+    {
+      key: 'taste-age',
+      question_key: 'age',
+      question_text: '연령',
+      selection_type: 'SINGLE',
+      is_required: true,
+      sort_order: 5,
+      options: [
+        {
+          answer_option_key: 'teen',
+          answer_option_text: '10대',
+          sort_order: 1,
+        },
+        {
+          answer_option_key: 'twenties',
+          answer_option_text: '20대',
+          sort_order: 2,
+        },
+        {
+          answer_option_key: 'thirties',
+          answer_option_text: '30대',
+          sort_order: 3,
+        },
+        {
+          answer_option_key: 'forties',
+          answer_option_text: '40대',
+          sort_order: 4,
+        },
+        {
+          answer_option_key: 'fifties',
+          answer_option_text: '50대',
+          sort_order: 5,
+        },
+      ],
+    },
+    {
+      key: 'taste-scent',
+      question_key: 'scent',
+      question_text: '향조',
+      selection_type: 'MULTI',
+      is_required: true,
+      sort_order: 6,
+      options: [
+        {
+          answer_option_key: 'citrus',
+          answer_option_text: '시트러스',
+          sort_order: 1,
+        },
+        {
+          answer_option_key: 'aromatic',
+          answer_option_text: '아로마틱',
+          sort_order: 2,
+        },
+        {
+          answer_option_key: 'oriental',
+          answer_option_text: '오리엔탈',
+          sort_order: 3,
+        },
+        {
+          answer_option_key: 'woody',
+          answer_option_text: '우디',
+          sort_order: 4,
+        },
+        {
+          answer_option_key: 'animalic',
+          answer_option_text: '애니멀릭',
+          sort_order: 5,
+        },
+        {
+          answer_option_key: 'floral',
+          answer_option_text: '플로럴',
+          sort_order: 6,
+        },
+      ],
+    },
+    {
+      key: 'taste-dislike-scent',
+      question_key: 'dislike-scent',
+      question_text: '기피 향조',
+      selection_type: 'MULTI',
+      is_required: true,
+      sort_order: 7,
+      options: [
+        {
+          answer_option_key: 'citrus',
+          answer_option_text: '시트러스',
+          sort_order: 1,
+        },
+        {
+          answer_option_key: 'aromatic',
+          answer_option_text: '아로마틱',
+          sort_order: 2,
+        },
+        {
+          answer_option_key: 'oriental',
+          answer_option_text: '오리엔탈',
+          sort_order: 3,
+        },
+        {
+          answer_option_key: 'woody',
+          answer_option_text: '우디',
+          sort_order: 4,
+        },
+        {
+          answer_option_key: 'animalic',
+          answer_option_text: '애니멀릭',
+          sort_order: 5,
+        },
+        {
+          answer_option_key: 'floral',
+          answer_option_text: '플로럴',
+          sort_order: 6,
+        },
+      ],
+    },
+    {
+      key: 'taste-products',
+      question_key: 'products',
+      question_text: '관심 제품군',
+      selection_type: 'SINGLE',
+      is_required: true,
+      sort_order: 8,
+      options: [
+        {
+          answer_option_key: 'diffuser',
+          answer_option_text: '디퓨저',
+          sort_order: 1,
+        },
+        {
+          answer_option_key: 'perfume',
+          answer_option_text: '향수',
+          sort_order: 2,
+        },
+      ],
+    },
+  ],
+  HEALTH: [
+    {
+      key: 'health-sleep',
+      question_key: 'sleep',
+      question_text: '수면 상태',
+      selection_type: 'SINGLE',
+      is_required: true,
+      sort_order: 1,
+      options: [
+        {
+          answer_option_key: 'sleep-well',
+          answer_option_text: '잘잔다',
+          sort_order: 1,
+        },
+        {
+          answer_option_key: 'wake-often',
+          answer_option_text: '자주 깬다',
+          sort_order: 2,
+        },
+        {
+          answer_option_key: 'hard-to-fall-asleep',
+          answer_option_text: '잠들기 어렵다',
+          sort_order: 3,
+        },
+        {
+          answer_option_key: 'always-tired',
+          answer_option_text: '항상 피곤하다',
+          sort_order: 4,
+        },
+      ],
+    },
+    {
+      key: 'health-stress',
+      question_key: 'stress',
+      question_text: '스트레스 수준',
+      selection_type: 'SINGLE',
+      is_required: true,
+      sort_order: 2,
+      options: [
+        {
+          answer_option_key: 'none',
+          answer_option_text: '거의 없다',
+          sort_order: 1,
+        },
+        {
+          answer_option_key: 'sometimes',
+          answer_option_text: '가끔 느낀다',
+          sort_order: 2,
+        },
+        {
+          answer_option_key: 'often',
+          answer_option_text: '자주 느낀다',
+          sort_order: 3,
+        },
+        {
+          answer_option_key: 'always',
+          answer_option_text: '항상 느낀다',
+          sort_order: 4,
+        },
+      ],
+    },
+    {
+      key: 'health-anxiety',
+      question_key: 'anxiety',
+      question_text: '불안 정도',
+      selection_type: 'SINGLE',
+      is_required: true,
+      sort_order: 3,
+      options: [
+        {
+          answer_option_key: 'none',
+          answer_option_text: '거의 없다',
+          sort_order: 1,
+        },
+        {
+          answer_option_key: 'sometimes',
+          answer_option_text: '가끔 느낀다',
+          sort_order: 2,
+        },
+        {
+          answer_option_key: 'often',
+          answer_option_text: '자주 느낀다',
+          sort_order: 3,
+        },
+        {
+          answer_option_key: 'always',
+          answer_option_text: '항상 느낀다',
+          sort_order: 4,
+        },
+      ],
+    },
+    {
+      key: 'health-focus',
+      question_key: 'focus',
+      question_text: '집중력',
+      selection_type: 'SINGLE',
+      is_required: true,
+      sort_order: 4,
+      options: [
+        {
+          answer_option_key: 'focus-good',
+          answer_option_text: '잘 집중한다',
+          sort_order: 1,
+        },
+        {
+          answer_option_key: 'distract-sometimes',
+          answer_option_text: '가끔 산만하다',
+          sort_order: 2,
+        },
+        {
+          answer_option_key: 'distract-often',
+          answer_option_text: '자주 산만하다',
+          sort_order: 3,
+        },
+        {
+          answer_option_key: 'focus-very-hard',
+          answer_option_text: '집중이 매우 어렵다',
+          sort_order: 4,
+        },
+      ],
+    },
+    {
+      key: 'health-improvement',
+      question_key: 'improvement',
+      question_text: '원하는 개선 영역',
+      selection_type: 'MULTI',
+      is_required: true,
+      sort_order: 5,
+      options: [
+        {
+          answer_option_key: 'relax-stress',
+          answer_option_text: '스트레스 완화',
+          sort_order: 1,
+        },
+        {
+          answer_option_key: 'improve-sleep',
+          answer_option_text: '수면개선',
+          sort_order: 2,
+        },
+        {
+          answer_option_key: 'relieve-anxiety',
+          answer_option_text: '불안해소',
+          sort_order: 3,
+        },
+        {
+          answer_option_key: 'improve-focus',
+          answer_option_text: '집중력 향상',
+          sort_order: 4,
+        },
+      ],
+    },
+    {
+      key: 'health-products',
+      question_key: 'products-health',
+      question_text: '관심 제품군',
+      selection_type: 'SINGLE',
+      is_required: true,
+      sort_order: 6,
+      options: [
+        {
+          answer_option_key: 'diffuser',
+          answer_option_text: '디퓨저',
+          sort_order: 1,
+        },
+        {
+          answer_option_key: 'perfume',
+          answer_option_text: '향수',
+          sort_order: 2,
+        },
+      ],
+    },
+  ],
+  INTERIOR: [
+    {
+      key: 'interior-photo',
+      question_key: 'photo-interior',
+      question_text: '사진 첨부',
+      selection_type: 'PHOTO',
+      is_required: true,
+      sort_order: 1,
+      options: [],
+    },
+    {
+      key: 'interior-products',
+      question_key: 'products-interior',
+      question_text: '관심 제품군',
+      selection_type: 'SINGLE',
+      is_required: true,
+      sort_order: 2,
+      options: [
+        {
+          answer_option_key: 'diffuser',
+          answer_option_text: '디퓨저',
+          sort_order: 1,
+        },
+        {
+          answer_option_key: 'perfume',
+          answer_option_text: '향수',
+          sort_order: 2,
+        },
+      ],
+    },
+  ],
+  OOTD: [
+    {
+      key: 'ootd-photo',
+      question_key: 'photo-ootd',
+      question_text: '사진 첨부',
+      selection_type: 'PHOTO',
+      is_required: true,
+      sort_order: 1,
+      options: [],
+    },
+    {
+      key: 'ootd-products',
+      question_key: 'products-ootd',
+      question_text: '관심 제품군',
+      selection_type: 'SINGLE',
+      is_required: true,
+      sort_order: 2,
+      options: [
+        {
+          answer_option_key: 'diffuser',
+          answer_option_text: '디퓨저',
+          sort_order: 1,
+        },
+        {
+          answer_option_key: 'perfume',
+          answer_option_text: '향수',
+          sort_order: 2,
+        },
+      ],
+    },
+  ],
+}
+
+/**
+ * 관리자가 선택할 수 있는 프리셋 목록
+ */
+export const ALL_PRESETS: Question[] = Object.values(DEFAULT_TEMPLATES).flat()
+
+/**
+ * 테스트 유형별 고정된 질문 키 옵션들 (AdminSelect용)
+ */
+export const CATEGORIZED_PRESET_OPTIONS: Record<
+  string,
+  { label: string; value: string }[]
+> = Object.keys(DEFAULT_TEMPLATES).reduce(
+  (acc, type) => {
+    acc[type] = [
+      ...DEFAULT_TEMPLATES[type].map((q) => ({
+        label: `${q.question_text} (${q.question_key})`,
+        value: q.question_key,
+      })),
+    ]
+    return acc
+  },
+  {} as Record<string, { label: string; value: string }[]>
+)
+
+/**
+ * 템플릿 데이터를 기반으로 질문 ID별 선택 가능한 벨류(Value) 옵션들을 생성하기.
+ */
+export const STANDARD_OPTIONS: Record<
+  string,
+  { label: string; value: string }[]
+> = Object.values(DEFAULT_TEMPLATES)
+  .flat()
+  .reduce(
+    (acc, q) => {
+      if (q.options.length > 0 && !acc[q.question_key]) {
+        acc[q.question_key] = q.options.map((o) => ({
+          label: o.answer_option_text,
+          value: o.answer_option_text,
+        }))
+      }
+      return acc
+    },
+    {} as Record<string, { label: string; value: string }[]>
+  )

--- a/src/app/admin/test/create/_constants/presets.ts
+++ b/src/app/admin/test/create/_constants/presets.ts
@@ -11,21 +11,25 @@ export const DEFAULT_TEMPLATES: Record<string, Question[]> = {
       sort_order: 1,
       options: [
         {
+          key: 'calm',
           answer_option_key: 'calm',
           answer_option_text: '차분',
           sort_order: 1,
         },
         {
+          key: 'vital',
           answer_option_key: 'vital',
           answer_option_text: '활기',
           sort_order: 2,
         },
         {
+          key: 'cozy',
           answer_option_key: 'cozy',
           answer_option_text: '포근',
           sort_order: 3,
         },
         {
+          key: 'focused',
           answer_option_key: 'focused',
           answer_option_text: '집중',
           sort_order: 4,
@@ -41,21 +45,25 @@ export const DEFAULT_TEMPLATES: Record<string, Question[]> = {
       sort_order: 2,
       options: [
         {
+          key: 'spring',
           answer_option_key: 'spring',
           answer_option_text: '봄',
           sort_order: 1,
         },
         {
+          key: 'summer',
           answer_option_key: 'summer',
           answer_option_text: '여름',
           sort_order: 2,
         },
         {
+          key: 'autumn',
           answer_option_key: 'autumn',
           answer_option_text: '가을',
           sort_order: 3,
         },
         {
+          key: 'winter',
           answer_option_key: 'winter',
           answer_option_text: '겨울',
           sort_order: 4,
@@ -71,17 +79,25 @@ export const DEFAULT_TEMPLATES: Record<string, Question[]> = {
       sort_order: 3,
       options: [
         {
+          key: 'forest',
           answer_option_key: 'forest',
           answer_option_text: '숲',
           sort_order: 1,
         },
-        { answer_option_key: 'sea', answer_option_text: '바다', sort_order: 2 },
         {
+          key: 'sea',
+          answer_option_key: 'sea',
+          answer_option_text: '바다',
+          sort_order: 2,
+        },
+        {
+          key: 'city',
           answer_option_key: 'city',
           answer_option_text: '도시',
           sort_order: 3,
         },
         {
+          key: 'village',
           answer_option_key: 'village',
           answer_option_text: '시골',
           sort_order: 4,
@@ -96,13 +112,20 @@ export const DEFAULT_TEMPLATES: Record<string, Question[]> = {
       is_required: true,
       sort_order: 4,
       options: [
-        { answer_option_key: 'male', answer_option_text: '남', sort_order: 1 },
         {
+          key: 'male',
+          answer_option_key: 'male',
+          answer_option_text: '남',
+          sort_order: 1,
+        },
+        {
+          key: 'female',
           answer_option_key: 'female',
           answer_option_text: '여',
           sort_order: 2,
         },
         {
+          key: 'neutral',
           answer_option_key: 'neutral',
           answer_option_text: '중성',
           sort_order: 3,
@@ -118,26 +141,31 @@ export const DEFAULT_TEMPLATES: Record<string, Question[]> = {
       sort_order: 5,
       options: [
         {
+          key: 'teen',
           answer_option_key: 'teen',
           answer_option_text: '10대',
           sort_order: 1,
         },
         {
+          key: 'twenties',
           answer_option_key: 'twenties',
           answer_option_text: '20대',
           sort_order: 2,
         },
         {
+          key: 'thirties',
           answer_option_key: 'thirties',
           answer_option_text: '30대',
           sort_order: 3,
         },
         {
+          key: 'forties',
           answer_option_key: 'forties',
           answer_option_text: '40대',
           sort_order: 4,
         },
         {
+          key: 'fifties',
           answer_option_key: 'fifties',
           answer_option_text: '50대',
           sort_order: 5,
@@ -153,31 +181,37 @@ export const DEFAULT_TEMPLATES: Record<string, Question[]> = {
       sort_order: 6,
       options: [
         {
+          key: 'citrus',
           answer_option_key: 'citrus',
           answer_option_text: '시트러스',
           sort_order: 1,
         },
         {
+          key: 'aromatic',
           answer_option_key: 'aromatic',
           answer_option_text: '아로마틱',
           sort_order: 2,
         },
         {
+          key: 'oriental',
           answer_option_key: 'oriental',
           answer_option_text: '오리엔탈',
           sort_order: 3,
         },
         {
+          key: 'woody',
           answer_option_key: 'woody',
           answer_option_text: '우디',
           sort_order: 4,
         },
         {
+          key: 'animalic',
           answer_option_key: 'animalic',
           answer_option_text: '애니멀릭',
           sort_order: 5,
         },
         {
+          key: 'floral',
           answer_option_key: 'floral',
           answer_option_text: '플로럴',
           sort_order: 6,
@@ -193,31 +227,37 @@ export const DEFAULT_TEMPLATES: Record<string, Question[]> = {
       sort_order: 7,
       options: [
         {
+          key: 'citrus',
           answer_option_key: 'citrus',
           answer_option_text: '시트러스',
           sort_order: 1,
         },
         {
+          key: 'aromatic',
           answer_option_key: 'aromatic',
           answer_option_text: '아로마틱',
           sort_order: 2,
         },
         {
+          key: 'oriental',
           answer_option_key: 'oriental',
           answer_option_text: '오리엔탈',
           sort_order: 3,
         },
         {
+          key: 'woody',
           answer_option_key: 'woody',
           answer_option_text: '우디',
           sort_order: 4,
         },
         {
+          key: 'animalic',
           answer_option_key: 'animalic',
           answer_option_text: '애니멀릭',
           sort_order: 5,
         },
         {
+          key: 'floral',
           answer_option_key: 'floral',
           answer_option_text: '플로럴',
           sort_order: 6,
@@ -233,11 +273,13 @@ export const DEFAULT_TEMPLATES: Record<string, Question[]> = {
       sort_order: 8,
       options: [
         {
+          key: 'diffuser',
           answer_option_key: 'diffuser',
           answer_option_text: '디퓨저',
           sort_order: 1,
         },
         {
+          key: 'perfume',
           answer_option_key: 'perfume',
           answer_option_text: '향수',
           sort_order: 2,
@@ -255,21 +297,25 @@ export const DEFAULT_TEMPLATES: Record<string, Question[]> = {
       sort_order: 1,
       options: [
         {
+          key: 'sleep-well',
           answer_option_key: 'sleep-well',
           answer_option_text: '잘잔다',
           sort_order: 1,
         },
         {
+          key: 'wake-often',
           answer_option_key: 'wake-often',
           answer_option_text: '자주 깬다',
           sort_order: 2,
         },
         {
+          key: 'hard-to-fall-asleep',
           answer_option_key: 'hard-to-fall-asleep',
           answer_option_text: '잠들기 어렵다',
           sort_order: 3,
         },
         {
+          key: 'always-tired',
           answer_option_key: 'always-tired',
           answer_option_text: '항상 피곤하다',
           sort_order: 4,
@@ -285,21 +331,25 @@ export const DEFAULT_TEMPLATES: Record<string, Question[]> = {
       sort_order: 2,
       options: [
         {
+          key: 'none',
           answer_option_key: 'none',
           answer_option_text: '거의 없다',
           sort_order: 1,
         },
         {
+          key: 'sometimes',
           answer_option_key: 'sometimes',
           answer_option_text: '가끔 느낀다',
           sort_order: 2,
         },
         {
+          key: 'often',
           answer_option_key: 'often',
           answer_option_text: '자주 느낀다',
           sort_order: 3,
         },
         {
+          key: 'always',
           answer_option_key: 'always',
           answer_option_text: '항상 느낀다',
           sort_order: 4,
@@ -315,21 +365,25 @@ export const DEFAULT_TEMPLATES: Record<string, Question[]> = {
       sort_order: 3,
       options: [
         {
+          key: 'none',
           answer_option_key: 'none',
           answer_option_text: '거의 없다',
           sort_order: 1,
         },
         {
+          key: 'sometimes',
           answer_option_key: 'sometimes',
           answer_option_text: '가끔 느낀다',
           sort_order: 2,
         },
         {
+          key: 'often',
           answer_option_key: 'often',
           answer_option_text: '자주 느낀다',
           sort_order: 3,
         },
         {
+          key: 'always',
           answer_option_key: 'always',
           answer_option_text: '항상 느낀다',
           sort_order: 4,
@@ -345,21 +399,25 @@ export const DEFAULT_TEMPLATES: Record<string, Question[]> = {
       sort_order: 4,
       options: [
         {
+          key: 'focus-good',
           answer_option_key: 'focus-good',
           answer_option_text: '잘 집중한다',
           sort_order: 1,
         },
         {
+          key: 'distract-sometimes',
           answer_option_key: 'distract-sometimes',
           answer_option_text: '가끔 산만하다',
           sort_order: 2,
         },
         {
+          key: 'distract-often',
           answer_option_key: 'distract-often',
           answer_option_text: '자주 산만하다',
           sort_order: 3,
         },
         {
+          key: 'focus-very-hard',
           answer_option_key: 'focus-very-hard',
           answer_option_text: '집중이 매우 어렵다',
           sort_order: 4,
@@ -375,21 +433,25 @@ export const DEFAULT_TEMPLATES: Record<string, Question[]> = {
       sort_order: 5,
       options: [
         {
+          key: 'relax-stress',
           answer_option_key: 'relax-stress',
           answer_option_text: '스트레스 완화',
           sort_order: 1,
         },
         {
+          key: 'improve-sleep',
           answer_option_key: 'improve-sleep',
           answer_option_text: '수면개선',
           sort_order: 2,
         },
         {
+          key: 'relieve-anxiety',
           answer_option_key: 'relieve-anxiety',
           answer_option_text: '불안해소',
           sort_order: 3,
         },
         {
+          key: 'improve-focus',
           answer_option_key: 'improve-focus',
           answer_option_text: '집중력 향상',
           sort_order: 4,
@@ -405,11 +467,13 @@ export const DEFAULT_TEMPLATES: Record<string, Question[]> = {
       sort_order: 6,
       options: [
         {
+          key: 'diffuser',
           answer_option_key: 'diffuser',
           answer_option_text: '디퓨저',
           sort_order: 1,
         },
         {
+          key: 'perfume',
           answer_option_key: 'perfume',
           answer_option_text: '향수',
           sort_order: 2,
@@ -436,11 +500,13 @@ export const DEFAULT_TEMPLATES: Record<string, Question[]> = {
       sort_order: 2,
       options: [
         {
+          key: 'diffuser',
           answer_option_key: 'diffuser',
           answer_option_text: '디퓨저',
           sort_order: 1,
         },
         {
+          key: 'perfume',
           answer_option_key: 'perfume',
           answer_option_text: '향수',
           sort_order: 2,
@@ -467,11 +533,13 @@ export const DEFAULT_TEMPLATES: Record<string, Question[]> = {
       sort_order: 2,
       options: [
         {
+          key: 'diffuser',
           answer_option_key: 'diffuser',
           answer_option_text: '디퓨저',
           sort_order: 1,
         },
         {
+          key: 'perfume',
           answer_option_key: 'perfume',
           answer_option_text: '향수',
           sort_order: 2,

--- a/src/app/admin/test/create/_hooks/useTestCreate.ts
+++ b/src/app/admin/test/create/_hooks/useTestCreate.ts
@@ -16,6 +16,10 @@ export const useTestCreate = () => {
       ...q,
       key: `${q.question_key}-${Date.now()}`, // 임시 키 생성
       sort_order: idx + 1,
+      options: q.options.map((o) => ({
+        ...o,
+        key: `${o.answer_option_key}-${Date.now()}`, // 마찬가지 임시 키 생성
+      })),
     })),
   }))
 
@@ -111,6 +115,7 @@ export const useTestCreate = () => {
   const addOption = (qKey: string) => {
     modifyQuestionOptions(qKey, (options) => {
       const newOption: Option = {
+        key: generateUid('opt'),
         answer_option_key: generateUid('opt'),
         answer_option_text: '',
         sort_order: options.length + 1,
@@ -119,22 +124,20 @@ export const useTestCreate = () => {
     })
   }
 
-  const removeOption = (qKey: string, optKey: string) => {
+  const removeOption = (qKey: string, optUid: string) => {
     modifyQuestionOptions(qKey, (options) => {
-      const filtered = options.filter((o) => o.answer_option_key !== optKey)
+      const filtered = options.filter((o) => o.key !== optUid)
       return filtered.map((o, idx) => ({ ...o, sort_order: idx + 1 }))
     })
   }
 
   const updateOption = (
     qKey: string,
-    optKey: string,
+    optUid: string,
     updates: Partial<Option>
   ) => {
     modifyQuestionOptions(qKey, (options) =>
-      options.map((o) =>
-        o.answer_option_key === optKey ? { ...o, ...updates } : o
-      )
+      options.map((o) => (o.key === optUid ? { ...o, ...updates } : o))
     )
   }
 

--- a/src/app/admin/test/create/_hooks/useTestCreate.ts
+++ b/src/app/admin/test/create/_hooks/useTestCreate.ts
@@ -1,0 +1,190 @@
+'use client'
+
+import { useState } from 'react'
+import { TestFormData, Question, Option } from '../_types'
+import { DEFAULT_TEMPLATES } from '../_constants/presets'
+
+export const useTestCreate = () => {
+  // UI 전용 상태: 현재 선택된 탭 카테고리 (취향, 건강, 인테리어, OOTD)
+  const [uiCategory, setUiCategory] = useState<string>('PREFERENCE')
+
+  const [formData, setFormData] = useState<TestFormData>(() => ({
+    name: '',
+    description: '',
+    profiling_type: 'PREFERENCE',
+    questions: DEFAULT_TEMPLATES['PREFERENCE'].map((q, idx) => ({
+      ...q,
+      key: `${q.question_key}-${Date.now()}`, // 임시 키 생성
+      sort_order: idx + 1,
+    })),
+  }))
+
+  // Helper for generating unique keys/ids
+  const generateUid = (prefix: string) =>
+    `${prefix}-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`
+
+  const updateField = <K extends keyof TestFormData>(
+    key: K,
+    value: TestFormData[K]
+  ) => {
+    setFormData((prev) => ({ ...prev, [key]: value }))
+  }
+
+  const updateCategory = (category: string) => {
+    setUiCategory(category)
+
+    const typeMap: Record<string, string> = {
+      취향: 'PREFERENCE',
+      건강: 'HEALTH',
+      인테리어: 'PREFERENCE',
+      OOTD: 'PREFERENCE',
+    }
+
+    const apiType = typeMap[category] || 'PREFERENCE'
+
+    setFormData((prev) => ({
+      ...prev,
+      profiling_type: apiType,
+      questions: (DEFAULT_TEMPLATES[category] || []).map((q, idx) => ({
+        ...q,
+        key: generateUid(q.question_key),
+        sort_order: idx + 1,
+      })),
+    }))
+  }
+
+  // --- Question Actions ---
+  const addQuestion = () => {
+    const newQuestion: Question = {
+      key: generateUid('custom'),
+      question_key: 'custom-type',
+      question_text: '',
+      selection_type: 'SINGLE',
+      is_required: true,
+      sort_order: formData.questions.length + 1,
+      options: [],
+    }
+    setFormData((prev) => ({
+      ...prev,
+      questions: [...prev.questions, newQuestion],
+    }))
+  }
+
+  const removeQuestion = (qKey: string) => {
+    setFormData((prev) => {
+      const filtered = prev.questions.filter((q) => q.key !== qKey)
+      const reordered = filtered.map((q, idx) => ({
+        ...q,
+        sort_order: idx + 1,
+      }))
+      return { ...prev, questions: reordered }
+    })
+  }
+
+  const updateQuestion = (qKey: string, updates: Partial<Question>) => {
+    setFormData((prev) => ({
+      ...prev,
+      questions: prev.questions.map((q) =>
+        q.key === qKey ? { ...q, ...updates } : q
+      ),
+    }))
+  }
+
+  const reorderQuestions = (questions: Question[]) => {
+    const reordered = questions.map((q, idx) => ({ ...q, sort_order: idx + 1 }))
+    setFormData((prev) => ({ ...prev, questions: reordered }))
+  }
+
+  // --- Option Actions ---
+  const modifyQuestionOptions = (
+    qKey: string,
+    transformer: (options: Option[]) => Option[]
+  ) => {
+    setFormData((prev) => ({
+      ...prev,
+      questions: prev.questions.map((q) =>
+        q.key === qKey ? { ...q, options: transformer(q.options) } : q
+      ),
+    }))
+  }
+
+  const addOption = (qKey: string) => {
+    modifyQuestionOptions(qKey, (options) => {
+      const newOption: Option = {
+        answer_option_key: generateUid('opt'),
+        answer_option_text: '',
+        sort_order: options.length + 1,
+      }
+      return [...options, newOption]
+    })
+  }
+
+  const removeOption = (qKey: string, optKey: string) => {
+    modifyQuestionOptions(qKey, (options) => {
+      const filtered = options.filter((o) => o.answer_option_key !== optKey)
+      return filtered.map((o, idx) => ({ ...o, sort_order: idx + 1 }))
+    })
+  }
+
+  const updateOption = (
+    qKey: string,
+    optKey: string,
+    updates: Partial<Option>
+  ) => {
+    modifyQuestionOptions(qKey, (options) =>
+      options.map((o) =>
+        o.answer_option_key === optKey ? { ...o, ...updates } : o
+      )
+    )
+  }
+
+  const reorderOptions = (qKey: string, options: Option[]) => {
+    const reordered = options.map((o, idx) => ({ ...o, sort_order: idx + 1 }))
+    updateQuestion(qKey, { options: reordered })
+  }
+
+  const handleSave = () => {
+    const payload = {
+      name: formData.name,
+      description: formData.description,
+      profiling_type: formData.profiling_type,
+      questions: formData.questions.map((q) => ({
+        question_key: q.question_key,
+        question_text: q.question_text,
+        selection_type: q.selection_type,
+        is_required: q.is_required,
+        sort_order: q.sort_order,
+        options: q.options.map((o) => ({
+          answer_option_key: o.answer_option_key,
+          answer_option_text: o.answer_option_text,
+          sort_order: o.sort_order,
+        })),
+      })),
+    }
+    console.log('요청 페이로드 : ', payload)
+  }
+
+  return {
+    state: {
+      uiCategory,
+      formData,
+    },
+    actions: {
+      updateField,
+      updateCategory,
+      handleSave,
+      question: {
+        add: addQuestion,
+        remove: removeQuestion,
+        update: updateQuestion,
+        reorder: reorderQuestions,
+      },
+      option: {
+        add: addOption,
+        remove: removeOption,
+        update: updateOption,
+        reorder: reorderOptions,
+      },
+    },
+  }
+}

--- a/src/app/admin/test/create/_types/index.ts
+++ b/src/app/admin/test/create/_types/index.ts
@@ -1,0 +1,22 @@
+export interface Option {
+  answer_option_key: string
+  answer_option_text: string
+  sort_order: number
+}
+
+export interface Question {
+  key: string // 내부 체크용 키
+  question_key: string
+  question_text: string
+  selection_type: 'SINGLE' | 'MULTI' | 'PHOTO'
+  is_required: boolean
+  sort_order: number
+  options: Option[]
+}
+
+export interface TestFormData {
+  name: string
+  description: string
+  profiling_type: string
+  questions: Question[]
+}

--- a/src/app/admin/test/create/_types/index.ts
+++ b/src/app/admin/test/create/_types/index.ts
@@ -1,4 +1,5 @@
 export interface Option {
+  key: string // 내부 체크용 키
   answer_option_key: string
   answer_option_text: string
   sort_order: number

--- a/src/app/admin/test/create/page.tsx
+++ b/src/app/admin/test/create/page.tsx
@@ -1,0 +1,187 @@
+'use client'
+
+import Link from 'next/link'
+import { Reorder } from 'motion/react'
+import {
+  AdminListCard,
+  AdminPageHeader,
+  AdminTabGroup,
+} from '@/app/admin/_components'
+import Button from '@/components/common/Button'
+import { useTestCreate } from './_hooks/useTestCreate'
+import { QuestionForm } from './_components/QuestionForm'
+import { Question } from './_types'
+
+const TEST_TYPE_TABS = [
+  { id: 'PREFERENCE', label: '취향' },
+  { id: 'HEALTH', label: '건강' },
+  { id: 'INTERIOR', label: '인테리어' },
+  { id: 'OOTD', label: 'OOTD' },
+]
+
+export default function TestCreatePage() {
+  const { state, actions } = useTestCreate()
+
+  return (
+    <div className="space-y-8">
+      <AdminPageHeader
+        title="새 테스트 생성"
+        leftContent={
+          <Link
+            href="/admin/test"
+            className="text-black-primary text-sm font-semibold underline"
+          >
+            목록으로 돌아가기
+          </Link>
+        }
+        rightContent={
+          <Button className="border-gray-light text-black-primary flex items-center gap-2 rounded-xl border bg-white px-4 py-2.5 text-sm font-bold">
+            미리보기
+          </Button>
+        }
+        buttonText="저장"
+        buttonIcon="save"
+        onButtonClick={actions.handleSave}
+        className="rounded-[20px] bg-white p-8"
+      />
+
+      <AdminListCard>
+        <div className="space-y-10">
+          <div className="space-y-4">
+            <div className="mb-4">
+              <span className="text-black-primary text-lg font-bold">
+                기본 정보
+              </span>
+            </div>
+
+            <div className="space-y-4">
+              <label className="flex items-center gap-2 text-sm font-bold text-gray-500">
+                테스트 이름
+                <span className="text-red-500">*</span>
+              </label>
+              <input
+                type="text"
+                value={state.formData.name}
+                onChange={(e) => actions.updateField('name', e.target.value)}
+                placeholder="테스트 이름을 입력하세요 ex) 취향 테스트 v1.1"
+                className="border-gray-light w-full rounded-2xl border bg-gray-50/50 p-4 text-sm outline-none focus:border-violet-300 focus:bg-white"
+              />
+            </div>
+
+            <div className="space-y-4">
+              <div className="mb-2 flex gap-2">
+                <label className="text-sm font-bold text-gray-500">
+                  테스트 유형
+                </label>
+                <span className="text-red-500">*</span>
+              </div>
+              <AdminTabGroup
+                tabs={TEST_TYPE_TABS}
+                activeTab={state.uiCategory}
+                onChange={(id) => actions.updateCategory(id)}
+                fullWidth
+              />
+            </div>
+
+            <div className="space-y-4">
+              <label className="flex items-center justify-between text-sm font-bold text-gray-500">
+                테스트 설명 (선택)
+                <span className="text-xs font-normal text-gray-400">
+                  {state.formData.description.length}/100
+                </span>
+              </label>
+              <textarea
+                value={state.formData.description}
+                onChange={(e) =>
+                  actions.updateField('description', e.target.value)
+                }
+                placeholder="테스트에 대한 간단한 설명을 입력하세요"
+                className="border-gray-light min-h-[120px] w-full rounded-2xl border bg-gray-50/50 p-6 text-sm outline-none focus:border-violet-300 focus:bg-white"
+                maxLength={100}
+              />
+            </div>
+          </div>
+
+          <div className="flex items-start gap-4 rounded-2xl border border-blue-100 bg-blue-50/50 p-5">
+            <div className="mt-1 flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-blue-800 text-xs font-bold text-blue-800">
+              i
+            </div>
+            <div className="space-y-1">
+              <h4 className="text-sm font-bold text-blue-900">
+                노출 상태 안내
+              </h4>
+              <p className="text-xs leading-relaxed text-blue-700 opacity-80">
+                새로 생성되는 테스트는 기본적으로{' '}
+                <span className="font-bold underline">비노출</span> 상태로
+                저장됩니다. 노출 설정은 목록에서 변경할 수 있습니다.
+              </p>
+            </div>
+          </div>
+        </div>
+      </AdminListCard>
+
+      <div className="space-y-6 rounded-[20px] bg-white p-8">
+        <div className="flex items-end justify-between px-2">
+          <h3 className="text-black-primary text-xl font-bold">테스트 질문</h3>
+          <Button
+            onClick={actions.question.add}
+            color="primary"
+            className="flex items-center gap-2 rounded-xl border-none bg-violet-100 px-6 py-2.5 font-bold text-violet-700 shadow-sm hover:bg-violet-200"
+          >
+            질문 추가
+          </Button>
+        </div>
+
+        {state.formData.questions.length === 0 ? (
+          <div className="border-gray-light flex min-h-[160px] flex-col items-center justify-center rounded-[20px] border-2 border-dashed bg-gray-50/30 text-center">
+            <p className="text-sm text-gray-400">
+              아직 추가된 질문이 없습니다.
+            </p>
+            <p className="mt-1 text-xs text-gray-400 opacity-70">
+              위의 질문 추가 버튼을 클릭하여 질문을 만들어보세요.
+            </p>
+          </div>
+        ) : (
+          <Reorder.Group
+            axis="y"
+            values={state.formData.questions}
+            onReorder={actions.question.reorder}
+            className="flex flex-col gap-6"
+          >
+            {state.formData.questions.map(
+              (question: Question, index: number) => (
+                <Reorder.Item
+                  key={question.key}
+                  value={question}
+                  className="cursor-default"
+                  initial={false}
+                  transition={{ duration: 0 }}
+                >
+                  <QuestionForm
+                    testType={state.uiCategory}
+                    question={question}
+                    index={index}
+                    onUpdate={(updates) =>
+                      actions.question.update(question.key, updates)
+                    }
+                    onRemove={() => actions.question.remove(question.key)}
+                    onAddOption={() => actions.option.add(question.key)}
+                    onRemoveOption={(optKey) =>
+                      actions.option.remove(question.key, optKey)
+                    }
+                    onUpdateOption={(optKey, updates) =>
+                      actions.option.update(question.key, optKey, updates)
+                    }
+                    onReorderOptions={(newOptions) =>
+                      actions.option.reorder(question.key, newOptions)
+                    }
+                  />
+                </Reorder.Item>
+              )
+            )}
+          </Reorder.Group>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/app/admin/test/page.tsx
+++ b/src/app/admin/test/page.tsx
@@ -12,6 +12,7 @@ import {
 import { TEST_MOCK_DATA, TEST_TABLE_HEADERS, TestData } from '@/constants/admin'
 import PenIcon from '@/assets/icons/pen.svg'
 import Button from '@/components/common/Button'
+import { useRouter } from 'next/navigation'
 
 const getStatusStyles = (status: TestData['status']) => {
   switch (status) {
@@ -25,18 +26,25 @@ const getStatusStyles = (status: TestData['status']) => {
 
 const getTypeStyles = (type: TestData['type']) => {
   switch (type) {
-    case '취향':
+    case 'PREFERENCE':
       return 'bg-status-purple-bg text-status-purple-text'
-    case '건강':
+    case 'HEALTH':
     default:
       return 'bg-status-info-bg text-status-info-text'
   }
 }
 
 export default function TestAdminPage() {
+  const router = useRouter()
+
   return (
     <AdminListCard>
-      <AdminPageHeader title="테스트 목록" buttonText="테스트 등록" />
+      <AdminPageHeader
+        title="테스트 목록"
+        buttonText="테스트 등록"
+        buttonIcon="plus"
+        onButtonClick={() => router.push('/admin/test/create')}
+      />
 
       <AdminFilterBar
         searchPlaceholder="테스트명 검색"


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->

테스트 관리 페이지에서 테스트 등록 할 수 있는 페이지를 새로 추가합니다.

## 📌 관련 이슈

<!-- Closes #이슈번호 -->

Closes #40 

## 🧩 작업 내용 (주요 변경사항)

- 테스트 관리 목록에서 새 테스트로 등록하기 위한 등록 버튼에 /create 라우팅을 추가하여 버튼 클릭 시 이동하도록 추가
-  새 테스트릉 생성 할 수 있는 등록 페이지를 추가하여 테스트의 기본 정보 + 유형 + 설명 + 테스트에 질문을 추가 가능
-  테스트 유형에 맞는 질문을 생성할 수 있는 QuestionForm을 추가
-  유형에 맞는 문제 정보를 가져오기 위한 preset 파일 작성 
-  테스트 생성에 필요한 상태와 폼 입력을 포함한 useTestCreate 추가히야  드래그 & 드롭 으로 질문 순서, 선지의 순서를 변경 가능

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->
- preset를 생성하여 테스트 생성시 필요한 옵션들을 미리 템플릿 형식으로 작성
- 현재 useTestCreate 파일에 handleSave를 통해 테스트 생성 시 payload를 명세서 형식 참고하여 작성

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->
![20260303144214](https://github.com/user-attachments/assets/b40d524b-8608-480d-be52-889a9055ff6a)

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->
추가로 해야할것 - 유효성 검증 로직 추가 및 모달

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 로컬에서 실행 확인 완료
