### PR TITLE
[Feat] 추천 관리 페이지 생성 로직 추가 (#78)

### DIFF
--- a/src/app/admin/_components/AdminSelect.tsx
+++ b/src/app/admin/_components/AdminSelect.tsx
@@ -6,7 +6,7 @@ import Button from '@/components/common/Button'
 import { useOutsideClick } from '@/hooks/useOutsideClick'
 
 interface AdminSelectProps {
-  options: { label: string; value: string }[]
+  options: { label: string; value: string; secondaryLabel?: string }[]
   value?: string
   onChange?: (value: string) => void
   className?: string
@@ -45,12 +45,12 @@ export const AdminSelect = ({
         type="button"
         onClick={toggle}
         className={cn(
-          'border-gray-light text-black-primary flex h-12 cursor-pointer items-center justify-between rounded-xl border-2 bg-white px-4 font-medium transition-all',
+          'border-gray-light text-black-primary flex h-12 cursor-pointer items-center justify-between rounded-xl border-2 bg-white px-4 font-medium transition-all active:scale-100',
           width,
-          isOpen && 'border-violet-300'
+          isOpen && 'border-black-primary'
         )}
       >
-        <span>{selectedOption?.label}</span>
+        <span className="truncate">{selectedOption?.label}</span>
         <svg
           width="16"
           height="16"
@@ -61,7 +61,7 @@ export const AdminSelect = ({
           strokeLinecap="round"
           strokeLinejoin="round"
           className={cn(
-            'transition-transform duration-200',
+            'ml-2 shrink-0 transition-transform duration-200',
             isOpen && 'rotate-180'
           )}
         >
@@ -72,7 +72,7 @@ export const AdminSelect = ({
       {isOpen && (
         <ul
           className={cn(
-            'absolute mt-1 cursor-pointer overflow-hidden rounded-md border border-neutral-200 bg-white',
+            'absolute z-10 mt-1 max-h-60 cursor-pointer overflow-y-auto rounded-md border border-neutral-200 bg-white shadow-lg',
             width
           )}
           role="listbox"
@@ -84,12 +84,17 @@ export const AdminSelect = ({
                 role="option"
                 aria-selected={opt.value === value}
                 className={cn(
-                  'hover:bg-gray-light hover:text-black-primary w-full cursor-pointer px-4 py-3 text-left text-sm transition-colors',
+                  'hover:bg-gray-light hover:text-black-primary flex w-full cursor-pointer items-center justify-between px-4 py-3 text-left text-sm transition-colors',
                   opt.value === value ? 'bg-gray-light font-bold' : ''
                 )}
                 onClick={() => handleSelect(opt.value)}
               >
-                {opt.label}
+                <span>{opt.label}</span>
+                {opt.secondaryLabel && (
+                  <span className="ml-2 text-[12px] font-normal text-gray-400">
+                    {opt.secondaryLabel}
+                  </span>
+                )}
               </button>
             </li>
           ))}

--- a/src/app/admin/_components/Slider.tsx
+++ b/src/app/admin/_components/Slider.tsx
@@ -1,0 +1,116 @@
+'use client'
+
+import React from 'react'
+import { cn } from '@/lib/cn'
+import Input from '@/components/common/Input'
+
+interface SliderProps {
+  label?: string
+  min: number
+  max: number
+  step?: number
+  value: number
+  onChange: (value: number) => void
+  helperText?: string
+  className?: string
+}
+
+const Slider = ({
+  label,
+  min,
+  max,
+  step = 1,
+  value,
+  onChange,
+  helperText,
+  className,
+}: SliderProps) => {
+  // 범위를 벗어나지 않는 값 계산
+  const clampedValue = Math.min(Math.max(value, min), max)
+
+  const percentage = ((clampedValue - min) / (max - min)) * 100
+
+  // 핸들러: 숫자 인풋 입력 시
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const val = Number(e.target.value)
+    // max만 즉시 제한 하기
+    if (val <= max) {
+      // 소숫점 들어오면 반올림
+      const steppedValue = Math.round(val / step) * step
+      onChange(steppedValue)
+    }
+  }
+
+  const handleInputBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+    const val = Number(e.target.value)
+    // 이미 max 제한 했으니 값이 범위 안에 있으면 두고 min보다 작으면 보장 및 빈 값 체크
+    if (val < min || isNaN(val)) onChange(min)
+  }
+
+  // 핸들러: 슬라이더 바 조작 시
+  const handleSliderChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onChange(Number(e.target.value))
+  }
+
+  return (
+    <div
+      className={cn('flex w-full flex-col gap-2', className)}
+      style={{ '--progress': `${percentage}%` } as React.CSSProperties}
+    >
+      <div className="flex items-center justify-between">
+        {label && <label className="px-1 font-bold">{label}</label>}
+        <Input
+          type="number"
+          min={min}
+          max={max}
+          step={step}
+          value={value}
+          onChange={handleInputChange}
+          onBlur={handleInputBlur}
+          className="[&]:bg-gray-light h-8 w-20 px-2 py-0.5 text-right font-bold [&]:border-none [&::-webkit-inner-spin-button]:appearance-none"
+          wrapperClassName="w-auto"
+        />
+      </div>
+
+      {/* 눈에 보일 슬라이더 */}
+      <div className="group relative flex h-6 items-center">
+        <div className="absolute h-2 w-full overflow-hidden rounded-full bg-gray-200">
+          <div
+            className="bg-black-primary h-full origin-left transition-transform duration-150 ease-out"
+            style={{ transform: 'scaleX(calc(var(--progress)))' }}
+          />
+        </div>
+
+        <input
+          type="range"
+          min={min}
+          max={max}
+          step={step}
+          value={clampedValue}
+          onChange={handleSliderChange}
+          className="absolute z-10 h-full w-full cursor-pointer opacity-0"
+        />
+
+        {/* 포인터 */}
+        <div
+          className="border-black-primary pointer-events-none absolute h-4 w-4 rounded-full border-2 bg-white transition-transform duration-150 ease-out group-hover:scale-110"
+          style={{
+            left: 'var(--progress)',
+            transform: 'translateX(-50%)',
+          }}
+        />
+      </div>
+
+      <div className="flex justify-between px-1">
+        <span className="text-[10px] font-medium text-gray-500">{min}</span>
+        <span className="text-[10px] font-medium text-gray-500">{max}</span>
+      </div>
+
+      {helperText && (
+        <span className="px-1 text-xs text-gray-400 italic">{helperText}</span>
+      )}
+    </div>
+  )
+}
+
+export default Slider

--- a/src/app/admin/recommend/_api/adminFetchRecommend.ts
+++ b/src/app/admin/recommend/_api/adminFetchRecommend.ts
@@ -8,6 +8,7 @@ import {
 export type FetchOptions = {
   page?: number
   size?: number
+  adoption_status?: string
 }
 
 const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000'
@@ -26,6 +27,8 @@ async function fetchAdminRecommendData<T>(
   const params = new URLSearchParams()
   if (options.page != null) params.set('page', String(options.page))
   if (options.size != null) params.set('size', String(options.size))
+  if (options.adoption_status != null)
+    params.set('adoption_status', options.adoption_status)
   const qs = params.toString()
   const url = `${BASE_URL}/api/v1/admin/matches/${endpoint}${qs ? `?${qs}` : ''}`
 

--- a/src/app/admin/recommend/_page/BlendMapsForm.tsx
+++ b/src/app/admin/recommend/_page/BlendMapsForm.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import React from 'react'
+import { AdminSelect } from '@/app/admin/_components'
+
+import { BlendMapsFormProps } from '@/app/admin/recommend/_types'
+
+export const BlendMapsForm = ({ value, onChange }: BlendMapsFormProps) => {
+  return (
+    <div className="flex flex-col gap-2 py-5">
+      <label className="text-lg font-bold">테스트 유형</label>
+      <AdminSelect
+        value={value}
+        onChange={onChange}
+        width="w-full"
+        options={[
+          // 유형 고정값
+          { label: '취향', value: 'PREFERENCE' },
+          { label: '건강', value: 'HEALTH' },
+          { label: 'OOTD', value: 'OOTD' },
+          { label: '인테리어', value: 'INTERIOR' },
+        ]}
+      />
+      <span className="text-sm text-gray-500">
+        선택한 테스트의 모든 가능한 조합을 계산하여 추천 맵이 생성됩니다.
+      </span>
+    </div>
+  )
+}

--- a/src/app/admin/recommend/_page/ProductMapsForm.tsx
+++ b/src/app/admin/recommend/_page/ProductMapsForm.tsx
@@ -1,0 +1,45 @@
+import React, { use } from 'react'
+import { AdminSelect } from '@/app/admin/_components'
+import { ProductMapsFormProps } from '@/app/admin/recommend/_types'
+import { PRODUCT_TYPE_LABELS } from '@/app/admin/test/_constants/testListLabels'
+import { formatDate } from '@/app/admin/test/_utils'
+
+export const ProductMapsForm = ({
+  value,
+  onChange,
+  poolsPromise,
+}: ProductMapsFormProps) => {
+  const res = use(poolsPromise)
+  const pools = res.data.content
+
+  const options = pools.map((p) => ({
+    label: `${p.id} - ${PRODUCT_TYPE_LABELS[p.product_type]} [${p.product_count}개]`,
+    secondaryLabel: formatDate(p.updated_at),
+    value: String(p.id),
+  }))
+
+  return (
+    <div className="flex flex-col gap-4 py-6">
+      <div className="flex flex-col gap-2">
+        <label className="text-lg font-bold">대상 후보군 선택</label>
+        {pools.length > 0 ? (
+          <AdminSelect
+            value={String(value)}
+            onChange={(val: string) => onChange(Number(val))}
+            width="w-full"
+            options={options}
+          />
+        ) : (
+          <div className="bg-gray-light/30 rounded-xl py-8 text-center text-gray-400">
+            채택 완료된 후보군이 없습니다. 제품 후보군 탭에서 채택을 먼저 진행해
+            주세요.
+          </div>
+        )}
+        <p className="text-sm text-gray-500">
+          채택 완료된 후보군을 선택하면, 해당 후보군 내의 제품들로 추천 맵을
+          생성합니다.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/app/admin/recommend/_page/ProductPoolsForm.tsx
+++ b/src/app/admin/recommend/_page/ProductPoolsForm.tsx
@@ -1,0 +1,107 @@
+'use client'
+
+import React from 'react'
+import { AdminSelect } from '@/app/admin/_components'
+import Slider from '@/app/admin/_components/Slider'
+
+import { ProductPoolsFormProps } from '@/app/admin/recommend/_types'
+
+export const ProductPoolsForm = ({
+  formData,
+  onFieldChange,
+  onConfigChange,
+}: ProductPoolsFormProps) => {
+  return (
+    <div className="flex flex-col gap-6 py-4">
+      <div className="grid grid-cols-2 gap-4">
+        <div className="flex flex-col gap-2">
+          <label className="font-bold">크롤링 소스</label>
+          <AdminSelect
+            value={formData.crawl_source}
+            onChange={(val) => onFieldChange('crawl_source', val)}
+            width="w-full"
+            options={[
+              { label: '네이버 스토어', value: 'NAVER_STORE' },
+              { label: '카카오 페이지', value: 'KAKAO_PAGE' },
+            ]}
+          />
+        </div>
+        <div className="flex flex-col gap-2">
+          <label className="font-bold">제품 유형</label>
+          <AdminSelect
+            value={formData.product_type}
+            onChange={(val) => onFieldChange('product_type', val)}
+            width="w-full"
+            options={[
+              { label: '디퓨저', value: 'DIFFUSER' },
+              { label: '향수', value: 'PERFUME' },
+            ]}
+          />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 items-start gap-6">
+        <Slider
+          label="수집 개수"
+          min={10}
+          max={100}
+          step={1}
+          value={formData.crawl_count}
+          onChange={(val) => onFieldChange('crawl_count', val)}
+        />
+        <div className="flex flex-col gap-2">
+          <label className="font-bold">정렬 기준</label>
+          <AdminSelect
+            value={formData.crawl_sort}
+            onChange={(val) => onFieldChange('crawl_sort', val)}
+            width="w-full"
+            options={[
+              { label: '리뷰 평점순', value: 'REVIEW_RATING' },
+              { label: '리뷰 개수순', value: 'REVIEW_COUNT' },
+              { label: '판매량순', value: 'SALES_VOLUME' },
+              { label: '낮은 가격순', value: 'PRICE_ASC' },
+            ]}
+          />
+        </div>
+      </div>
+
+      <div className="mt-2 flex flex-col gap-4 rounded-xl">
+        <h3 className="text-lg font-bold">상세 필터 설정</h3>
+        <div className="grid grid-cols-2 gap-x-4 gap-y-6">
+          <Slider
+            label="최소 가격"
+            min={10000}
+            max={100000}
+            step={5000}
+            value={formData.crawl_config.min_price}
+            onChange={(val) => onConfigChange('min_price', val)}
+          />
+          <Slider
+            label="최대 가격"
+            min={100000}
+            max={200000}
+            step={5000}
+            value={formData.crawl_config.max_price}
+            onChange={(val) => onConfigChange('max_price', val)}
+          />
+          <Slider
+            label="최소 평점"
+            min={0}
+            max={5}
+            step={0.5}
+            value={formData.crawl_config.min_rating}
+            onChange={(val) => onConfigChange('min_rating', val)}
+          />
+          <Slider
+            label="최소 리뷰수"
+            min={0}
+            max={100}
+            step={5}
+            value={formData.crawl_config.min_review_count}
+            onChange={(val) => onConfigChange('min_review_count', val)}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/admin/recommend/_page/RecommendAdminContent.tsx
+++ b/src/app/admin/recommend/_page/RecommendAdminContent.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import {
   AdminListCard,
@@ -19,6 +20,7 @@ import {
   BlendMapsTab,
   ProductPoolsTab,
   ProductMapsTab,
+  RecommendPostModal,
 } from '@/app/admin/recommend/_page'
 
 const TAB_COMPONENTS: Record<
@@ -40,6 +42,7 @@ export default function RecommendAdminContent({
   activeTab,
 }: RecommendAdminContentProps) {
   const router = useRouter()
+  const [isPostModalOpen, setIsPostModalOpen] = useState(false)
 
   const activeTabLabel =
     RECOMMEND_TABS.find((t) => t.id === activeTab)?.label || ''
@@ -59,25 +62,37 @@ export default function RecommendAdminContent({
   const ActiveTabContent = TAB_COMPONENTS[activeTab]
 
   return (
-    <AdminListCard>
-      <AdminPageHeader title={`${activeTabLabel} 목록`} buttonText={'등록'} />
-      <AdminFilterBar
-        searchPlaceholder="검색"
-        filterOptions={[{ label: '전체', value: 'all' }]}
-      />
-      <AdminTabGroup
-        tabs={RECOMMEND_TABS}
+    <>
+      <AdminListCard>
+        <AdminPageHeader
+          title={`${activeTabLabel} 목록`}
+          buttonText={'등록'}
+          onButtonClick={() => setIsPostModalOpen(true)}
+        />
+        <AdminFilterBar
+          searchPlaceholder="검색"
+          filterOptions={[{ label: '전체', value: 'all' }]}
+        />
+        <AdminTabGroup
+          tabs={RECOMMEND_TABS}
+          activeTab={activeTab}
+          onChange={handleTabChange}
+        />
+        <AdminTable headers={RECOMMEND_TAB_HEADERS[activeTab]}>
+          {ActiveTabContent && (
+            <ActiveTabContent
+              data={recommendData}
+              onTogglePublish={handleTogglePublish}
+            />
+          )}
+        </AdminTable>
+      </AdminListCard>
+
+      <RecommendPostModal
+        isOpen={isPostModalOpen}
+        onClose={() => setIsPostModalOpen(false)}
         activeTab={activeTab}
-        onChange={handleTabChange}
       />
-      <AdminTable headers={RECOMMEND_TAB_HEADERS[activeTab]}>
-        {ActiveTabContent && (
-          <ActiveTabContent
-            data={recommendData}
-            onTogglePublish={handleTogglePublish}
-          />
-        )}
-      </AdminTable>
-    </AdminListCard>
+    </>
   )
 }

--- a/src/app/admin/recommend/_page/RecommendPostModal.tsx
+++ b/src/app/admin/recommend/_page/RecommendPostModal.tsx
@@ -1,0 +1,146 @@
+import React, { useState, Suspense, useMemo } from 'react'
+import Modal from '@/components/common/Modal'
+import Button from '@/components/common/Button'
+import { RecommendTabId, RECOMMEND_TABS } from '@/app/admin/recommend/_types'
+import { RECOMMEND_API } from '@/app/admin/recommend/_api'
+import { BlendMapsForm } from './BlendMapsForm'
+import { ProductPoolsForm } from './ProductPoolsForm'
+import { ProductMapsForm } from './ProductMapsForm'
+
+interface RecommendPostModalProps {
+  isOpen: boolean
+  onClose: () => void
+  activeTab: RecommendTabId
+}
+
+// 제품 추천맵 폼 로딩 폴백 임시
+const ProductMapsFormFallback = () => (
+  <div className="flex w-full items-center justify-center py-20 font-bold text-gray-400">
+    후보군 불러오는 중...
+  </div>
+)
+
+export const RecommendPostModal = ({
+  isOpen,
+  onClose,
+  activeTab,
+}: RecommendPostModalProps) => {
+  const activeTabLabel =
+    RECOMMEND_TABS.find((t) => t.id === activeTab)?.label || ''
+
+  // 각 탭별 폼 default 값 설정
+  const [formData, setFormData] = useState({
+    // 1. 향조합 (Blend Maps)
+    inputType: 'PREFERENCE',
+
+    // 2. 제품 후보군 (Product Pools)
+    crawl_source: 'NAVER_STORE',
+    crawl_count: 50,
+    crawl_sort: 'REVIEW_RATING',
+    product_type: 'DIFFUSER',
+    crawl_config: {
+      min_price: 10000,
+      max_price: 100000,
+      min_rating: 4.0,
+      min_review_count: 10,
+    },
+
+    // 3. 제품 추천맵 (Product Maps)
+    product_pool_id: 1,
+  })
+
+  const poolsPromise = useMemo(() => {
+    if (!isOpen || activeTab !== 'product-maps') return null
+    return RECOMMEND_API.productPools({
+      size: 20,
+      adoption_status: 'ADOPTED',
+    })
+  }, [isOpen, activeTab])
+
+  // 일반 필드 업데이트
+  const handleChange = (key: string, value: any) => {
+    setFormData((prev) => ({ ...prev, [key]: value }))
+  }
+
+  // 후보군 설정 업데이트
+  const handleConfigChange = (key: string, value: any) => {
+    setFormData((prev) => ({
+      ...prev,
+      crawl_config: { ...prev.crawl_config, [key]: value },
+    }))
+  }
+
+  const handleRegister = () => {
+    // 탭별 전송 데이터 가공
+    let submitData: any = {}
+    if (activeTab === 'blend-maps') {
+      submitData = { input_type: formData.inputType }
+    } else if (activeTab === 'product-pools') {
+      submitData = {
+        crawl_source: formData.crawl_source,
+        crawl_count: formData.crawl_count,
+        crawl_sort: formData.crawl_sort,
+        product_type: formData.product_type,
+        crawl_config: formData.crawl_config,
+      }
+    } else if (activeTab === 'product-maps') {
+      submitData = { product_pool_id: formData.product_pool_id }
+    }
+
+    console.log(`[${activeTab}] 등록 데이터 TEST : `, submitData)
+    onClose()
+  }
+
+  const renderContent = () => {
+    switch (activeTab) {
+      case 'blend-maps':
+        return (
+          <BlendMapsForm
+            value={formData.inputType}
+            onChange={(val) => handleChange('inputType', val)}
+          />
+        )
+      case 'product-pools':
+        return (
+          <ProductPoolsForm
+            formData={formData}
+            onFieldChange={handleChange}
+            onConfigChange={handleConfigChange}
+          />
+        )
+      case 'product-maps':
+        return (
+          <Suspense fallback={<ProductMapsFormFallback />}>
+            {poolsPromise && (
+              <ProductMapsForm
+                value={formData.product_pool_id}
+                onChange={(val) => handleChange('product_pool_id', Number(val))}
+                poolsPromise={poolsPromise}
+              />
+            )}
+          </Suspense>
+        )
+      default:
+        return null
+    }
+  }
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} size="md">
+      <Modal.Header>{activeTabLabel} 등록</Modal.Header>
+      <Modal.Content>{renderContent()}</Modal.Content>
+      <Modal.Footer className="flex justify-end gap-2 text-[16px]">
+        <Button
+          color="none"
+          className="border-gray-light border"
+          onClick={onClose}
+        >
+          취소
+        </Button>
+        <Button color="primary" onClick={handleRegister}>
+          등록
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  )
+}

--- a/src/app/admin/recommend/_page/index.ts
+++ b/src/app/admin/recommend/_page/index.ts
@@ -1,3 +1,4 @@
 export * from './BlendMapsTab'
 export * from './ProductPoolsTab'
 export * from './ProductMapsTab'
+export * from './RecommendPostModal'

--- a/src/app/admin/recommend/_types/BlendMapsTypes.ts
+++ b/src/app/admin/recommend/_types/BlendMapsTypes.ts
@@ -9,3 +9,8 @@ export interface BlendMapsItemResponse {
 }
 
 export type BlendMapsListResponse = RecommendApiResponse<BlendMapsItemResponse>
+
+export interface BlendMapsFormProps {
+  value: string
+  onChange: (val: string) => void
+}

--- a/src/app/admin/recommend/_types/ProductMapsTypes.ts
+++ b/src/app/admin/recommend/_types/ProductMapsTypes.ts
@@ -1,4 +1,5 @@
 import { RecommendApiResponse } from './RecommendData'
+import { ProductPoolsListResponse } from './ProductPoolsTypes'
 
 export interface ProductMapsItemResponse {
   id: number
@@ -10,3 +11,9 @@ export interface ProductMapsItemResponse {
 
 export type ProductMapsListResponse =
   RecommendApiResponse<ProductMapsItemResponse>
+
+export interface ProductMapsFormProps {
+  value: number
+  onChange: (val: number) => void
+  poolsPromise: Promise<ProductPoolsListResponse>
+}

--- a/src/app/admin/recommend/_types/ProductPoolsTypes.ts
+++ b/src/app/admin/recommend/_types/ProductPoolsTypes.ts
@@ -11,3 +11,20 @@ export interface ProductPoolsItemResponse {
 
 export type ProductPoolsListResponse =
   RecommendApiResponse<ProductPoolsItemResponse>
+
+export interface ProductPoolsFormProps {
+  formData: {
+    crawl_source: string
+    crawl_count: number
+    crawl_sort: string
+    product_type: string
+    crawl_config: {
+      min_price: number
+      max_price: number
+      min_rating: number
+      min_review_count: number
+    }
+  }
+  onFieldChange: (key: string, value: any) => void
+  onConfigChange: (key: string, value: any) => void
+}

--- a/src/components/common/Modal/Modal.variants.ts
+++ b/src/components/common/Modal/Modal.variants.ts
@@ -1,38 +1,35 @@
 import { cva } from 'class-variance-authority'
 
-export const modalVariants = cva(
-  'relative w-full bg-white flex flex-col overflow-hidden',
-  {
-    variants: {
-      type: {
-        center: 'm-4',
-        bottomSheet: 'mt-auto rounded-t-[32px] rounded-b-none',
-      },
-      size: {
-        xs: 'max-w-[320px]',
-        sm: 'max-w-[400px]',
-        md: 'max-w-[448px]',
-        ml: 'max-w-[512px]',
-        lg: 'max-w-[672px]',
-        full: 'max-w-full h-full rounded-none',
-      },
-      rounded: {
-        none: 'rounded-none',
-        sm: 'rounded-[16px]',
-        md: 'rounded-[24px]',
-        lg: 'rounded-[32px]',
-      },
+export const modalVariants = cva('relative w-full bg-white flex flex-col', {
+  variants: {
+    type: {
+      center: 'm-4',
+      bottomSheet: 'mt-auto rounded-t-[32px] rounded-b-none',
     },
-    compoundVariants: [
-      {
-        type: 'bottomSheet',
-        className: 'max-w-full',
-      },
-    ],
-    defaultVariants: {
-      type: 'center',
-      size: 'md',
-      rounded: 'md',
+    size: {
+      xs: 'max-w-[320px]',
+      sm: 'max-w-[400px]',
+      md: 'max-w-[448px]',
+      ml: 'max-w-[512px]',
+      lg: 'max-w-[672px]',
+      full: 'max-w-full h-full rounded-none',
     },
-  }
-)
+    rounded: {
+      none: 'rounded-none',
+      sm: 'rounded-[16px]',
+      md: 'rounded-[24px]',
+      lg: 'rounded-[32px]',
+    },
+  },
+  compoundVariants: [
+    {
+      type: 'bottomSheet',
+      className: 'max-w-full',
+    },
+  ],
+  defaultVariants: {
+    type: 'center',
+    size: 'md',
+    rounded: 'md',
+  },
+})

--- a/src/mocks/handlers/adminRecommendHandlers.ts
+++ b/src/mocks/handlers/adminRecommendHandlers.ts
@@ -38,10 +38,19 @@ export const adminProductPoolsHandlers = http.get(
     const url = new URL(request.url)
     const page = Number(url.searchParams.get('page') ?? 1)
     const size = Number(url.searchParams.get('size') ?? 10)
+    const adoptionStatus = url.searchParams.get('adoption_status')
+
+    // 상태 필터링 적용
+    let filteredData = mockAdminProductPools
+    if (adoptionStatus) {
+      filteredData = mockAdminProductPools.filter(
+        (item) => item.adoption_status === adoptionStatus
+      )
+    }
 
     const start = (page - 1) * size
-    const content = mockAdminProductPools.slice(start, start + size)
-    const total_elements = mockAdminProductPools.length
+    const content = filteredData.slice(start, start + size)
+    const total_elements = filteredData.length
     const total_pages = Math.ceil(total_elements / size) || 1
 
     return HttpResponse.json({


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->
각 MAPS 와 POOLS에 대해 정해진 입력 값을 받게 하여 새롭게 생성할 수 있는 Modal을 추가

## 📌 관련 이슈

<!-- Closes #이슈번호 -->

Closes #78 

## 🧩 작업 내용 (주요 변경사항)

- BlendMaps, ProductPools, ProductMaps 등록 시 입력 받아야할 타입을 추가
- PostModal을 추가하여 등록 버튼을 activeTab 별로 받아와 종류에 맞는 입력폼 출력
- 제품 추천맵 등록 모달에서는 현재 PUBLISED된 제품 후보군 목록을 확인해야하기 때문에 추가 + Progress Bar 형식으로 입력을 받을 수 있는 Slider 컴포넌트 추가

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

https://github.com/user-attachments/assets/05181b91-79eb-4d6d-8c6b-7232c847dc09


## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->
다음 작업으로는 커스텀 공통 Fetch 함수를 생성할 예정이라 현재 API 호출 관련 코드에 변경사항이 생길 예정입니다. 


## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 로컬에서 실행 확인 완료
