### PR TITLE
[Feat] 제품 후보군 페이지 MSW 연동 (#65)

### DIFF
--- a/src/app/admin/_components/AdminTable.tsx
+++ b/src/app/admin/_components/AdminTable.tsx
@@ -3,7 +3,10 @@
 import { cn } from '@/lib/cn'
 import { AdminTableHeader } from '@/constants/admin'
 import { formatDate, getTypeStyles } from '@/app/admin/test/_utils'
-import { TYPE_LABELS } from '@/app/admin/test/_constants/testListLabels'
+import {
+  PRODUCT_TYPE_LABELS,
+  TYPE_LABELS,
+} from '@/app/admin/test/_constants/testListLabels'
 
 interface AdminTableProps {
   headers: AdminTableHeader[]
@@ -14,7 +17,7 @@ const TABLE_GRID_LAYOUT = 'grid-cols-[1.5fr_1fr_1fr_1fr_1fr_1fr_80px]'
 
 interface AdminTableCellProps {
   slot?: number
-  children: React.ReactNode
+  children?: React.ReactNode
   className?: string
 }
 
@@ -67,7 +70,7 @@ export const AdminTypeCell = ({
         getTypeStyles(type)
       )}
     >
-      {TYPE_LABELS[type] || type}
+      {PRODUCT_TYPE_LABELS[type] || TYPE_LABELS[type] || type}
     </span>
   </AdminTableCell>
 )
@@ -76,10 +79,14 @@ export const AdminTypeCell = ({
 export const AdminStatusCell = ({
   slot,
   status,
+  trueLabel = '발행',
+  falseLabel = '미발행',
   onClick,
 }: {
   slot: number
   status: 'PUBLISHED' | 'UNPUBLISHED'
+  trueLabel?: string
+  falseLabel?: string
   onClick: () => void
 }) => {
   const isPublished = status === 'PUBLISHED'
@@ -101,7 +108,7 @@ export const AdminStatusCell = ({
             isPublished ? 'bg-status-success-text' : 'bg-status-neutral-text'
           )}
         />
-        {isPublished ? '발행' : '미 발행'}
+        {isPublished ? trueLabel : falseLabel}
       </button>
     </AdminTableCell>
   )

--- a/src/app/admin/recommend/_api/adminFetchRecommend.ts
+++ b/src/app/admin/recommend/_api/adminFetchRecommend.ts
@@ -1,11 +1,14 @@
-import { BlendMapListResponse } from '@/app/admin/recommend/_types'
+import {
+  ScentMapListResponse,
+  ProductMapListResponse,
+} from '@/app/admin/recommend/_types'
 
 export type FetchOptions = {
   page?: number
   size?: number
 }
 
-const DEFAULT_EMPTY_BLEND_MAPS_DATA: BlendMapListResponse = {
+const DEFAULT_EMPTY_SCENT_MAPS_DATA: ScentMapListResponse = {
   success: true,
   data: {
     content: [],
@@ -16,9 +19,20 @@ const DEFAULT_EMPTY_BLEND_MAPS_DATA: BlendMapListResponse = {
   },
 }
 
-export async function fetchAdminBlendMaps(
+const DEFAULT_EMPTY_PRODUCT_MAPS_DATA: ProductMapListResponse = {
+  success: true,
+  data: {
+    content: [],
+    page: 1,
+    size: 10,
+    total_elements: 0,
+    total_pages: 0,
+  },
+}
+
+export async function fetchAdminScentMaps(
   options: FetchOptions = {}
-): Promise<BlendMapListResponse> {
+): Promise<ScentMapListResponse> {
   try {
     const params = new URLSearchParams()
     if (options.page != null) params.set('page', String(options.page))
@@ -31,6 +45,25 @@ export async function fetchAdminBlendMaps(
     return res.json()
   } catch (err) {
     console.error('API 호출 실패', err)
-    return DEFAULT_EMPTY_BLEND_MAPS_DATA
+    return DEFAULT_EMPTY_SCENT_MAPS_DATA
+  }
+}
+
+export async function fetchAdminProductMaps(
+  options: FetchOptions = {}
+): Promise<ProductMapListResponse> {
+  try {
+    const params = new URLSearchParams()
+    if (options.page != null) params.set('page', String(options.page))
+    if (options.size != null) params.set('size', String(options.size))
+    const qs = params.toString()
+    const url = `/api/v1/admin/matches/product-pools${qs ? `?${qs}` : ''}`
+
+    const res = await fetch(url)
+    if (!res.ok) throw new Error(`API 호출 실패 ${res.status}`)
+    return res.json()
+  } catch (err) {
+    console.error('API 호출 실패', err)
+    return DEFAULT_EMPTY_PRODUCT_MAPS_DATA
   }
 }

--- a/src/app/admin/recommend/_hooks/useRecommendList.ts
+++ b/src/app/admin/recommend/_hooks/useRecommendList.ts
@@ -1,28 +1,41 @@
 import { useCallback, useState } from 'react'
-import { BlendMapItemResponse } from '@/app/admin/recommend/_types'
-import { fetchAdminBlendMaps } from '@/app/admin/recommend/_api'
+import {
+  ScentMapItemResponse,
+  ProductMapItemResponse,
+} from '@/app/admin/recommend/_types'
+import {
+  fetchAdminScentMaps,
+  fetchAdminProductMaps,
+} from '@/app/admin/recommend/_api'
 
 export const useRecommendList = () => {
-  const [data, setData] = useState<BlendMapItemResponse[]>([])
+  const [data, setData] = useState<
+    (ScentMapItemResponse | ProductMapItemResponse)[]
+  >([])
   const [isLoading, setIsLoading] = useState(false)
 
   const getRecommendList = useCallback(async (tabId: string) => {
+    setIsLoading(true)
     if (tabId === 'SCENT_MAP') {
-      setIsLoading(true)
-      const response = await fetchAdminBlendMaps()
+      const response = await fetchAdminScentMaps()
       if (response.success) {
         setData(response.data.content)
       }
-      setIsLoading(false)
+    } else if (tabId === 'PRODUCT_MAP') {
+      const response = await fetchAdminProductMaps()
+      if (response.success) {
+        setData(response.data.content)
+      }
     } else {
       setData([])
     }
+    setIsLoading(false)
   }, [])
 
   const handleTogglePublish = async (id: number, currentTab: string) => {
     if (!id) return
 
-    // TODO: toggle publish api 호출
+    // TODO: toggle 발행 / 미발행 or 채택 / 비채택 api 호출
     await getRecommendList(currentTab)
   }
 

--- a/src/app/admin/recommend/_page/ProductMapTab.tsx
+++ b/src/app/admin/recommend/_page/ProductMapTab.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import {
+  AdminTableRow,
+  AdminTableCell,
+  AdminDateCell,
+  AdminFirstCell,
+  AdminStatusCell,
+  AdminTypeCell,
+} from '@/app/admin/_components'
+import Button from '@/components/common/Button'
+import TrashIcon from '@/assets/icons/trash.svg'
+import { ProductMapItemResponse } from '@/app/admin/recommend/_types'
+
+interface ProductMapTabProps {
+  data: ProductMapItemResponse[]
+  onTogglePublish: (id: number) => void
+}
+
+export const ProductMapTab = ({
+  data,
+  onTogglePublish,
+}: ProductMapTabProps) => {
+  return (
+    <>
+      {data.map((row) => (
+        <AdminTableRow key={row.id}>
+          <AdminFirstCell>{row.product_count}개</AdminFirstCell>
+
+          <AdminTypeCell slot={2} type={row.product_type} />
+
+          <AdminStatusCell
+            slot={3}
+            status={
+              row.adoption_status === 'ADOPTED' ? 'PUBLISHED' : 'UNPUBLISHED'
+            }
+            trueLabel="채택"
+            falseLabel="미채택"
+            onClick={() => onTogglePublish(row.id)}
+          />
+
+          <AdminTableCell slot={4} />
+          <AdminDateCell slot={5} date={row.created_at} />
+          <AdminDateCell slot={6} date={row.updated_at} />
+          <AdminTableCell slot={7}>
+            <Button color="none" size="w32h32" rounded="sm">
+              <TrashIcon
+                width={16}
+                height={16}
+                className="hover:text-red-500"
+              />
+            </Button>
+          </AdminTableCell>
+        </AdminTableRow>
+      ))}
+    </>
+  )
+}

--- a/src/app/admin/recommend/_page/ScentMapTab.tsx
+++ b/src/app/admin/recommend/_page/ScentMapTab.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import {
+  AdminTableRow,
+  AdminTableCell,
+  AdminDateCell,
+  AdminFirstCell,
+  AdminStatusCell,
+  AdminTypeCell,
+} from '@/app/admin/_components'
+import Button from '@/components/common/Button'
+import TrashIcon from '@/assets/icons/trash.svg'
+import { ScentMapItemResponse } from '@/app/admin/recommend/_types'
+
+interface ScentMapTabProps {
+  data: ScentMapItemResponse[]
+  onTogglePublish: (id: number) => void
+}
+
+export const ScentMapTab = ({ data, onTogglePublish }: ScentMapTabProps) => {
+  return (
+    <>
+      {data.map((row) => (
+        <AdminTableRow key={row.id}>
+          <AdminFirstCell>{row.id}</AdminFirstCell>
+
+          <AdminTypeCell slot={2} type={row.input_type} />
+
+          <AdminStatusCell
+            slot={3}
+            status={row.publish_status}
+            onClick={() => onTogglePublish(row.id)}
+          />
+
+          <AdminTableCell slot={4} />
+          <AdminDateCell slot={5} date={row.created_at} />
+          <AdminDateCell slot={6} date={row.updated_at} />
+          <AdminTableCell slot={7}>
+            <Button color="none" size="w32h32" rounded="sm">
+              <TrashIcon
+                width={16}
+                height={16}
+                className="hover:text-red-500"
+              />
+            </Button>
+          </AdminTableCell>
+        </AdminTableRow>
+      ))}
+    </>
+  )
+}

--- a/src/app/admin/recommend/_page/index.ts
+++ b/src/app/admin/recommend/_page/index.ts
@@ -1,0 +1,2 @@
+export * from './ScentMapTab'
+export * from './ProductMapTab'

--- a/src/app/admin/recommend/_types/ProductMapTypes.ts
+++ b/src/app/admin/recommend/_types/ProductMapTypes.ts
@@ -1,0 +1,19 @@
+export interface ProductMapItemResponse {
+  id: number
+  product_type: 'DIFFUSER' | 'PERFUME'
+  product_count: number
+  adoption_status: 'ADOPTED' | 'UNADOPTED'
+  created_at: string
+  updated_at: string
+}
+
+export interface ProductMapListResponse {
+  success: boolean
+  data: {
+    content: ProductMapItemResponse[]
+    page: number
+    size: number
+    total_elements: number
+    total_pages: number
+  }
+}

--- a/src/app/admin/recommend/_types/ScentMapTypes.ts
+++ b/src/app/admin/recommend/_types/ScentMapTypes.ts
@@ -1,4 +1,4 @@
-export interface BlendMapItemResponse {
+export interface ScentMapItemResponse {
   id: number
   input_type: string
   publish_status: 'PUBLISHED' | 'UNPUBLISHED'
@@ -6,10 +6,10 @@ export interface BlendMapItemResponse {
   updated_at: string
 }
 
-export interface BlendMapListResponse {
+export interface ScentMapListResponse {
   success: boolean
   data: {
-    content: BlendMapItemResponse[]
+    content: ScentMapItemResponse[]
     page: number
     size: number
     total_elements: number

--- a/src/app/admin/recommend/_types/index.ts
+++ b/src/app/admin/recommend/_types/index.ts
@@ -1,1 +1,2 @@
-export * from './BlendMapTypes'
+export * from './ScentMapTypes'
+export * from './ProductMapTypes'

--- a/src/app/admin/recommend/page.tsx
+++ b/src/app/admin/recommend/page.tsx
@@ -1,48 +1,44 @@
 'use client'
 
-import React, { useEffect, useState } from 'react'
-import { cn } from '@/lib/cn'
+import { useEffect } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
 import {
   AdminListCard,
   AdminPageHeader,
   AdminTable,
-  AdminTableRow,
-  AdminTableCell,
   AdminFilterBar,
   AdminTabGroup,
-  AdminDateCell,
-  AdminFirstCell,
-  AdminStatusCell,
-  AdminTypeCell,
 } from '@/app/admin/_components'
 import { RECOMMEND_TABLE_HEADERS } from '@/constants/admin'
-import Button from '@/components/common/Button'
-import TrashIcon from '@/assets/icons/trash.svg'
 import { useRecommendList } from './_hooks'
-import { getTypeFirstTextColor } from '@/app/admin/test/_utils'
-import { TEST_TYPE_TABS } from '@/app/admin/test/create/_constants'
+import {
+  ScentMapItemResponse,
+  ProductMapItemResponse,
+} from '@/app/admin/recommend/_types'
+import { ScentMapTab, ProductMapTab } from '@/app/admin/recommend/_page'
 
 const RECOMMEND_TABS = [
   { id: 'SCENT_MAP', label: '향조합 추천맵' },
-  { id: 'PRODUCT_CANDIDATES', label: '제품 후보군' },
-  { id: 'PRODUCT_MAP', label: '제품 추천맵' },
+  { id: 'PRODUCT_MAP', label: '제품 후보군' },
+  { id: 'PRODUCT_CANDIDATES', label: '제품 추천맵' },
 ]
 
 export default function RecommendAdminPage() {
-  const [activeTab, setActiveTab] = useState('SCENT_MAP')
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const activeTab = searchParams.get('tab') || 'SCENT_MAP'
+
   const { data, handleTogglePublish, getRecommendList } = useRecommendList()
 
   const activeTabLabel =
     RECOMMEND_TABS.find((t) => t.id === activeTab)?.label || ''
 
-  // 1. 처음 페이지에 들어왔을 때만 실행 (Mount)
   useEffect(() => {
     getRecommendList(activeTab)
-  }, [getRecommendList]) // 초기 로드는 최초 1회만
-  // 2. 사용자가 탭을 클릭했을 때 실행 (Event)
+  }, [getRecommendList, activeTab])
+
   const handleTabChange = (tabId: string) => {
-    setActiveTab(tabId)
-    getRecommendList(tabId) // 클릭하는 순간 바로 데이터 요청!
+    router.push(`/admin/recommend?tab=${tabId}`, { scroll: false })
   }
 
   return (
@@ -58,35 +54,18 @@ export default function RecommendAdminPage() {
         onChange={handleTabChange}
       />
       <AdminTable headers={RECOMMEND_TABLE_HEADERS}>
-        {data.map((row) => (
-          <AdminTableRow key={row.id}>
-            <AdminFirstCell>
-              <span className={cn(getTypeFirstTextColor(row.input_type))}>
-                {TEST_TYPE_TABS.find((t) => t.id === row.input_type)?.label ||
-                  row.input_type}
-              </span>
-            </AdminFirstCell>
-
-            <AdminTypeCell slot={2} type={row.input_type} />
-
-            <AdminStatusCell
-              slot={3}
-              status={row.publish_status}
-              onClick={() => handleTogglePublish(row.id, activeTab)}
-            />
-            <AdminDateCell slot={5} date={row.created_at} />
-            <AdminDateCell slot={6} date={row.updated_at} />
-            <AdminTableCell slot={7}>
-              <Button color="none" size="w32h32" rounded="sm">
-                <TrashIcon
-                  width={16}
-                  height={16}
-                  className="hover:text-red-500"
-                />
-              </Button>
-            </AdminTableCell>
-          </AdminTableRow>
-        ))}
+        {activeTab === 'SCENT_MAP' && (
+          <ScentMapTab
+            data={data as ScentMapItemResponse[]}
+            onTogglePublish={(id: number) => handleTogglePublish(id, activeTab)}
+          />
+        )}
+        {activeTab === 'PRODUCT_MAP' && (
+          <ProductMapTab
+            data={data as ProductMapItemResponse[]}
+            onTogglePublish={(id: number) => handleTogglePublish(id, activeTab)}
+          />
+        )}
       </AdminTable>
     </AdminListCard>
   )

--- a/src/app/admin/test/_constants/testListLabels.ts
+++ b/src/app/admin/test/_constants/testListLabels.ts
@@ -5,6 +5,11 @@ export const TYPE_LABELS: Record<string, string> = {
   OOTD: 'OOTD',
 }
 
+export const PRODUCT_TYPE_LABELS: Record<string, string> = {
+  DIFFUSER: '디퓨저',
+  PERFUME: '향수',
+}
+
 export const FILTER_OPTIONS: { label: string; value: string }[] = [
   { label: '전체', value: 'all' },
   ...Object.entries(TYPE_LABELS).map(([key, value]) => ({

--- a/src/app/admin/test/_utils/adminTestStatus.ts
+++ b/src/app/admin/test/_utils/adminTestStatus.ts
@@ -20,6 +20,10 @@ export const getTypeStyles = (type: string) => {
       return 'bg-status-warning-bg text-status-warning-text'
     case 'OOTD':
       return 'bg-status-danger-bg text-status-danger-text'
+    case 'DIFFUSER':
+      return 'bg-status-info-bg text-status-info-text'
+    case 'PERFUME':
+      return 'bg-status-purple-bg text-status-purple-text'
     default:
       return 'bg-gray-100 text-gray-600'
   }
@@ -35,6 +39,10 @@ export const getTypeFirstTextColor = (type: string) => {
       return 'text-status-warning-text'
     case 'OOTD':
       return 'text-status-danger-text'
+    case 'DIFFUSER':
+      return 'text-status-info-text'
+    case 'PERFUME':
+      return 'text-status-purple-text'
     default:
       return 'text-black-secondary'
   }
@@ -50,6 +58,10 @@ export const getTypeRowBgColor = (type: string) => {
       return 'bg-status-warning-bg'
     case 'OOTD':
       return 'bg-status-danger-bg'
+    case 'DIFFUSER':
+      return 'bg-status-info-bg'
+    case 'PERFUME':
+      return 'bg-status-purple-bg'
     default:
       return 'bg-transparent'
   }

--- a/src/mocks/data/adminRecommend.ts
+++ b/src/mocks/data/adminRecommend.ts
@@ -1,4 +1,4 @@
-export const mockAdminBlendMaps = [
+export const mockAdminScentMaps = [
   {
     id: 1,
     input_type: 'PREFERENCE',
@@ -67,6 +67,89 @@ export const mockAdminBlendMaps = [
     input_type: 'HEALTH',
     publish_status: 'PUBLISHED',
     created_at: '2024-03-10T18:00:00Z',
-    updated_at: '2024-03-10T18:50:00Z',
+    updated_at: '2026-03-10T19:00:00Z',
+  },
+]
+
+export const mockAdminProductMaps = [
+  {
+    id: 1,
+    product_type: 'DIFFUSER',
+    product_count: 48,
+    adoption_status: 'ADOPTED',
+    created_at: '2026-02-15T10:00:00Z',
+    updated_at: '2026-02-20T10:00:00Z',
+  },
+  {
+    id: 2,
+    product_type: 'PERFUME',
+    product_count: 32,
+    adoption_status: 'UNADOPTED',
+    created_at: '2026-02-16T11:00:00Z',
+    updated_at: '2026-02-16T11:00:00Z',
+  },
+  {
+    id: 3,
+    product_type: 'DIFFUSER',
+    product_count: 15,
+    adoption_status: 'ADOPTED',
+    created_at: '2026-02-17T09:00:00Z',
+    updated_at: '2026-02-18T14:30:00Z',
+  },
+  {
+    id: 4,
+    product_type: 'PERFUME',
+    product_count: 120,
+    adoption_status: 'UNADOPTED',
+    created_at: '2026-02-18T15:00:00Z',
+    updated_at: '2026-02-18T15:00:00Z',
+  },
+  {
+    id: 5,
+    product_type: 'DIFFUSER',
+    product_count: 55,
+    adoption_status: 'ADOPTED',
+    created_at: '2026-02-19T10:00:00Z',
+    updated_at: '2026-02-20T11:00:00Z',
+  },
+  {
+    id: 6,
+    product_type: 'PERFUME',
+    product_count: 12,
+    adoption_status: 'ADOPTED',
+    created_at: '2026-02-20T12:00:00Z',
+    updated_at: '2026-02-21T09:00:00Z',
+  },
+  {
+    id: 7,
+    product_type: 'DIFFUSER',
+    product_count: 88,
+    adoption_status: 'UNADOPTED',
+    created_at: '2026-02-21T14:00:00Z',
+    updated_at: '2026-02-21T14:00:00Z',
+  },
+  {
+    id: 8,
+    product_type: 'PERFUME',
+    product_count: 45,
+    adoption_status: 'ADOPTED',
+    created_at: '2026-02-22T16:00:00Z',
+    updated_at: '2026-02-23T10:00:00Z',
+  },
+  {
+    id: 9,
+    product_type: 'DIFFUSER',
+    product_count: 27,
+    adoption_status: 'ADOPTED',
+    created_at: '2026-02-23T08:00:00Z',
+    updated_at: '2026-02-24T12:00:00Z',
+  },
+  {
+    id: 10,
+    product_type: 'PERFUME',
+    product_count: 67,
+    adoption_status: 'UNADOPTED',
+    created_at: '2026-02-24T09:00:00Z',
+    updated_at: '2026-02-24T09:00:00Z',
   },
 ]

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -4,7 +4,10 @@ import { mockCombinationsItems, mockCombinationsPageMeta } from './data/combo'
 import { mockElementDetails } from './data/singlesDetails'
 import { mockBlendDetails } from './data/comboDetails'
 import { adminTestsHandler } from './handlers/adminTestHandlers'
-import { adminRecommendHandlers } from './handlers/adminRecommendHandlers'
+import {
+  adminScentMapHandlers,
+  adminProductMapHandlers,
+} from './handlers/adminRecommendHandlers'
 
 /**
  * 단품 목록 조회 GET /api/v1/scents/singles
@@ -106,5 +109,6 @@ export const handlers = [
   elementDetailHandler,
   blendDetailHandler,
   adminTestsHandler,
-  adminRecommendHandlers,
+  adminScentMapHandlers,
+  adminProductMapHandlers,
 ]

--- a/src/mocks/handlers/adminRecommendHandlers.ts
+++ b/src/mocks/handlers/adminRecommendHandlers.ts
@@ -1,7 +1,10 @@
 import { http, HttpResponse } from 'msw'
-import { mockAdminBlendMaps } from '../data/adminRecommend'
+import {
+  mockAdminScentMaps,
+  mockAdminProductMaps,
+} from '@/mocks/data/adminRecommend'
 
-export const adminRecommendHandlers = http.get(
+export const adminScentMapHandlers = http.get(
   '/api/v1/admin/matches/blend-maps',
   ({ request }) => {
     const url = new URL(request.url)
@@ -9,8 +12,33 @@ export const adminRecommendHandlers = http.get(
     const size = Number(url.searchParams.get('size') ?? 10)
 
     const start = (page - 1) * size
-    const content = mockAdminBlendMaps.slice(start, start + size)
-    const total_elements = mockAdminBlendMaps.length
+    const content = mockAdminScentMaps.slice(start, start + size)
+    const total_elements = mockAdminScentMaps.length
+    const total_pages = Math.ceil(total_elements / size) || 1
+
+    return HttpResponse.json({
+      success: true,
+      data: {
+        content: content.map((item) => ({ ...item })),
+        page,
+        size,
+        total_elements,
+        total_pages,
+      },
+    })
+  }
+)
+
+export const adminProductMapHandlers = http.get(
+  '/api/v1/admin/matches/product-pools',
+  ({ request }) => {
+    const url = new URL(request.url)
+    const page = Number(url.searchParams.get('page') ?? 1)
+    const size = Number(url.searchParams.get('size') ?? 10)
+
+    const start = (page - 1) * size
+    const content = mockAdminProductMaps.slice(start, start + size)
+    const total_elements = mockAdminProductMaps.length
     const total_pages = Math.ceil(total_elements / size) || 1
 
     return HttpResponse.json({


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->
제품 후보군에 사용될 MOCK을 명세서 타입에 맞게 정의해 미리 만들어 놓아 출력 할 수 있도록 추가
제품 후보군에서 새로운 후보군을 등록 시 명세서 타입에 맞게 입력을 받게 하여 등록할 수 있도록 추가

## 📌 관련 이슈

<!-- Closes #이슈번호 -->

Closes #65 

## 🧩 작업 내용 (주요 변경사항)

- Scent_MAP , PRODUCT_MAP , PRODUCT_CANDIDATES 에 맞추기 위해 미리 파일을 분리하여 관리 하도록 했습니다.
- 제품 추천맵 목록 조회에 사용될 handler를 type에 맞게 받아오게 하고 이 type에 맞는 MOCK을 생성
- TAB 메뉴의 id에 따라 추천관리 페이지를 관리

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->
<img width="1670" height="833" alt="image" src="https://github.com/user-attachments/assets/83896b98-44c9-439b-8f9d-9f0becd32efb" />


## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->
MOCK 데이터 추가했슴다

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 로컬에서 실행 확인 완료
