### PR TITLE
[Feat] Custom Fetch 함수 생성 (#81)

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { AdminSidebar } from '@/app/admin/_components/AdminSidebar'
 
 export default function AdminLayout({

--- a/src/app/admin/recommend/_actions/recommendActions.ts
+++ b/src/app/admin/recommend/_actions/recommendActions.ts
@@ -1,0 +1,8 @@
+'use server'
+
+import { updateTag } from 'next/cache'
+
+// 추천 시스템 관리자 페이지의 캐시를 강제로 무효화하는 액션
+export async function updateRecommendList({ tabId }: { tabId: string }) {
+  updateTag(tabId)
+}

--- a/src/app/admin/recommend/_api/adminFetchRecommend.ts
+++ b/src/app/admin/recommend/_api/adminFetchRecommend.ts
@@ -4,69 +4,32 @@ import {
   ProductPoolsListResponse,
   RecommendTabId,
 } from '@/app/admin/recommend/_types'
+import { authFetch } from '@/lib/api'
 
+// 탭별 쿼리 파라미터 옵션
 export type FetchOptions = {
   page?: number
   size?: number
   adoption_status?: string
 }
 
-const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000'
-
+// 탭별 응답 타입 매핑
 interface RecommendResponseMap {
   'blend-maps': BlendMapsListResponse
   'product-pools': ProductPoolsListResponse
   'product-maps': ProductMapsListResponse
 }
 
-// 추천 관리 받아오기
-async function fetchAdminRecommendData<T>(
-  endpoint: string,
-  options: FetchOptions = {}
-): Promise<T> {
-  const params = new URLSearchParams()
-  if (options.page != null) params.set('page', String(options.page))
-  if (options.size != null) params.set('size', String(options.size))
-  if (options.adoption_status != null)
-    params.set('adoption_status', options.adoption_status)
-  const qs = params.toString()
-  const url = `${BASE_URL}/api/v1/admin/matches/${endpoint}${qs ? `?${qs}` : ''}`
-
-  const res = await fetch(url)
-  if (!res.ok) throw new Error(`실패: ${res.status}`)
-  return res.json()
-}
-
-// 빈 값
-const createEmptyData = <T extends RecommendTabId>(
-  _tabId: T
-): RecommendResponseMap[T] =>
-  ({
-    success: true,
-    data: {
-      content: [],
-      page: 1,
-      size: 10,
-      total_elements: 0,
-      total_pages: 0,
-    },
-  }) as RecommendResponseMap[T]
-
 // 탭 ID를 넣으면 매핑된 타입을 자동으로 추론하여 반환
-export const fetchAdminRecommendList = async <T extends RecommendTabId>(
+export const fetchAdminRecommendList = <T extends RecommendTabId>(
   tabId: T,
   options?: FetchOptions
-): Promise<RecommendResponseMap[T]> => {
-  try {
-    return await fetchAdminRecommendData<RecommendResponseMap[T]>(
-      tabId,
-      options
-    )
-  } catch (err) {
-    console.error(`${tabId}에서 API 에러`, err)
-    return createEmptyData(tabId)
-  }
-}
+): Promise<RecommendResponseMap[T]> =>
+  authFetch.get<RecommendResponseMap[T]>(`/api/v1/admin/matches/${tabId}`, {
+    params: options,
+    cache: 'force-cache',
+    next: { tags: [`${tabId}`] },
+  })
 
 // 탭별 API 함수 모음
 export const RECOMMEND_API = {

--- a/src/app/admin/recommend/_page/RecommendAdminContent.tsx
+++ b/src/app/admin/recommend/_page/RecommendAdminContent.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, use, Suspense } from 'react'
 import { useRouter } from 'next/navigation'
 import {
   AdminListCard,
@@ -12,9 +12,10 @@ import {
 import { RECOMMEND_TAB_HEADERS } from '@/constants/admin'
 import {
   RecommendTabId,
-  RecommendListItem,
   RecommendTabProps,
   RECOMMEND_TABS,
+  RecommendListItem,
+  RecommendApiResponse,
 } from '@/app/admin/recommend/_types'
 import {
   BlendMapsTab,
@@ -22,6 +23,8 @@ import {
   ProductMapsTab,
   RecommendPostModal,
 } from '@/app/admin/recommend/_page'
+
+import { updateRecommendList } from '@/app/admin/recommend/_actions/recommendActions'
 
 const TAB_COMPONENTS: Record<
   RecommendTabId,
@@ -33,12 +36,12 @@ const TAB_COMPONENTS: Record<
 }
 
 interface RecommendAdminContentProps {
-  recommendData: RecommendListItem[]
+  recommendDataPromise: Promise<RecommendApiResponse<RecommendListItem>>
   activeTab: RecommendTabId
 }
 
 export default function RecommendAdminContent({
-  recommendData,
+  recommendDataPromise,
   activeTab,
 }: RecommendAdminContentProps) {
   const router = useRouter()
@@ -55,11 +58,8 @@ export default function RecommendAdminContent({
     if (!dataId) return
 
     // TODO: 실제 상태 변경 API 호출 (Patch 등)
-    // 성공 시:
-    router.refresh()
+    await updateRecommendList({ tabId: activeTab })
   }
-
-  const ActiveTabContent = TAB_COMPONENTS[activeTab]
 
   return (
     <>
@@ -79,12 +79,20 @@ export default function RecommendAdminContent({
           onChange={handleTabChange}
         />
         <AdminTable headers={RECOMMEND_TAB_HEADERS[activeTab]}>
-          {ActiveTabContent && (
-            <ActiveTabContent
-              data={recommendData}
+          <Suspense
+            key={activeTab}
+            fallback={
+              <h1 className="py-20 text-center text-gray-400">
+                데이터 불러오는 중...
+              </h1>
+            }
+          >
+            <TableBodyWrapper
+              recommendDataPromise={recommendDataPromise}
+              activeTab={activeTab}
               onTogglePublish={handleTogglePublish}
             />
-          )}
+          </Suspense>
         </AdminTable>
       </AdminListCard>
 
@@ -94,5 +102,23 @@ export default function RecommendAdminContent({
         activeTab={activeTab}
       />
     </>
+  )
+}
+
+function TableBodyWrapper({
+  recommendDataPromise,
+  activeTab,
+  onTogglePublish,
+}: {
+  recommendDataPromise: Promise<RecommendApiResponse<RecommendListItem>>
+  activeTab: RecommendTabId
+  onTogglePublish: (id: number) => void
+}) {
+  const response = use(recommendDataPromise)
+  const recommendData = response?.success ? response.data.content : []
+  const ActiveTabContent = TAB_COMPONENTS[activeTab]
+
+  return (
+    <ActiveTabContent data={recommendData} onTogglePublish={onTogglePublish} />
   )
 }

--- a/src/app/admin/recommend/page.tsx
+++ b/src/app/admin/recommend/page.tsx
@@ -1,38 +1,32 @@
-import { Suspense } from 'react'
 import { RECOMMEND_API } from './_api'
-import { RecommendTabId, RecommendListItem } from './_types'
+import { RecommendTabId } from './_types'
 import RecommendAdminContent from './_page/RecommendAdminContent'
 
 interface PageProps {
   searchParams: Promise<{ tab?: string }>
 }
 
-async function getRecommendData(
-  activeTab: RecommendTabId
-): Promise<RecommendListItem[]> {
-  try {
-    const response = await RECOMMEND_API.get(activeTab)
-    return response?.success ? response.data.content : []
-  } catch (error) {
-    console.error('데이터 불러오기 실패', error)
-    return []
-  }
-}
+const VALID_TABS: RecommendTabId[] = [
+  'blend-maps',
+  'product-pools',
+  'product-maps',
+]
 
 export default async function RecommendAdminPage({ searchParams }: PageProps) {
   const params = await searchParams
+  const rawTab = params.tab as string
 
-  // 넘겨줄 데이터 먼저 받아오기
-  const activeTab = (params.tab as RecommendTabId) || 'blend-maps'
-  const recommendData = await getRecommendData(activeTab)
+  // 유효한 탭인지 검사하고 아니면 기본값으로 고정
+  const activeTab = VALID_TABS.includes(rawTab as RecommendTabId)
+    ? (rawTab as RecommendTabId)
+    : 'blend-maps'
 
-  // TODO: fallback UI 처리해주기
+  const recommendDataPromise = RECOMMEND_API.get(activeTab)
+
   return (
-    <Suspense fallback={<div>목록 조회 중... </div>}>
-      <RecommendAdminContent
-        recommendData={recommendData}
-        activeTab={activeTab}
-      />
-    </Suspense>
+    <RecommendAdminContent
+      recommendDataPromise={recommendDataPromise}
+      activeTab={activeTab}
+    />
   )
 }

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -1,0 +1,54 @@
+import { createFetch } from './createFetch'
+import { FetchError } from './fetchError'
+import { ApiErrorResponse } from './types'
+
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000'
+
+const DEFAULT_HEADERS: Record<string, string> = {
+  'Content-Type': 'application/json',
+  Accept: 'application/json',
+}
+
+// 공통 Response Interceptor
+export const handleResponse = async (response: Response): Promise<Response> => {
+  if (response.ok) return response
+
+  const errorBody: ApiErrorResponse = await response.json().catch(() => ({
+    success: false as const,
+    error: { code: 'UNKNOWN', message: `알 수 없는 오류 (${response.status})` },
+  }))
+
+  throw new FetchError({
+    code: errorBody.error.code,
+    message: errorBody.error.message,
+    status: response.status,
+    statusText: response.statusText,
+    url: response.url,
+    details: errorBody.error.details,
+  })
+}
+
+// 인증 필요없는 Fetch 요청
+export const apiFetch = createFetch({
+  baseUrl: BASE_URL,
+  headers: DEFAULT_HEADERS,
+  interceptors: {
+    response: handleResponse,
+  },
+})
+
+// 인증이 필요한 Fetch 요청
+export const authFetch = createFetch({
+  baseUrl: BASE_URL,
+  headers: DEFAULT_HEADERS,
+  interceptors: {
+    request: async (args) => {
+      // TODO: 로그인 구현 후 토큰 주입
+      // if (token) {
+      //   args.options.headers = { ...args.options.headers, Authorization: `Bearer ${token}` }
+      // }
+      return args
+    },
+    response: handleResponse,
+  },
+})

--- a/src/lib/api/createFetch.ts
+++ b/src/lib/api/createFetch.ts
@@ -1,0 +1,58 @@
+import { FetchArgs, FetchConfig, FetchInstance, FetchOptions } from './types'
+
+export const createFetch = ({
+  baseUrl,
+  headers: defaultHeaders,
+  interceptors,
+}: FetchConfig): FetchInstance => {
+  const baseFetch = async <T>(
+    url: string,
+    options: FetchOptions = {}
+  ): Promise<T> => {
+    const { params, ...restOptions } = options
+
+    const query = params
+      ? `?${new URLSearchParams(params as Record<string, string>)}`
+      : ''
+    let args: FetchArgs = {
+      url: `${baseUrl}${url}${query}`,
+      options: {
+        ...restOptions,
+        headers: {
+          ...defaultHeaders, // 기본 헤더
+          ...restOptions.headers, // 추가로 전달할 헤더 (Token)
+        },
+      },
+    }
+
+    if (interceptors?.request) {
+      args = await interceptors.request(args)
+    }
+
+    let response = await fetch(args.url, args.options)
+
+    if (interceptors?.response) {
+      response = await interceptors.response(response, args)
+    }
+
+    return response.json()
+  }
+
+  // baseFetch에 메서드 바인딩 시키기
+  return Object.assign(baseFetch, {
+    get: <T>(url: string, opt?: FetchOptions) =>
+      baseFetch<T>(url, { ...opt, method: 'GET' }),
+    post: <T>(url: string, body?: unknown, opt?: FetchOptions) =>
+      baseFetch<T>(url, { ...opt, method: 'POST', body: JSON.stringify(body) }),
+    put: <T>(url: string, body?: unknown, opt?: FetchOptions) =>
+      baseFetch<T>(url, { ...opt, method: 'PUT', body: JSON.stringify(body) }),
+    patch: <T>(url: string, body?: unknown, opt?: FetchOptions) =>
+      baseFetch<T>(url, {
+        ...opt,
+        method: 'PATCH',
+        body: JSON.stringify(body),
+      }),
+    delete: <T>(url: string, opt?: FetchOptions) =>
+      baseFetch<T>(url, { ...opt, method: 'DELETE' }),
+  })
+}

--- a/src/lib/api/fetchError.ts
+++ b/src/lib/api/fetchError.ts
@@ -1,0 +1,30 @@
+import { ApiErrorResponse } from './types'
+
+// API 에러 클래스
+export class FetchError extends Error {
+  code: string
+  status: number
+  statusText: string
+  url: string
+  details?: { field?: string; reason?: string }
+
+  constructor(params: {
+    code: string
+    message: string
+    status: number
+    statusText: string
+    url: string
+    details?: { field?: string; reason?: string }
+  }) {
+    super(params.message)
+    this.name = 'FetchError'
+    this.code = params.code
+    this.status = params.status
+    this.statusText = params.statusText
+    this.url = params.url
+    this.details = params.details
+  }
+}
+
+// re-export for convenience
+export type { ApiErrorResponse }

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -1,0 +1,12 @@
+// 단일 진입점 (외부에서 import 시 여기서만 가져오세요)
+export { apiFetch, authFetch, handleResponse } from './client'
+export { createFetch } from './createFetch'
+export { FetchError } from './fetchError'
+export type {
+  FetchOptions,
+  FetchArgs,
+  FetchConfig,
+  FetchInterceptor,
+  FetchInstance,
+  ApiErrorResponse,
+} from './types'

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -1,0 +1,54 @@
+// 표준 fetch옵션 상속 + 추가 옵션
+export type FetchOptions = RequestInit & {
+  params?: Record<string, string | number>
+  cache?: 'no-store' | 'force-cache'
+  next?: {
+    revalidate?: number | false // 재검증 주기 (초)
+    tags?: string[] // On-demand 재검증용 태그
+  }
+}
+
+// 인터셉터에 전달되는 요청 정보
+export type FetchArgs = {
+  url: string
+  options: FetchOptions
+}
+
+// 인터셉터 정의
+export type FetchInterceptor = {
+  request?: (args: FetchArgs) => FetchArgs | Promise<FetchArgs>
+  response?: (
+    response: Response,
+    requestArgs: FetchArgs
+  ) => Response | Promise<Response>
+}
+
+// createFetch 설정
+export type FetchConfig = {
+  baseUrl: string
+  headers?: Record<string, string>
+  interceptors?: FetchInterceptor
+}
+
+// 생성된 fetch 인스턴스의 인터페이스
+export interface FetchInstance {
+  <T>(url: string, options?: FetchOptions): Promise<T>
+  get: <T>(url: string, options?: FetchOptions) => Promise<T>
+  post: <T>(url: string, body?: unknown, options?: FetchOptions) => Promise<T>
+  put: <T>(url: string, body?: unknown, options?: FetchOptions) => Promise<T>
+  patch: <T>(url: string, body?: unknown, options?: FetchOptions) => Promise<T>
+  delete: <T>(url: string, options?: FetchOptions) => Promise<T>
+}
+
+// 서버 에러 응답 구조 타입
+export type ApiErrorResponse = {
+  success: false
+  error: {
+    code: string
+    message: string
+    details?: {
+      field?: string
+      reason?: string
+    }
+  }
+}


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->

- Next.js App Router 환경에 최적화된 커스텀 Fetch(createFetch) 함수를 구현
- 추천 시스템 관리자 페이지의 API를 해당 함수로 적용


## 📌 관련 이슈

<!-- Closes #이슈번호 -->

Closes #81 

## 🧩 작업 내용 (주요 변경사항)

- BaseURL 및 기본 Header, Interceptor를 캡슐화 한 팩토리 함수 추가하였습니다
- HTTP 메서드를 지원하여 Axios와 유사하게 사용할 수 있도록 DX를 제공하였습니다.
- 실제 api 호출 시 사용할 변수 apiFetch, authFetch을 생성하여 토큰이 필요한 요청인지 아닌지 쉽게 확인 할 수 있으며 공통 response
interceptor로직을 작성하여 전역적인 에러를 처리 할 수 있도록 하였습니다.
- createFetch 함수에 필요한 데이터들에 대한 타입 파일을 추가하여 안정성을 추가하였고 기존 Native Fetch의 cache: 'force-cache', next.tags 옵션을 커스텀 래퍼에서도 그대로 활용할 수 있도록 지원 하였습니다.


## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

Cache Invalidation 로직처리 -> fetch 요청시 cashe : 'force-cashe' 후 cashe 적용됨을 확인하였고 
요청시 함께 옵션을 추가하였던 tags: ["tabId"] 를 통해 

```
export async function updateRecommendList({ tabId }: { tabId: string }) {
  updateTag(tabId)
}

```
서버 액션으로 처리 하여 cashe를 강제 무효화 후 다시 data fetch 해보았습니다.


## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

1. force-cashe 적용된 상황에서 updateTag(tabId) 적용 전

<img width="659" height="138" alt="image" src="https://github.com/user-attachments/assets/3ecc8e7e-5e0e-4a91-9ff6-13bb900166f2" />

2. updateTag(tabId) 적용 후

<img width="621" height="168" alt="image" src="https://github.com/user-attachments/assets/3f8a87c7-da27-419f-9101-5a3d0fb1d80b" />

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

에러 핸들링은 추후에 Modal/Toast/Console 등에 전파되도록 구성할 예정이며, 공통 인터셉터를 통해 나중에 토큰 재발급 로직을 쉽게 끼워 넣을 수 있는 구조입니다.

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 로컬에서 실행 확인 완료
