### PR TITLE
[refactor] 향조 라벨, 향기 노트 공통컴포넌트로 분리 (#67)

### DIFF
--- a/src/components/products/ProductCard.tsx
+++ b/src/components/products/ProductCard.tsx
@@ -2,14 +2,13 @@
 
 import Image from 'next/image'
 import { cn } from '@/lib/cn'
-import { SCENT_FAMILIES } from '@/constants/productFilters'
-import { ACCORD_LABEL_STYLES } from '@/constants/accordLabelStyles'
+import {
+  getAccordLabels,
+  ACCORD_LABEL_PILL_SM_CLASS,
+  SCENT_NOTE_LINE_CLASS,
+} from '@/constants/accordLabelStyles'
 import { Lens } from '@/components/magicui/lens'
 import { ShineBorder } from '../magicui/shine-border'
-
-const scentFamilyMap = Object.fromEntries(
-  SCENT_FAMILIES.map((f) => [f.id, f])
-) as Record<string, (typeof SCENT_FAMILIES)[number]>
 
 export type ProductCardProps = {
   variant: 'single' | 'combo'
@@ -34,9 +33,9 @@ export function ProductCard({
   priority = false,
 }: ProductCardProps) {
   const accordIds: string[] =
-    variant === 'combo' && scentFamilyIds?.length // 조합 카드에서만 사용. 여러 향조 라벨을 표시 (없으면 scentFamilyId 1개만 표시)
+    variant === 'combo' && scentFamilyIds?.length
       ? scentFamilyIds
-      : [scentFamilyId] // 단품 카드에서는 scentFamilyId 1개만 표시
+      : [scentFamilyId]
 
   return (
     <ShineBorder
@@ -63,29 +62,23 @@ export function ProductCard({
             {name}
           </h3>
           <div className="flex flex-wrap gap-1">
-            {accordIds.map((id) => {
-              const family = scentFamilyMap[id] ?? scentFamilyMap.woody
-              const style =
-                ACCORD_LABEL_STYLES[family.colorClass] ??
-                ACCORD_LABEL_STYLES.woody
-              return (
-                <span
-                  key={id}
-                  className="inline-block rounded-full border px-2 py-0.5 text-xs font-medium"
-                  style={{
-                    backgroundColor: style.bg,
-                    borderColor: style.border,
-                    color: style.text,
-                    borderWidth: 1,
-                  }}
-                >
-                  {family.label}
-                </span>
-              )
-            })}
+            {getAccordLabels(accordIds).map(({ id, label, style }) => (
+              <span
+                key={id}
+                className={ACCORD_LABEL_PILL_SM_CLASS}
+                style={{
+                  backgroundColor: style.bg,
+                  borderColor: style.border,
+                  color: style.text,
+                  borderWidth: 1,
+                }}
+              >
+                {label}
+              </span>
+            ))}
           </div>
           {variant === 'combo' && scentNotes.length > 0 && (
-            <p className="mt-2 line-clamp-1 px-1.5 text-xs text-neutral-500">
+            <p className={cn(SCENT_NOTE_LINE_CLASS, 'mt-2 px-1.5')}>
               {scentNotes.join(' ')}
             </p>
           )}

--- a/src/components/products/ProductDetailModal.tsx
+++ b/src/components/products/ProductDetailModal.tsx
@@ -3,8 +3,11 @@
 import React from 'react'
 import Image from 'next/image'
 import { useRouter } from 'next/navigation'
-import { SCENT_FAMILIES } from '@/constants/productFilters'
-import { ACCORD_LABEL_STYLES } from '@/constants/accordLabelStyles'
+import {
+  getAccordLabels,
+  ACCORD_LABEL_PILL_MD_CLASS,
+  SCENT_NOTE_PILL_CLASS,
+} from '@/constants/accordLabelStyles'
 import Button from '@/components/common/Button'
 import { buttonVariants } from '@/components/common/Button/Button.variants'
 import { cn } from '@/lib/cn'
@@ -47,10 +50,7 @@ const styles = {
   dividerLine: 'bg-neutral-200 h-px flex-1',
   dividerIcon: 'text-neutral-400',
 
-  // ── 섹션·칩 (향조 pill, 향기 노트 pill)
   section: 'flex flex-col gap-2',
-  accordPill: 'inline-block rounded-full border px-3 py-1 text-sm font-medium',
-  notePill: 'rounded-lg bg-neutral-100 px-3 py-1.5 text-sm text-neutral-700',
   noteEmpty: 'text-neutral-400 text-sm',
 } as const
 
@@ -68,11 +68,6 @@ const testButtonProps = {
   className:
     'rounded-lg shadow-sm w-full h-10 flex items-center justify-between px-4 py-2.5 text-sm bg-neutral-100 text-neutral-800 border-2 border-transparent transition-all duration-200 hover:border-[var(--color-purple-primary)] hover:text-[var(--color-purple-primary)] active:scale-[0.98]',
 }
-
-// ─── 타입 ─────────────────────────────────────────────────────────────────
-const scentFamilyMap = Object.fromEntries(
-  SCENT_FAMILIES.map((f) => [f.id, f])
-) as Record<string, (typeof SCENT_FAMILIES)[number]>
 
 export type ProductDetailModalProduct = {
   name: string
@@ -112,13 +107,7 @@ export function ProductDetailModal({
 
   /** 연관 추천 상품 보러가기: 상세의 product_link */
   const productLink = product?.productLink?.trim() ?? ''
-  const accordLabels =
-    product?.scentFamilyIds.map((id) => {
-      const family = scentFamilyMap[id] ?? scentFamilyMap.woody
-      const style =
-        ACCORD_LABEL_STYLES[family.colorClass] ?? ACCORD_LABEL_STYLES.woody
-      return { id, label: family.label, style }
-    }) ?? []
+  const accordLabels = product ? getAccordLabels(product.scentFamilyIds) : []
 
   return (
     <div className={styles.overlay} onClick={handleOverlayClick}>
@@ -199,20 +188,22 @@ export function ProductDetailModal({
               <div className={styles.section}>
                 <p className={styles.subTitle}>향조</p>
                 <div className="flex flex-wrap gap-2">
-                  {accordLabels.map(({ id, label, style }) => (
-                    <span
-                      key={id}
-                      className={styles.accordPill}
-                      style={{
-                        backgroundColor: style.bg,
-                        borderColor: style.border,
-                        color: style.text,
-                        borderWidth: 1,
-                      }}
-                    >
-                      {label}
-                    </span>
-                  ))}
+                  {getAccordLabels(product.scentFamilyIds).map(
+                    ({ id, label, style }) => (
+                      <span
+                        key={id}
+                        className={ACCORD_LABEL_PILL_MD_CLASS}
+                        style={{
+                          backgroundColor: style.bg,
+                          borderColor: style.border,
+                          color: style.text,
+                          borderWidth: 1,
+                        }}
+                      >
+                        {label}
+                      </span>
+                    )
+                  )}
                 </div>
               </div>
 
@@ -220,17 +211,17 @@ export function ProductDetailModal({
                 <>
                   <div className={styles.section}>
                     <p className={styles.subTitle}>향기 노트</p>
-                    <div className="flex flex-wrap gap-2">
-                      {product.noteLabels.length > 0 ? (
-                        product.noteLabels.map((note) => (
-                          <span key={note} className={styles.notePill}>
+                    {product.noteLabels.length > 0 ? (
+                      <div className="flex flex-wrap gap-2">
+                        {product.noteLabels.map((note) => (
+                          <span key={note} className={SCENT_NOTE_PILL_CLASS}>
                             {note}
                           </span>
-                        ))
-                      ) : (
-                        <span className={styles.noteEmpty}>-</span>
-                      )}
-                    </div>
+                        ))}
+                      </div>
+                    ) : (
+                      <span className={styles.noteEmpty}>-</span>
+                    )}
                   </div>
 
                   <div className="mt-2">

--- a/src/constants/accordLabelStyles.ts
+++ b/src/constants/accordLabelStyles.ts
@@ -1,14 +1,8 @@
-/**
- * 향조(Accord) 라벨 공통 스타일
- * - ProductCard, ProductDetailModal 등에서 재사용
- * - colorClass는 @/constants/productFilters SCENT_FAMILIES.colorClass와 매칭
- */
-export type AccordLabelStyle = {
-  bg: string
-  border: string
-  text: string
-}
+import { SCENT_FAMILIES } from '@/constants/productFilters'
 
+export type AccordLabelStyle = { bg: string; border: string; text: string }
+
+// 향조 라벨 스타일
 export const ACCORD_LABEL_STYLES: Record<string, AccordLabelStyle> = {
   floral: { bg: '#fce7f3', border: '#fccee8', text: '#a3004c' },
   citrus: { bg: '#fffde5', border: '#fff085', text: '#894b00' },
@@ -18,3 +12,39 @@ export const ACCORD_LABEL_STYLES: Record<string, AccordLabelStyle> = {
   animalic: { bg: '#fef2f2', border: '#ffc9c9', text: '#ef0009' },
   woody: { bg: '#fff7ed', border: '#fed7aa', text: '#c2410c' },
 }
+
+// 향조 라벨 매핑
+const familyMap = Object.fromEntries(
+  SCENT_FAMILIES.map((f) => [f.id, f])
+) as Record<string, (typeof SCENT_FAMILIES)[number]>
+
+// 향조 라벨 타입
+export type AccordLabel = { id: string; label: string; style: AccordLabelStyle }
+
+// 향조 라벨 조회 (주어진 라벨 외 id는 base 스타일 사용)
+export const getAccordLabel = (id: string): AccordLabel => {
+  const family = familyMap[id]
+  if (family) {
+    const style =
+      ACCORD_LABEL_STYLES[family.colorClass] ?? ACCORD_LABEL_STYLES.base
+    return { id, label: family.label, style }
+  }
+  return { id, label: id, style: ACCORD_LABEL_STYLES.base }
+}
+
+// 향조 라벨 여러 개 조회
+export const getAccordLabels = (ids: string[]): AccordLabel[] =>
+  ids.map(getAccordLabel)
+
+// 향조 라벨 스타일 클래스
+export const ACCORD_LABEL_PILL_SM_CLASS =
+  'inline-block rounded-full border px-2 py-0.5 text-xs font-medium'
+
+// 향조 라벨 스타일 클래스
+export const ACCORD_LABEL_PILL_MD_CLASS =
+  'inline-block rounded-full border px-3 py-1 text-sm font-medium'
+
+// 향기 노트 스타일 클래스 (카드 한 줄 / 모달 pill)
+export const SCENT_NOTE_LINE_CLASS = 'line-clamp-1 text-xs text-neutral-500'
+export const SCENT_NOTE_PILL_CLASS =
+  'rounded-lg bg-neutral-100 px-3 py-1.5 text-sm text-neutral-700'

--- a/src/constants/accordLabelStyles.ts
+++ b/src/constants/accordLabelStyles.ts
@@ -1,3 +1,14 @@
+/**
+ * 향조 라벨 & 향기 노트 스타일
+ *
+ * [향조 라벨]
+ * - getAccordLabels(ids) 로 id 배열 → { id, label, style }[] 변환
+ * - pill: ACCORD_LABEL_PILL_SM_CLASS(카드) / ACCORD_LABEL_PILL_MD_CLASS(모달)
+ * - style.bg, style.border, style.text 를 인라인 style 로 넣어서 렌더
+ *
+ * [향기 노트]
+ * - SCENT_NOTE_LINE_CLASS, pill: SCENT_NOTE_PILL_CLASS
+ */
 import { SCENT_FAMILIES } from '@/constants/productFilters'
 
 export type AccordLabelStyle = { bg: string; border: string; text: string }
@@ -44,7 +55,8 @@ export const ACCORD_LABEL_PILL_SM_CLASS =
 export const ACCORD_LABEL_PILL_MD_CLASS =
   'inline-block rounded-full border px-3 py-1 text-sm font-medium'
 
-// 향기 노트 스타일 클래스 (카드 한 줄 / 모달 pill)
+// 기타 스타일 클래스 (카드 한 줄)
 export const SCENT_NOTE_LINE_CLASS = 'line-clamp-1 text-xs text-neutral-500'
+// 향기 노트 스타일 클래스
 export const SCENT_NOTE_PILL_CLASS =
   'rounded-lg bg-neutral-100 px-3 py-1.5 text-sm text-neutral-700'


### PR DESCRIPTION
## ✨ PR 개요
향조 라벨, 향기 노트 공통컴포넌트로 분리

## 📌 관련 이슈
Closes #67 

## 🧩 작업 내용 (주요 변경사항)
향조 라벨, 향기 노트 공통컴포넌트로 분리

## 💬 리뷰 포인트
<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항
<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->
# 향조 라벨 / 향기 노트 사용법
- `@/constants/accordLabelStyles` 에서 가져와 사용합니다.

## ✅ PR 체크리스트
- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료
