### PR TITLE
[Feat] 어드민 상품 페이지 렌더링 구조 개선 및 등록 모달 UX 최적화 (#88)

### DIFF
--- a/src/app/admin/product/_components/ProductTableServer.tsx
+++ b/src/app/admin/product/_components/ProductTableServer.tsx
@@ -1,0 +1,109 @@
+import Image from 'next/image'
+import {
+  AdminTableRow,
+  AdminTableCell,
+  AdminTableEmpty,
+} from '@/app/admin/_components'
+import Button from '@/components/common/Button'
+import PenIcon from '@/assets/icons/pen.svg'
+import { fetchAdminProductList } from '../_api/adminFetchProductList'
+import type {
+  ProductTabId,
+  AdminElementProduct,
+  AdminBlendProduct,
+} from '../_types/AdminProductType'
+import {
+  getAccordLabel,
+  ACCORD_LABEL_PILL_SM_CLASS,
+} from '@/constants/accordLabelStyles'
+
+interface ProductTableServerProps {
+  activeTab: ProductTabId
+}
+
+export async function ProductTableServer({
+  activeTab,
+}: ProductTableServerProps) {
+  const response = await fetchAdminProductList(activeTab)
+  const items = response?.data?.results || []
+
+  if (!items.length) {
+    return <AdminTableEmpty />
+  }
+
+  return (
+    <>
+      {items.map((item: AdminElementProduct | AdminBlendProduct) => {
+        const isSingle = activeTab === 'ELEMENT'
+        const elementItem = item as AdminElementProduct
+        const blendItem = item as AdminBlendProduct
+
+        return (
+          <AdminTableRow key={item.id}>
+            <AdminTableCell slot={1}>
+              <div className="flex items-center gap-3">
+                <Image
+                  src={item.thumbnail_image_url || ''}
+                  alt={item.name}
+                  width={40}
+                  height={40}
+                  className="h-20 w-20 rounded-md object-cover"
+                />
+                <span className="text-[16px] font-bold">{item.name}</span>
+              </div>
+            </AdminTableCell>
+
+            <AdminTableCell slot={2}>
+              <div className="flex flex-wrap items-center justify-center gap-1.5">
+                {isSingle
+                  ? (() => {
+                      const familyId =
+                        elementItem.element_category?.name?.en?.toLowerCase() ||
+                        'base'
+                      const krName =
+                        elementItem.element_category?.name?.kr || '미지정'
+                      const { style } = getAccordLabel(familyId)
+                      return (
+                        <span
+                          className={ACCORD_LABEL_PILL_SM_CLASS}
+                          style={{
+                            backgroundColor: style.bg,
+                            borderColor: style.border,
+                            color: style.text,
+                          }}
+                        >
+                          {krName}
+                        </span>
+                      )
+                    })()
+                  : blendItem.blend_categories
+                      ?.filter((c) => c.name?.kr)
+                      .map((c) => {
+                        const krName = c.name.kr
+                        return (
+                          <span
+                            key={`${blendItem.id}-${krName}`}
+                            className={ACCORD_LABEL_PILL_SM_CLASS}
+                          >
+                            # {krName}
+                          </span>
+                        )
+                      })}
+              </div>
+            </AdminTableCell>
+
+            <AdminTableCell slot={4}>
+              {isSingle ? '단품' : '조합'}
+            </AdminTableCell>
+
+            <AdminTableCell slot={7}>
+              <Button color="none" size="w32h32" rounded="sm">
+                <PenIcon width={16} height={16} />
+              </Button>
+            </AdminTableCell>
+          </AdminTableRow>
+        )
+      })}
+    </>
+  )
+}

--- a/src/app/admin/product/_page/ProductAdminContent.tsx
+++ b/src/app/admin/product/_page/ProductAdminContent.tsx
@@ -1,38 +1,25 @@
 'use client'
 
-import { use, Suspense } from 'react'
+import { Suspense } from 'react'
 import { useRouter } from 'next/navigation'
-import Image from 'next/image'
 import {
   AdminListCard,
   AdminPageHeader,
   AdminFilterBar,
   AdminTable,
-  AdminTableRow,
-  AdminTableCell,
   AdminTabGroup,
-  AdminFirstCell,
-  AdminTableLoading,
   AdminTableError,
-  AdminTableEmpty,
+  AdminTableLoading,
 } from '@/app/admin/_components'
-import Button from '@/components/common/Button'
-import PenIcon from '@/assets/icons/pen.svg'
 import type {
   AdminElementListResponse,
-  AdminBlendListResponse,
-  AdminElementProduct,
-  AdminBlendProduct,
   ProductTabId,
 } from '../_types/AdminProductType'
 import { PRODUCT_TABLE_HEADERS } from '@/constants/admin'
-import { useModalStore } from '@/store/useModalStore'
 import { ProductPostModal } from './ProductPostModal'
 import { ErrorBoundary } from 'react-error-boundary'
-import {
-  getAccordLabel,
-  ACCORD_LABEL_PILL_SM_CLASS,
-} from '@/constants/accordLabelStyles'
+import { useModalStore } from '@/store/useModalStore'
+import { fetchAdminProductList } from '../_api/adminFetchProductList'
 
 const PRODUCT_TABS: { id: ProductTabId; label: string }[] = [
   { id: 'ELEMENT', label: '단품' },
@@ -40,16 +27,16 @@ const PRODUCT_TABS: { id: ProductTabId; label: string }[] = [
 ]
 
 type ProductAdminContentProps = {
-  dataPromise: Promise<AdminElementListResponse | AdminBlendListResponse>
   activeTab: ProductTabId
+  children: React.ReactNode
 }
 
 export default function ProductAdminContent({
-  dataPromise,
   activeTab,
+  children,
 }: ProductAdminContentProps) {
   const router = useRouter()
-  // const { openModal } = useModalStore()
+  const { openModal } = useModalStore()
 
   const activeTabLabel =
     PRODUCT_TABS.find((t) => t.id === activeTab)?.label || '단품'
@@ -59,7 +46,21 @@ export default function ProductAdminContent({
   }
 
   const handleOpenRegisterModal = () => {
-    // openModal(<ProductPostModal activeTab={activeTab} />)
+    // 🔥 무한 루프 방지 핵심: 렌더링 함수 내부가 아닌 "이벤트 핸들러"에서 호출!!
+    // 또한 page.tsx 의 오버페칭(초기 로딩 낭비) 문제도 완벽하게 해결!
+    const elementPromise =
+      activeTab === 'BLEND'
+        ? fetchAdminProductList('ELEMENT', { size: 100 })
+        : Promise.resolve(null)
+
+    openModal(
+      <Suspense fallback={null}>
+        <ProductPostModal
+          activeTab={activeTab}
+          elementPromise={elementPromise}
+        />
+      </Suspense>
+    )
   }
 
   return (
@@ -84,101 +85,10 @@ export default function ProductAdminContent({
       <AdminTable headers={PRODUCT_TABLE_HEADERS}>
         <ErrorBoundary fallback={<AdminTableError />}>
           <Suspense key={activeTab} fallback={<AdminTableLoading />}>
-            <TableBodyWrapper dataPromise={dataPromise} activeTab={activeTab} />
+            {children}
           </Suspense>
         </ErrorBoundary>
       </AdminTable>
     </AdminListCard>
-  )
-}
-
-function TableBodyWrapper({
-  dataPromise,
-  activeTab,
-}: {
-  dataPromise: Promise<AdminElementListResponse | AdminBlendListResponse>
-  activeTab: ProductTabId
-}) {
-  const response = use(dataPromise)
-  const items = response?.data?.results || []
-
-  if (!items.length) {
-    return <AdminTableEmpty />
-  }
-
-  return (
-    <>
-      {items.map((item: AdminElementProduct | AdminBlendProduct) => {
-        const isSingle = activeTab === 'ELEMENT'
-        const elementItem = item as AdminElementProduct
-        const blendItem = item as AdminBlendProduct
-
-        return (
-          <AdminTableRow key={item.id}>
-            <AdminTableCell slot={1}>
-              <div className="flex items-center gap-3">
-                <Image
-                  src={item.thumbnail_image_url || ''}
-                  alt={item.name}
-                  width={40}
-                  height={40}
-                  className="h-20 w-20 rounded-md object-cover"
-                />
-                <span className="text-[16px] font-bold">{item.name}</span>
-              </div>
-            </AdminTableCell>
-
-            <AdminTableCell slot={2}>
-              <div className="flex flex-wrap items-center justify-center gap-1.5">
-                {isSingle
-                  ? (() => {
-                      const familyId =
-                        elementItem.element_category?.name?.en?.toLowerCase() ||
-                        'base'
-                      const krName =
-                        elementItem.element_category?.name?.kr || '미지정'
-                      const { style } = getAccordLabel(familyId)
-                      return (
-                        <span
-                          className={ACCORD_LABEL_PILL_SM_CLASS}
-                          style={{
-                            backgroundColor: style.bg,
-                            borderColor: style.border,
-                            color: style.text,
-                          }}
-                        >
-                          {krName}
-                        </span>
-                      )
-                    })()
-                  : blendItem.blend_categories
-                      ?.filter((c) => c.name?.kr)
-                      .map((c) => {
-                        const krName = c.name.kr
-                        return (
-                          <span
-                            key={`${blendItem.id}-${krName}`}
-                            className={ACCORD_LABEL_PILL_SM_CLASS}
-                          >
-                            # {krName}
-                          </span>
-                        )
-                      })}
-              </div>
-            </AdminTableCell>
-
-            <AdminTableCell slot={4}>
-              {isSingle ? '단품' : '조합'}
-            </AdminTableCell>
-
-            <AdminTableCell slot={7}>
-              <Button color="none" size="w32h32" rounded="sm">
-                <PenIcon width={16} height={16} />
-              </Button>
-            </AdminTableCell>
-          </AdminTableRow>
-        )
-      })}
-    </>
   )
 }

--- a/src/app/admin/product/_page/ProductPostModal.tsx
+++ b/src/app/admin/product/_page/ProductPostModal.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React, { useState, use, Suspense } from 'react'
+import { ErrorBoundary } from 'react-error-boundary'
 import Modal from '@/components/common/Modal/Modal'
 import Button from '@/components/common/Button'
 import { useModalStore } from '@/store/useModalStore'
@@ -179,21 +180,29 @@ export const ProductPostModal = ({
             <div className={LABEL_CLASS}>
               구성 단품 선택 (현재 {blendData.element_ids.length} / 4개)
               <div className="border-gray-light grid h-40 grid-cols-2 gap-2 overflow-y-auto rounded-md border p-2 font-normal">
-                <Suspense
+                <ErrorBoundary
                   fallback={
-                    <span className="col-span-2 my-auto text-center text-xs">
-                      단품 목록을 불러오는 중...
+                    <span className="text-danger col-span-2 my-auto text-center text-xs">
+                      단품 목록을 불러오는 데 실패했습니다.
                     </span>
                   }
                 >
-                  {elementPromise && (
-                    <ElementCheckboxList
-                      elementPromise={elementPromise}
-                      selectedIds={blendData.element_ids}
-                      onToggle={toggleElementId}
-                    />
-                  )}
-                </Suspense>
+                  <Suspense
+                    fallback={
+                      <span className="text-black-tertiary col-span-2 my-auto text-center text-xs">
+                        단품 목록을 불러오는 중...
+                      </span>
+                    }
+                  >
+                    {elementPromise && (
+                      <ElementCheckboxList
+                        elementPromise={elementPromise}
+                        selectedIds={blendData.element_ids}
+                        onToggle={toggleElementId}
+                      />
+                    )}
+                  </Suspense>
+                </ErrorBoundary>
               </div>
             </div>
 

--- a/src/app/admin/product/_page/ProductPostModal.tsx
+++ b/src/app/admin/product/_page/ProductPostModal.tsx
@@ -1,0 +1,264 @@
+'use client'
+
+import React, { useState, use, Suspense } from 'react'
+import Modal from '@/components/common/Modal/Modal'
+import Button from '@/components/common/Button'
+import { useModalStore } from '@/store/useModalStore'
+import type {
+  ProductTabId,
+  AdminElementListResponse,
+} from '../_types/AdminProductType'
+import Input from '@/components/common/Input'
+
+const LABEL_CLASS = 'flex flex-col gap-2 font-semibold'
+const INPUT_CLASS =
+  'border-gray-light focus:border-black-primary rounded-md border p-2 focus:outline-none'
+
+interface ProductPostModalProps {
+  activeTab: ProductTabId
+  elementPromise: Promise<AdminElementListResponse | null>
+}
+
+export const ProductPostModal = ({
+  activeTab,
+  elementPromise,
+}: ProductPostModalProps) => {
+  const { closeModal, openAlert } = useModalStore()
+  const isElement = activeTab === 'ELEMENT'
+
+  // 단품
+  const [elementData, setElementData] = useState({
+    name: '',
+    description: '',
+    category_id: '', // TODO: 카테고리 목록 불러오는 로직 적용 후 선택 가능하게
+    // image_urls: '', // TODO: 이후 S3 업로드 로직으로 교체
+  })
+
+  // 조합
+  const [blendData, setBlendData] = useState({
+    name: '',
+    description: '',
+    blend_categories_text: '',
+    element_ids: [] as number[], // 선택된 단품 ID 4개
+    // image_url: '', // TODO: 이후 S3 업로드 로직으로 교체
+  })
+
+  // 단품 핸들러
+  const handleElementChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target
+    setElementData((prev) => ({ ...prev, [name]: value }))
+  }
+
+  // 조합 핸들러
+  const handleBlendChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target
+    setBlendData((prev) => ({ ...prev, [name]: value }))
+  }
+
+  const toggleElementId = (id: number) => {
+    setBlendData((prev) => {
+      const isSelected = prev.element_ids.includes(id)
+      let newIds = prev.element_ids
+      if (isSelected) {
+        newIds = newIds.filter((v) => v !== id)
+      } else {
+        if (newIds.length >= 4) {
+          return prev
+        }
+        newIds = [...newIds, id]
+      }
+      return { ...prev, element_ids: newIds }
+    })
+  }
+
+  const handleRegister = () => {
+    if (isElement) {
+      const submitElementData = {
+        name: elementData.name,
+        // image_url: [] // TODO: S3 연동
+        description: elementData.description ?? '',
+        category_id: Number(elementData.category_id),
+      }
+      console.log(`단품 입력 : `, submitElementData)
+    } else {
+      const submitBlendData = {
+        name: blendData.name,
+        // image_url: '' // TODO: S3 연동
+        description: blendData.description ?? '',
+        blend_category_ids: blendData.blend_categories_text
+          .split(',')
+          .map((v) => Number(v.trim())),
+        element_ids: blendData.element_ids,
+      }
+
+      if (submitBlendData.element_ids.length !== 4) {
+        openAlert({
+          type: 'danger',
+          title: '선택 오류',
+          content: '단품을 반드시 4개 선택해주세요.',
+        })
+        return
+      }
+      console.log(`조합 입력 : `, submitBlendData)
+    }
+    closeModal()
+  }
+
+  return (
+    <Modal isOpen onClose={closeModal} size="md">
+      <Modal.Header>{isElement ? '단품' : '조합'} 등록</Modal.Header>
+
+      <Modal.Content className="flex flex-col gap-3 text-sm">
+        {isElement ? (
+          <>
+            <label className={LABEL_CLASS}>
+              단품명
+              <Input
+                name="name"
+                value={elementData.name}
+                onChange={handleElementChange}
+                placeholder="단품명을 입력하세요"
+              />
+            </label>
+
+            <label className={LABEL_CLASS}>
+              설명
+              <Input
+                name="description"
+                value={elementData.description}
+                onChange={handleElementChange}
+                placeholder="상품에 대한 설명을 입력하세요"
+              />
+            </label>
+
+            <label className={LABEL_CLASS}>
+              향조 선택
+              <Input
+                name="category_id"
+                type="number"
+                value={elementData.category_id}
+                onChange={handleElementChange}
+                placeholder=""
+              />
+            </label>
+
+            <div>이미지 업로드는 추후 S3 연동 시 추가예정</div>
+          </>
+        ) : (
+          <>
+            <label className={LABEL_CLASS}>
+              조합명
+              <Input
+                name="name"
+                value={blendData.name}
+                onChange={handleBlendChange}
+                placeholder="조합명을 입력하세요 (예: 하트 시그널)"
+              />
+            </label>
+
+            <label className={LABEL_CLASS}>
+              설명
+              <Input
+                name="description"
+                value={blendData.description}
+                onChange={handleBlendChange}
+                placeholder="조합에 대한 무드/설명을 입력하세요"
+              />
+            </label>
+
+            <label className={LABEL_CLASS}>
+              테마 선택
+              <Input
+                name="blend_categories_text"
+                value={blendData.blend_categories_text}
+                onChange={handleBlendChange}
+                placeholder=""
+              />
+            </label>
+
+            <div className={LABEL_CLASS}>
+              구성 단품 선택 (현재 {blendData.element_ids.length} / 4개)
+              <div className="border-gray-light grid h-40 grid-cols-2 gap-2 overflow-y-auto rounded-md border p-2 font-normal">
+                <Suspense
+                  fallback={
+                    <span className="col-span-2 my-auto text-center text-xs">
+                      단품 목록을 불러오는 중...
+                    </span>
+                  }
+                >
+                  {elementPromise && (
+                    <ElementCheckboxList
+                      elementPromise={elementPromise}
+                      selectedIds={blendData.element_ids}
+                      onToggle={toggleElementId}
+                    />
+                  )}
+                </Suspense>
+              </div>
+            </div>
+
+            <div>이미지 업로드는 추후 S3 연동 시 추가예정</div>
+          </>
+        )}
+      </Modal.Content>
+
+      <Modal.Footer className="flex justify-end gap-2 text-[16px]">
+        <Button
+          color="none"
+          className="border-gray-light border"
+          onClick={closeModal}
+        >
+          취소
+        </Button>
+        <Button color="primary" onClick={handleRegister}>
+          {isElement ? '단품' : '조합'} 등록
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  )
+}
+
+function ElementCheckboxList({
+  elementPromise,
+  selectedIds,
+  onToggle,
+}: {
+  elementPromise: Promise<AdminElementListResponse | null>
+  selectedIds: number[]
+  onToggle: (id: number) => void
+}) {
+  const elementResponse = use(elementPromise)
+  const elementList = elementResponse?.data?.results || []
+
+  if (elementList.length === 0) {
+    return (
+      <span className="col-span-2 my-auto text-center text-xs">
+        등록된 단품 데이터가 없습니다.
+      </span>
+    )
+  }
+
+  return (
+    <>
+      {elementList.map((el) => {
+        const isChecked = selectedIds.includes(el.id)
+        return (
+          <label
+            key={el.id}
+            className="flex cursor-pointer items-center gap-2 rounded px-1.5 py-1 hover:bg-neutral-50"
+          >
+            <input
+              type="checkbox"
+              checked={isChecked}
+              onChange={() => onToggle(el.id)}
+              className="accent-black-primary"
+            />
+            <span className="truncate text-xs">
+              {el.name} (ID: {el.id})
+            </span>
+          </label>
+        )
+      })}
+    </>
+  )
+}

--- a/src/app/admin/product/page.tsx
+++ b/src/app/admin/product/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next'
-import { fetchAdminProductList } from './_api/adminFetchProductList'
 import ProductAdminContent from './_page/ProductAdminContent'
 import type { ProductTabId } from './_types/AdminProductType'
+import { ProductTableServer } from './_components/ProductTableServer'
 
 export const metadata: Metadata = {
   title: '어드민 상품 관리',
@@ -20,8 +20,9 @@ export default async function ProductAdminPage({
   const activeTab: ProductTabId =
     typeof typeParam === 'string' && typeParam === 'BLEND' ? 'BLEND' : 'ELEMENT'
 
-  // 페치 함수 호출 Promise 자체를 Client 컴포넌트로 전달
-  const dataPromise = fetchAdminProductList(activeTab)
-
-  return <ProductAdminContent dataPromise={dataPromise} activeTab={activeTab} />
+  return (
+    <ProductAdminContent activeTab={activeTab}>
+      <ProductTableServer activeTab={activeTab} />
+    </ProductAdminContent>
+  )
 }


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->

단품과 조합에 대해 입력 값을 새로 받아 새 상품을 생성할 수 있는 Modal을 추가
조합 등록 추가시 받아올 단품 목록을 모달 내에서 구현 -> 단품 데이터를 다 받아오기 전까지 모달 창 자체가 뜨지 않도록 UI는 바로 보여주고 data는 받아와지면 출력되도록 

## 📌 관련 이슈

<!-- Closes #이슈번호 -->

Closes #88 

## 🧩 작업 내용 (주요 변경사항)

- 전역 모달 데이터 로딩 최적화 및 무한 루프 차단 -> 사용자가 상품 등록 버튼을 클릭하는 이벤트 핸들러 내부에서 비동기 함수를 생성하여 모달 내부의 fetching할 데이터를 받아오는 곳에 적절한 Suspense 적용
- 기존 방식대은 page의 최상위에서 미리 promise 함수를 생성 -> 직관적으로 별도의 서버 컴포넌트에서 data를 비동기로 받아오는 구조로 수정하여 클라이언트 컴포넌트 코드와 분리 시킴

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

Product/page.tsx에서 기존 방식은 미리 fetch Promise를 만들어 ProductAdminContent라는 하위 클라이언트 컴포넌트로 Props 전달 후 use 훅을 사용하여 클라이언트 컴포넌트 내부에서 fetch된 데이터를 출력 -> ProductAdmincontent에서 ProductTableServer를 children으로 받아 fetching 작업을 진행하도록 하여 page에서는 server와 client를 직관적으로 분리 시킬려고 구조를 변경하였습니다.

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

https://github.com/user-attachments/assets/15a53d05-122e-4718-ac41-36bad74dee72


## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 로컬에서 실행 확인 완료
