### PR TITLE
feat: 테스트 결과 페이지 API·MSW 및 다른 테스트 선택 모달 (#93)

### DIFF
--- a/public/ai.svg
+++ b/public/ai.svg
@@ -1,0 +1,27 @@
+<svg width="88" height="88" viewBox="0 0 88 88" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_dd_144_16032)">
+<path d="M12 18C12 9.16344 19.1634 2 28 2H60C68.8366 2 76 9.16344 76 18V50C76 58.8366 68.8366 66 60 66H28C19.1634 66 12 58.8366 12 50V18Z" fill="#414141" shape-rendering="crispEdges"/>
+<path d="M47.3337 23.334H40.667L37.3337 27.334H33.3337C32.6264 27.334 31.9481 27.6149 31.448 28.115C30.9479 28.6151 30.667 29.2934 30.667 30.0007V42.0007C30.667 42.7079 30.9479 43.3862 31.448 43.8863C31.9481 44.3864 32.6264 44.6673 33.3337 44.6673H54.667C55.3742 44.6673 56.0525 44.3864 56.5526 43.8863C57.0527 43.3862 57.3337 42.7079 57.3337 42.0007V30.0007C57.3337 29.2934 57.0527 28.6151 56.5526 28.115C56.0525 27.6149 55.3742 27.334 54.667 27.334H50.667L47.3337 23.334Z" stroke="white" stroke-width="2.66667" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M44 39.334C46.2091 39.334 48 37.5431 48 35.334C48 33.1248 46.2091 31.334 44 31.334C41.7909 31.334 40 33.1248 40 35.334C40 37.5431 41.7909 39.334 44 39.334Z" stroke="white" stroke-width="2.66667" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<filter id="filter0_dd_144_16032" x="0" y="0" width="88" height="88" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feMorphology radius="4" operator="erode" in="SourceAlpha" result="effect1_dropShadow_144_16032"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="3"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_144_16032"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feMorphology radius="3" operator="erode" in="SourceAlpha" result="effect2_dropShadow_144_16032"/>
+<feOffset dy="10"/>
+<feGaussianBlur stdDeviation="7.5"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"/>
+<feBlend mode="normal" in2="effect1_dropShadow_144_16032" result="effect2_dropShadow_144_16032"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect2_dropShadow_144_16032" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/src/app/api/v1/profilings/results/[resultId]/route.ts
+++ b/src/app/api/v1/profilings/results/[resultId]/route.ts
@@ -1,0 +1,32 @@
+/**
+ * 결과 상세 조회 (MSW 미가로챔 시 fallback)
+ * GET /api/v1/profilings/results/:resultId
+ */
+import { NextResponse } from 'next/server'
+import { mockProfilingResultDetail } from '@/mocks/data/profilingResults'
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ resultId: string }> }
+) {
+  const { resultId } = await params
+  const id = Number(resultId)
+  if (!Number.isInteger(id) || id < 1) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          code: 'NOT_FOUND',
+          message: '리소스를 찾을 수 없습니다.',
+          details: null,
+        },
+      },
+      { status: 404 }
+    )
+  }
+
+  return NextResponse.json({
+    success: true,
+    data: { ...mockProfilingResultDetail, id },
+  })
+}

--- a/src/app/api/v1/profilings/submit/route.ts
+++ b/src/app/api/v1/profilings/submit/route.ts
@@ -1,0 +1,54 @@
+/**
+ * 테스트 제출 (MSW 미가로챔 시 fallback)
+ * POST /api/v1/profilings/submit
+ */
+import { NextResponse } from 'next/server'
+import { mockProfilingResultDetail } from '@/mocks/data/profilingResults'
+
+export async function POST(request: Request) {
+  let body: {
+    profiling_type?: string
+    product_type?: string
+    responses?: unknown[]
+  }
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          code: 'BAD_REQUEST',
+          message: '요청 본문이 올바르지 않습니다.',
+          details: null,
+        },
+      },
+      { status: 400 }
+    )
+  }
+
+  if (!body?.profiling_type || !Array.isArray(body?.responses)) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          code: 'BAD_REQUEST',
+          message: '필수 항목이 누락되었습니다.',
+          details: null,
+        },
+      },
+      { status: 400 }
+    )
+  }
+
+  return NextResponse.json(
+    {
+      success: true,
+      data: {
+        result_id: mockProfilingResultDetail.id,
+        message: '테스트가 제출되었습니다.',
+      },
+    },
+    { status: 201 }
+  )
+}

--- a/src/app/find-my-scent/_api/profilingClient.ts
+++ b/src/app/find-my-scent/_api/profilingClient.ts
@@ -1,12 +1,17 @@
 /**
  * 향기 성향 테스트 API
+ * - GET forms/active, POST submit, GET results/:id
  * - 목데이터(MSW): NEXT_PUBLIC_USE_MOCK_API=true 시 같은 origin 요청 → MSW가 가로챔
- * - 실제 API: NEXT_PUBLIC_API_BASE_URL 사용
  */
 import { apiFetch } from '@/lib/api'
 import type {
+  AnswersState,
   ProfilingFormResponse,
   ProfilingQuestion,
+  ProfilingResultDetail,
+  ProfilingResultDetailResponse,
+  ProfilingSubmitRequest,
+  ProfilingSubmitResponse,
   ProfilingType,
   QuizQuestion,
 } from '../_types'
@@ -14,12 +19,14 @@ import type {
 function toQuizQuestion(q: ProfilingQuestion): QuizQuestion {
   return {
     id: String(q.id),
+    questionKey: q.question_key,
     text: q.question_text,
     required: q.is_required,
     questionType: q.selection_type,
     options: q.options.map((opt) => ({
       id: String(opt.id),
       text: opt.answer_option_text,
+      answerOptionKey: opt.answer_option_key,
     })),
   }
 }
@@ -43,4 +50,85 @@ export async function fetchProfilingFormActive(
       params: { profiling_type: profilingType },
     }
   )
+}
+
+/**
+ * 퀴즈 답변(questions + answers)을 API 제출용 payload로 변환
+ */
+export function buildSubmitPayload(
+  questions: QuizQuestion[],
+  answers: AnswersState,
+  profilingType: ProfilingType,
+  productType: 'DIFFUSER' | 'PERFUME' = 'DIFFUSER'
+): ProfilingSubmitRequest {
+  const responses = questions.map((q) => {
+    const selectedIds = answers[q.id] ?? []
+    const answer_option_keys = selectedIds
+      .map((optId) => q.options.find((o) => o.id === optId)?.answerOptionKey)
+      .filter((k): k is string => Boolean(k))
+    return { question_key: q.questionKey ?? q.id, answer_option_keys }
+  })
+  return { profiling_type: profilingType, product_type: productType, responses }
+}
+
+/**
+ * 테스트 제출
+ * POST /api/v1/profilings/submit
+ */
+export async function submitProfiling(
+  body: ProfilingSubmitRequest
+): Promise<ProfilingSubmitResponse> {
+  return apiFetch.post<ProfilingSubmitResponse>(
+    '/api/v1/profilings/submit',
+    body
+  )
+}
+
+/**
+ * 결과 상세 조회
+ * GET /api/v1/profilings/results/{result_id}
+ */
+export async function fetchProfilingResult(
+  resultId: number
+): Promise<ProfilingResultDetailResponse> {
+  return apiFetch.get<ProfilingResultDetailResponse>(
+    `/api/v1/profilings/results/${resultId}`
+  )
+}
+
+/** 결과 상세 API 응답 → ResultContentBox props (primaryButtonHref = 추천 상품 링크) */
+export function resultDetailToContentBoxProps(detail: ProfilingResultDetail): {
+  productImageUrl: string
+  productName: string
+  description: string
+  scentTypeLabel?: string
+  showRecommendLabel: boolean
+  scentTypeTags: string[]
+  noteTags: string[]
+  /** 추천한 향기와 어울리는 연관 추천 상품 보러가기 버튼 링크 */
+  primaryButtonHref: string
+} {
+  const { recommended_blend, recommended_products } = detail
+  const scentTypeTags =
+    recommended_blend.contained_elements?.map(
+      (e) => e.category?.en ?? e.category?.kr ?? ''
+    ) ?? []
+  const scentTypeLabel =
+    recommended_blend.contained_elements?.[0]?.category?.en ??
+    recommended_blend.contained_elements?.[0]?.category?.kr
+  const primaryButtonHref = recommended_products[0].purchase_url
+  const noteTags =
+    recommended_blend.contained_elements?.map(
+      (e) => `#${e.category?.en ?? e.name}`
+    ) ?? []
+  return {
+    productImageUrl: recommended_blend.image_url ?? '',
+    productName: recommended_blend.name ?? '',
+    description: recommended_blend.description ?? '',
+    scentTypeLabel: scentTypeLabel ?? undefined,
+    showRecommendLabel: true,
+    scentTypeTags: scentTypeTags.filter(Boolean),
+    noteTags,
+    primaryButtonHref,
+  }
 }

--- a/src/app/find-my-scent/_components/OtherTestCard.tsx
+++ b/src/app/find-my-scent/_components/OtherTestCard.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+/** 다른 테스트 하러가기 모달 내 개별 테스트 유형 카드 */
+import Image from 'next/image'
+import Link from 'next/link'
+
+export type OtherTestCardProps = {
+  iconSrc: string
+  title: string
+  subtitle: string
+  href: string
+}
+
+const styles = {
+  card: 'flex w-full items-center gap-4 rounded-xl bg-[#F5F0E8] px-4 py-4 transition-colors hover:bg-[#EDE8E0]',
+  iconWrap: 'relative h-10 w-10 shrink-0',
+  textWrap: 'min-w-0 flex-1',
+  title: 'text-base font-semibold text-[var(--color-black-primary)]',
+  subtitle: 'text-sm text-neutral-600',
+  arrow: 'shrink-0 text-[var(--color-black-primary)]',
+} as const
+
+export function OtherTestCard({
+  iconSrc,
+  title,
+  subtitle,
+  href,
+}: OtherTestCardProps) {
+  return (
+    <Link href={href} className={styles.card}>
+      <div className={styles.iconWrap}>
+        <Image
+          src={iconSrc}
+          alt=""
+          fill
+          className="object-contain"
+          unoptimized
+        />
+      </div>
+      <div className={styles.textWrap}>
+        <p className={styles.title}>{title}</p>
+        <p className={styles.subtitle}>{subtitle}</p>
+      </div>
+      <span className={styles.arrow} aria-hidden>
+        ›
+      </span>
+    </Link>
+  )
+}

--- a/src/app/find-my-scent/_components/OtherTestModal.tsx
+++ b/src/app/find-my-scent/_components/OtherTestModal.tsx
@@ -1,0 +1,107 @@
+'use client'
+
+/** 다른 테스트 하러가기 모달 — 현재 결과 유형 제외 2가지 테스트 선택 */
+import Image from 'next/image'
+import type { ResultPageType } from '../_types'
+import { OtherTestCard } from './OtherTestCard'
+
+const OTHER_TEST_CONFIG: Record<
+  ResultPageType,
+  { icon: string; title: string; subtitle: string; href: string }
+> = {
+  PREFERENCE: {
+    icon: '/taste.svg',
+    title: '취향 테스트',
+    subtitle: '질문 기반 맞춤 향기 추천',
+    href: '/find-my-scent/taste-test',
+  },
+  HEALTH: {
+    icon: '/wellness.svg',
+    title: '웰니스 케어 진단',
+    subtitle: '건강 정보 기반 맞춤 향기 추천',
+    href: '/find-my-scent/wellness',
+  },
+  AI: {
+    icon: '/ai.svg',
+    title: 'AI 비주얼 분석',
+    subtitle: '사진 업로드 기반 AI 향기 추천',
+    href: '/find-my-scent/ai-visual',
+  },
+}
+
+const ALL_TYPES: ResultPageType[] = ['PREFERENCE', 'HEALTH', 'AI']
+
+export type OtherTestModalProps = {
+  isOpen: boolean
+  onClose: () => void
+  /** 현재 결과 페이지 유형 — 이 유형은 목록에서 제외 */
+  currentResultType: ResultPageType
+}
+
+const styles = {
+  overlay:
+    'fixed inset-0 z-[100] flex items-center justify-center bg-black/40 px-4',
+  modal: 'w-full max-w-md rounded-2xl bg-white p-6 shadow-lg',
+  header: 'relative mb-5',
+  closeBtn:
+    'absolute -right-1 -top-1 flex h-8 w-8 items-center justify-center rounded-full text-neutral-500 transition-colors hover:bg-neutral-100 hover:text-black',
+  title: 'text-xl font-bold text-[var(--color-black-primary)]',
+  subtitle: 'mt-1 text-sm text-neutral-600',
+  list: 'flex flex-col gap-3',
+} as const
+
+export function OtherTestModal({
+  isOpen,
+  onClose,
+  currentResultType,
+}: OtherTestModalProps) {
+  if (!isOpen) return null
+
+  const options = ALL_TYPES.filter((t) => t !== currentResultType).map(
+    (type) => OTHER_TEST_CONFIG[type]
+  )
+
+  return (
+    <div
+      className={styles.overlay}
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="other-test-modal-title"
+    >
+      <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+        <header className={styles.header}>
+          <button
+            type="button"
+            onClick={onClose}
+            className={styles.closeBtn}
+            aria-label="닫기"
+          >
+            <Image
+              src="/modalClose.svg"
+              alt=""
+              width={20}
+              height={20}
+              unoptimized
+            />
+          </button>
+          <h2 id="other-test-modal-title" className={styles.title}>
+            다른 테스트 하러가기
+          </h2>
+          <p className={styles.subtitle}>관심 있는 테스트를 선택해주세요</p>
+        </header>
+        <div className={styles.list}>
+          {options.map((opt) => (
+            <OtherTestCard
+              key={opt.href}
+              iconSrc={opt.icon}
+              title={opt.title}
+              subtitle={opt.subtitle}
+              href={opt.href}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/find-my-scent/_components/ProfilingTestPage.tsx
+++ b/src/app/find-my-scent/_components/ProfilingTestPage.tsx
@@ -9,7 +9,6 @@ import { useErrorPopup } from '../_hooks/useErrorPopup'
 import type { TestType } from '../_types'
 
 const styles = {
-  loadingText: 'text-neutral-500',
   emptyText: 'text-neutral-500',
   retryBtn:
     'mt-4 rounded-xl bg-[var(--color-black-primary)] px-6 py-3 text-sm font-medium text-white transition-opacity hover:opacity-90',
@@ -19,14 +18,6 @@ export function ProfilingTestPage({ testType }: { testType: TestType }) {
   const { questions, isLoading, error, refetch } = useProfilingForm(testType)
   const { isOpen: showErrorPopup, close: closeErrorPopup } =
     useErrorPopup(error)
-
-  if (isLoading) {
-    return (
-      <PageCenter>
-        <p className={styles.loadingText}>질문을 불러오는 중...</p>
-      </PageCenter>
-    )
-  }
 
   if (error) {
     return (

--- a/src/app/find-my-scent/_components/QuizView.tsx
+++ b/src/app/find-my-scent/_components/QuizView.tsx
@@ -1,21 +1,22 @@
 'use client'
 
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
-/** 퀴즈 본문: 헤더·진행바·질문카드·이전/다음 푸터 (useQuizStep 사용) */
 import type { QuizQuestion, TestType } from '../_types'
 import { useQuizStep } from '../_hooks'
-
-const RESULT_PATH: Record<TestType, string> = {
-  PREFERENCE: '/find-my-scent/taste-test/result',
-  HEALTH: '/find-my-scent/wellness/result',
-}
+import { buildSubmitPayload, submitProfiling } from '../_api/profilingClient'
+import { ErrorFeedbackModal } from '@/components/common/ErrorFeedback'
 import { AlertModal } from '@/components/common/Modal/AlertModal'
 import { ModalPortal } from '@/components/common/Modal/ModalPortal'
 import { TestQuizHeader } from './TestQuizHeader'
 import { TestProgressBar } from './TestProgressBar'
 import { TestQuestionCard } from './TestQuestionCard'
 import { TestQuizFooter } from './TestQuizFooter'
+
+const RESULT_PATH: Record<TestType, string> = {
+  PREFERENCE: '/find-my-scent/taste-test/result',
+  HEALTH: '/find-my-scent/wellness/result',
+}
 
 const MIN_SELECTION_WARNING_MESSAGE =
   '다중선택 문제유형은 지문을 최소 2개이상 선택해야 합니다'
@@ -41,6 +42,7 @@ export function QuizView({
     currentNumber,
     total,
     selectedIds,
+    answers,
     canGoNext,
     isFirst,
     isLast,
@@ -51,10 +53,36 @@ export function QuizView({
     handleNext,
   } = useQuizStep(questions)
   const router = useRouter()
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [submitError, setSubmitError] = useState<Error | null>(null)
 
-  const handleNextOrSubmit = () => {
+  const handleNextOrSubmit = async () => {
     if (isLast) {
-      router.push(RESULT_PATH[testType])
+      setIsSubmitting(true)
+      setSubmitError(null)
+      try {
+        const payload = buildSubmitPayload(
+          questions,
+          answers,
+          testType,
+          'DIFFUSER'
+        )
+        const res = await submitProfiling(payload)
+        if (!res.success || !res.data?.result_id) {
+          setSubmitError(
+            new Error(
+              (res as { error?: { message?: string } }).error?.message ??
+                '제출에 실패했습니다.'
+            )
+          )
+          return
+        }
+        router.push(`${RESULT_PATH[testType]}?result_id=${res.data.result_id}`)
+      } catch (err) {
+        setSubmitError(err instanceof Error ? err : new Error(String(err)))
+      } finally {
+        setIsSubmitting(false)
+      }
       return
     }
     handleNext()
@@ -90,11 +118,20 @@ export function QuizView({
             isFirst={isFirst}
             isLast={isLast}
             canGoNext={canGoNext}
+            isSubmitting={isSubmitting}
             onPrev={handlePrev}
             onNext={handleNextOrSubmit}
           />
         </div>
       </div>
+
+      {submitError && (
+        <ErrorFeedbackModal
+          message={submitError.message}
+          isOpen
+          onClose={() => setSubmitError(null)}
+        />
+      )}
 
       {showMinSelectionWarning && (
         <ModalPortal>

--- a/src/app/find-my-scent/_components/ResultContentBox.tsx
+++ b/src/app/find-my-scent/_components/ResultContentBox.tsx
@@ -1,4 +1,7 @@
+'use client'
+
 /** 결과 페이지 컨텐츠 박스 — 상단 로고, 중간(이미지/상품명/라벨·향조·노트·설명), 하단 버튼 3개 */
+import { useState } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
 import {
@@ -6,6 +9,9 @@ import {
   ACCORD_LABEL_PILL_MD_CLASS,
   SCENT_NOTE_PILL_CLASS,
 } from '@/constants/accordLabelStyles'
+import { ModalPortal } from '@/components/common/Modal/ModalPortal'
+import type { ResultPageType } from '../_types'
+import { OtherTestModal } from './OtherTestModal'
 
 export type ResultContentBoxProps = {
   /** 중간 영역 — API 연동 후 전달 */
@@ -22,7 +28,8 @@ export type ResultContentBoxProps = {
   primaryButtonHref: string
   primaryButtonLabel?: string
   retestButtonHref: string
-  otherTestButtonHref: string
+  /** 현재 결과 페이지 유형 — 다른 테스트 하러가기 클릭 시 모달에서 제외 */
+  resultType: ResultPageType
 }
 
 const DEFAULT_PRIMARY_LABEL = '추천한 향기와 어울리는 연관 추천 상품 보러가기 →'
@@ -65,127 +72,145 @@ export function ResultContentBox({
   primaryButtonHref,
   primaryButtonLabel = DEFAULT_PRIMARY_LABEL,
   retestButtonHref,
-  otherTestButtonHref,
+  resultType,
 }: ResultContentBoxProps) {
-  return (
-    <article className={styles.card}>
-      <div className={styles.topRow}>
-        <div className="relative h-12 w-12 shrink-0">
-          <Image
-            src="/resultContainer.svg"
-            alt=""
-            fill
-            className="object-contain"
-            unoptimized
-          />
-        </div>
-        <div>
-          <h2 className={styles.reportTitle}>분석 리포트</h2>
-          <p className={styles.reportSub}>AI 기반 향기 프로파일링</p>
-        </div>
-      </div>
+  const [isOtherTestModalOpen, setIsOtherTestModalOpen] = useState(false)
 
-      {/* 중간: 좌측 이미지 영역(배경+라벨+상품명), 우측 향조/노트/설명 */}
-      <div className={styles.middle}>
-        <div className={styles.left}>
-          <div
-            className={styles.imageWrap}
-            style={
-              productImageUrl
-                ? { backgroundImage: `url(${productImageUrl})` }
-                : undefined
-            }
-          >
-            <div className={styles.labelsTopLeft}>
-              {scentTypeLabel && (
-                <span className={styles.labelScent}>{scentTypeLabel}</span>
-              )}
-              {showRecommendLabel && (
-                <Image
-                  src="/Recommendation.svg"
-                  alt="추천"
-                  width={69}
-                  height={34}
-                  className="h-8 w-auto"
-                  unoptimized
-                />
-              )}
-            </div>
-            <p className={styles.productNameOverlay}>{productName}</p>
+  return (
+    <>
+      <article className={styles.card}>
+        <div className={styles.topRow}>
+          <div className="relative h-12 w-12 shrink-0">
+            <Image
+              src="/resultContainer.svg"
+              alt=""
+              fill
+              className="object-contain"
+              unoptimized
+            />
+          </div>
+          <div>
+            <h2 className={styles.reportTitle}>분석 리포트</h2>
+            <p className={styles.reportSub}>AI 기반 향기 프로파일링</p>
           </div>
         </div>
 
-        <div className={styles.right}>
-          <section>
-            <h3 className={styles.sectionTitle}>향조 타입</h3>
-            <div className={styles.tagRow}>
-              {scentTypeTags.length > 0 ? (
-                getAccordLabels(
-                  scentTypeTags.map((id) => id.toLowerCase())
-                ).map(({ id, label, style }) => (
-                  <span
-                    key={id}
-                    className={ACCORD_LABEL_PILL_MD_CLASS}
-                    style={{
-                      backgroundColor: style.bg,
-                      borderColor: style.border,
-                      color: style.text,
-                      borderWidth: 1,
-                    }}
-                  >
-                    {label}
-                  </span>
-                ))
-              ) : (
-                <span className="text-sm text-neutral-400">—</span>
-              )}
-            </div>
-          </section>
-          <section>
-            <h3 className={styles.sectionTitle}>향기 노트</h3>
-            <div className={styles.tagRow}>
-              {noteTags.length > 0 ? (
-                noteTags.map((note) => (
-                  <span key={note} className={SCENT_NOTE_PILL_CLASS}>
-                    {note}
-                  </span>
-                ))
-              ) : (
-                <span className="text-sm text-neutral-400">—</span>
-              )}
-            </div>
-          </section>
-          <section>
+        {/* 중간: 좌측 이미지 영역(배경+라벨+상품명), 우측 향조/노트/설명 */}
+        <div className={styles.middle}>
+          <div className={styles.left}>
             <div
-              className={`${styles.sectionTitle} ${styles.descriptionHeader}`}
-            ></div>
-            <div className={styles.descriptionBox}>
-              <Image
-                src="/details.svg"
-                alt=""
-                width={120}
-                height={50}
-                className="shrink-0"
-                unoptimized
-              />
-              {description || '추천 조합 설명이 여기에 표시됩니다.'}
+              className={styles.imageWrap}
+              style={
+                productImageUrl
+                  ? { backgroundImage: `url(${productImageUrl})` }
+                  : undefined
+              }
+            >
+              <div className={styles.labelsTopLeft}>
+                {scentTypeLabel && (
+                  <span className={styles.labelScent}>{scentTypeLabel}</span>
+                )}
+                {showRecommendLabel && (
+                  <Image
+                    src="/Recommendation.svg"
+                    alt="추천"
+                    width={69}
+                    height={34}
+                    className="h-8 w-auto"
+                    unoptimized
+                  />
+                )}
+              </div>
+              <p className={styles.productNameOverlay}>{productName}</p>
             </div>
-          </section>
-        </div>
-      </div>
+          </div>
 
-      {/* 하단 버튼 3개 */}
-      <div className={styles.buttons}>
-        <Link href={primaryButtonHref} className={styles.btnPrimary}>
-          {primaryButtonLabel}
-        </Link>
-        <Link href={retestButtonHref} className={styles.btnSecondary}>
-          테스트 다시하기
-        </Link>
-        <Link href={otherTestButtonHref} className={styles.btnSecondary}>
-          다른 테스트 하러가기
-        </Link>
-      </div>
-    </article>
+          <div className={styles.right}>
+            <section>
+              <h3 className={styles.sectionTitle}>향조 타입</h3>
+              <div className={styles.tagRow}>
+                {scentTypeTags.length > 0 ? (
+                  getAccordLabels(
+                    scentTypeTags.map((id) => id.toLowerCase())
+                  ).map(({ id, label, style }) => (
+                    <span
+                      key={id}
+                      className={ACCORD_LABEL_PILL_MD_CLASS}
+                      style={{
+                        backgroundColor: style.bg,
+                        borderColor: style.border,
+                        color: style.text,
+                        borderWidth: 1,
+                      }}
+                    >
+                      {label}
+                    </span>
+                  ))
+                ) : (
+                  <span className="text-sm text-neutral-400">—</span>
+                )}
+              </div>
+            </section>
+            <section>
+              <h3 className={styles.sectionTitle}>향기 노트</h3>
+              <div className={styles.tagRow}>
+                {noteTags.length > 0 ? (
+                  noteTags.map((note) => (
+                    <span key={note} className={SCENT_NOTE_PILL_CLASS}>
+                      {note}
+                    </span>
+                  ))
+                ) : (
+                  <span className="text-sm text-neutral-400">—</span>
+                )}
+              </div>
+            </section>
+            <section>
+              <div
+                className={`${styles.sectionTitle} ${styles.descriptionHeader}`}
+              ></div>
+              <div className={styles.descriptionBox}>
+                <Image
+                  src="/details.svg"
+                  alt=""
+                  width={120}
+                  height={50}
+                  className="shrink-0"
+                  unoptimized
+                />
+                {description || '추천 조합 설명이 여기에 표시됩니다.'}
+              </div>
+            </section>
+          </div>
+        </div>
+
+        {/* 하단 버튼 3개 */}
+        <div className={styles.buttons}>
+          <Link href={primaryButtonHref} className={styles.btnPrimary}>
+            {primaryButtonLabel}
+          </Link>
+          <Link href={retestButtonHref} className={styles.btnSecondary}>
+            테스트 다시하기
+          </Link>
+          <button
+            type="button"
+            onClick={() => setIsOtherTestModalOpen(true)}
+            className={styles.btnSecondary}
+          >
+            다른 테스트 하러가기
+          </button>
+        </div>
+      </article>
+
+      {isOtherTestModalOpen && (
+        <ModalPortal>
+          <OtherTestModal
+            isOpen={isOtherTestModalOpen}
+            onClose={() => setIsOtherTestModalOpen(false)}
+            currentResultType={resultType}
+          />
+        </ModalPortal>
+      )}
+    </>
   )
 }

--- a/src/app/find-my-scent/_components/ResultPageWithAnalyzing.tsx
+++ b/src/app/find-my-scent/_components/ResultPageWithAnalyzing.tsx
@@ -11,8 +11,8 @@ const DEFAULT_ANALYZING_MS = 3000
 
 type ResultPageWithAnalyzingProps = {
   resultType: ResultPageType
-  /** API 결과로 채운 컨텐츠 박스 props (없으면 더미 표시) */
-  contentBoxProps?: Omit<
+  /** 컨텐츠 박스 props (API 결과 또는 목데이터) */
+  contentBoxProps: Omit<
     ComponentProps<typeof TestResultPage>,
     'resultType'
   >['contentBoxProps']

--- a/src/app/find-my-scent/_components/ResultPageWithAnalyzing.tsx
+++ b/src/app/find-my-scent/_components/ResultPageWithAnalyzing.tsx
@@ -2,6 +2,7 @@
 
 /** 결과 페이지: 분석 중 UI 표시 후 결과 콘텐츠 표시 */
 import { useState, useEffect } from 'react'
+import type { ComponentProps } from 'react'
 import { AnalyzingUI } from '@/components/common/AnalyzingUI'
 import { TestResultPage } from './TestResultPage'
 import type { ResultPageType } from '../_types'
@@ -10,12 +11,17 @@ const DEFAULT_ANALYZING_MS = 3000
 
 type ResultPageWithAnalyzingProps = {
   resultType: ResultPageType
-
+  /** API 결과로 채운 컨텐츠 박스 props (없으면 더미 표시) */
+  contentBoxProps?: Omit<
+    ComponentProps<typeof TestResultPage>,
+    'resultType'
+  >['contentBoxProps']
   analyzingDurationMs?: number
 }
 
 export function ResultPageWithAnalyzing({
   resultType,
+  contentBoxProps,
   analyzingDurationMs = DEFAULT_ANALYZING_MS,
 }: ResultPageWithAnalyzingProps) {
   const [isAnalyzing, setIsAnalyzing] = useState(true)
@@ -29,5 +35,7 @@ export function ResultPageWithAnalyzing({
     return <AnalyzingUI />
   }
 
-  return <TestResultPage resultType={resultType} />
+  return (
+    <TestResultPage resultType={resultType} contentBoxProps={contentBoxProps} />
+  )
 }

--- a/src/app/find-my-scent/_components/TestQuizFooter.tsx
+++ b/src/app/find-my-scent/_components/TestQuizFooter.tsx
@@ -4,7 +4,8 @@ import { cn } from '@/lib/cn'
 type TestQuizFooterProps = {
   isFirst: boolean
   isLast: boolean
-  canGoNext: boolean // 다음 질문으로 이동 가능 여부
+  canGoNext: boolean
+  isSubmitting?: boolean
   onPrev: () => void
   onNext: () => void
 }
@@ -23,15 +24,17 @@ export function TestQuizFooter({
   isFirst,
   isLast,
   canGoNext,
+  isSubmitting = false,
   onPrev,
   onNext,
 }: TestQuizFooterProps) {
   const prevClassName = cn(styles.prev, isFirst && styles.prevHidden)
+  const nextDisabled = !canGoNext || isSubmitting
   const nextClassName = cn(
     styles.next,
-    canGoNext ? styles.nextActive : styles.nextInactive
+    nextDisabled ? styles.nextInactive : styles.nextActive
   )
-  const nextLabel = isLast ? '결과 보기' : '다음'
+  const nextLabel = isSubmitting ? '제출 중...' : isLast ? '결과 보기' : '다음'
 
   return (
     <footer className={styles.wrap}>
@@ -41,7 +44,7 @@ export function TestQuizFooter({
       <button
         type="button"
         onClick={onNext}
-        disabled={!canGoNext} //
+        disabled={nextDisabled}
         className={nextClassName}
       >
         {nextLabel} <span className={styles.arrow}>›</span>

--- a/src/app/find-my-scent/_components/TestResultPage.tsx
+++ b/src/app/find-my-scent/_components/TestResultPage.tsx
@@ -29,19 +29,6 @@ const RESULT_PATHS: Record<ResultPageType, { retest: string }> = {
   AI: { retest: '/find-my-scent/ai-visual' },
 }
 
-/** 컨텐츠 박스 더미 데이터 (API 연동 전 미리보기용) */
-const DUMMY_CONTENT_BOX = {
-  productImageUrl: '/img/17.svg',
-  productName: '오리엔탈 럭셔리 조합',
-  scentTypeLabel: 'Oriental',
-  showRecommendLabel: true,
-  scentTypeTags: ['oriental'] as string[],
-  noteTags: ['#숙면', '#집중', '#기분전환', '#로맨틱'] as string[],
-  description:
-    '깊고 신비로운 오리엔탈 조합 향기가 당신만의 개성을 표현합니다. 은은한 스파이시 노트와 우디 베이스가 조화를 이루어 특별한 순간을 더해줍니다.',
-  primaryButtonHref: 'https://www.coupang.com/',
-}
-
 const styles = {
   wrap: 'min-h-screen bg-[var(--background-light-bg)] px-4 py-8 pb-50',
   inner: 'mx-auto w-full max-w-[1200px]',
@@ -54,8 +41,8 @@ const styles = {
 
 export type TestResultPageProps = {
   resultType: ResultPageType
-  /** 컨텐츠 박스에 전달할 props (API 연동 시 primaryButtonHref = recommended_products[0].purchase_url) */
-  contentBoxProps?: Omit<
+  /** 컨텐츠 박스 props (API 결과 또는 목데이터) */
+  contentBoxProps: Omit<
     ComponentProps<typeof ResultContentBox>,
     'retestButtonHref' | 'resultType'
   >
@@ -89,7 +76,6 @@ export function TestResultPage({
           <ResultContentBox
             retestButtonHref={retest}
             resultType={resultType}
-            {...DUMMY_CONTENT_BOX}
             {...contentBoxProps}
           />
         </div>

--- a/src/app/find-my-scent/_components/TestResultPage.tsx
+++ b/src/app/find-my-scent/_components/TestResultPage.tsx
@@ -22,23 +22,11 @@ const RESULT_HEADER_CONFIG: Record<
   },
 }
 
-/** 결과 유형별 재테스트/다른 테스트 경로 */
-const RESULT_PATHS: Record<
-  ResultPageType,
-  { retest: string; otherTest: string }
-> = {
-  PREFERENCE: {
-    retest: '/find-my-scent/taste-test',
-    otherTest: '/find-my-scent/wellness',
-  },
-  HEALTH: {
-    retest: '/find-my-scent/wellness',
-    otherTest: '/find-my-scent/taste-test',
-  },
-  AI: {
-    retest: '/find-my-scent/ai-visual',
-    otherTest: '/find-my-scent/taste-test',
-  },
+/** 결과 유형별 재테스트 경로 (다른 테스트는 모달에서 선택) */
+const RESULT_PATHS: Record<ResultPageType, { retest: string }> = {
+  PREFERENCE: { retest: '/find-my-scent/taste-test' },
+  HEALTH: { retest: '/find-my-scent/wellness' },
+  AI: { retest: '/find-my-scent/ai-visual' },
 }
 
 /** 컨텐츠 박스 더미 데이터 (API 연동 전 미리보기용) */
@@ -51,6 +39,7 @@ const DUMMY_CONTENT_BOX = {
   noteTags: ['#숙면', '#집중', '#기분전환', '#로맨틱'] as string[],
   description:
     '깊고 신비로운 오리엔탈 조합 향기가 당신만의 개성을 표현합니다. 은은한 스파이시 노트와 우디 베이스가 조화를 이루어 특별한 순간을 더해줍니다.',
+  primaryButtonHref: 'https://www.coupang.com/',
 }
 
 const styles = {
@@ -65,10 +54,10 @@ const styles = {
 
 export type TestResultPageProps = {
   resultType: ResultPageType
-  /** 컨텐츠 박스에 전달할 props (API 연동 시 사용) */
+  /** 컨텐츠 박스에 전달할 props (API 연동 시 primaryButtonHref = recommended_products[0].purchase_url) */
   contentBoxProps?: Omit<
     ComponentProps<typeof ResultContentBox>,
-    'primaryButtonHref' | 'retestButtonHref' | 'otherTestButtonHref'
+    'retestButtonHref' | 'resultType'
   >
 }
 
@@ -77,7 +66,7 @@ export function TestResultPage({
   contentBoxProps,
 }: TestResultPageProps) {
   const { title, subtitle } = RESULT_HEADER_CONFIG[resultType]
-  const { retest, otherTest } = RESULT_PATHS[resultType]
+  const { retest } = RESULT_PATHS[resultType]
 
   return (
     <div className={styles.wrap}>
@@ -98,9 +87,8 @@ export function TestResultPage({
 
         <div className={styles.content}>
           <ResultContentBox
-            primaryButtonHref="/products/combo"
             retestButtonHref={retest}
-            otherTestButtonHref={otherTest}
+            resultType={resultType}
             {...DUMMY_CONTENT_BOX}
             {...contentBoxProps}
           />

--- a/src/app/find-my-scent/_hooks/useQuizStep.ts
+++ b/src/app/find-my-scent/_hooks/useQuizStep.ts
@@ -1,11 +1,10 @@
 'use client'
 import { useState } from 'react'
-import type { QuizQuestion } from '../_types'
+import type { AnswersState, QuizQuestion } from '../_types'
 
 /** 퀴즈 단계·답변 상태 + 이전/다음/선택 토글 (단일·다중선택 규칙 적용) */
 
-// 답변 상태
-export type AnswersState = Record<string, string[]>
+export type { AnswersState }
 
 // 퀴즈 단계·답변 상태 + 이전/다음/선택 토글 (단일·다중선택 규칙 적용)
 export function useQuizStep(questions: QuizQuestion[]) {
@@ -65,6 +64,7 @@ export function useQuizStep(questions: QuizQuestion[]) {
     currentNumber: step + 1,
     total,
     selectedIds,
+    answers,
     canGoNext,
     isFirst,
     isLast,

--- a/src/app/find-my-scent/_types/index.ts
+++ b/src/app/find-my-scent/_types/index.ts
@@ -37,13 +37,60 @@ export type ProfilingFormResponse = {
   data: ProfilingForm
 }
 
-/** QuizView에서 쓰는 질문 형태 */
+/** QuizView에서 쓰는 질문 형태 (제출 시 question_key, answer_option_keys 매핑용) */
 export type QuizQuestion = {
   id: string
+  /** API 제출용 (POST submit) */
+  questionKey?: string
   text: string
   required: boolean
   questionType: 'SINGLE' | 'MULTI'
-  options: { id: string; text: string }[]
+  options: {
+    id: string
+    text: string
+    /** API 제출용 */ answerOptionKey?: string
+  }[]
+}
+
+/** POST /api/v1/profilings/submit 요청 */
+export type ProfilingSubmitRequest = {
+  profiling_type: ProfilingType
+  product_type: 'DIFFUSER' | 'PERFUME'
+  responses: { question_key: string; answer_option_keys: string[] }[]
+}
+
+/** POST /api/v1/profilings/submit 응답 */
+export type ProfilingSubmitResponse = {
+  success: boolean
+  data?: { result_id: number; message: string }
+  error?: { code: string; message: string; details?: Record<string, unknown> }
+}
+
+/** GET /api/v1/profilings/results/{result_id} 응답 - recommended_blend 등 */
+export type ProfilingResultBlend = {
+  name: string
+  image_url: string
+  description: string
+  contained_elements: {
+    name: string
+    category: { kr: string; en: string }
+  }[]
+}
+
+export type ProfilingResultDetail = {
+  id: number
+  input_data_type: string
+  product_type: string
+  input_data_summary: string
+  recommended_blend: ProfilingResultBlend
+  recommended_products: { purchase_url: string }[]
+  created_at: string
+}
+
+export type ProfilingResultDetailResponse = {
+  success: boolean
+  data?: ProfilingResultDetail
+  error?: { code: string; message: string; details?: Record<string, unknown> }
 }
 
 /** ProfilingType과 동일 (UI용 alias) */
@@ -54,3 +101,6 @@ export type ResultPageType = 'PREFERENCE' | 'HEALTH' | 'AI'
 
 /** 질문 유형 - 고정 */
 export type QuestionType = 'SINGLE' | 'MULTI'
+
+/** 퀴즈 답변 상태 (question id → 선택된 option id[]) */
+export type AnswersState = Record<string, string[]>

--- a/src/app/find-my-scent/ai-visual/result/page.tsx
+++ b/src/app/find-my-scent/ai-visual/result/page.tsx
@@ -1,6 +1,16 @@
-/** AI 조합 향기 분석 결과 페이지 — 분석 중 UI 후 결과 표시 */
+/** AI 조합 향기 분석 결과 페이지 — API 미연동 시 목데이터 표시 */
+import { resultDetailToContentBoxProps } from '../../_api/profilingClient'
 import { ResultPageWithAnalyzing } from '../../_components/ResultPageWithAnalyzing'
+import { mockProfilingResultDetail } from '@/mocks/data/profilingResults'
 
 export default function AIResultPage() {
-  return <ResultPageWithAnalyzing resultType="AI" />
+  const contentBoxProps = resultDetailToContentBoxProps(
+    mockProfilingResultDetail
+  )
+  return (
+    <ResultPageWithAnalyzing
+      resultType="AI"
+      contentBoxProps={contentBoxProps}
+    />
+  )
 }

--- a/src/app/find-my-scent/taste-test/loading.tsx
+++ b/src/app/find-my-scent/taste-test/loading.tsx
@@ -1,10 +1,10 @@
 import { PageCenter } from '@/components/common/PageCenter'
 
-/** 취향 테스트 질문 로딩 중 (Suspense fallback) */
+/** 취향 테스트 로딩 (Suspense fallback) */
 export default function TasteTestLoading() {
   return (
     <PageCenter>
-      <p className="text-neutral-500">질문을 불러오는 중...</p>
+      <div className="h-8 w-8 animate-spin rounded-full border-2 border-neutral-300 border-t-[var(--color-black-primary)]" />
     </PageCenter>
   )
 }

--- a/src/app/find-my-scent/taste-test/result/page.tsx
+++ b/src/app/find-my-scent/taste-test/result/page.tsx
@@ -1,6 +1,34 @@
-/** 취향 테스트 결과 페이지 — 분석 중 UI 후 결과 표시 */
+/** 취향 테스트 결과 페이지 — result_id 있으면 서버에서 조회 후 표시 */
+import {
+  fetchProfilingResult,
+  resultDetailToContentBoxProps,
+} from '../../_api/profilingClient'
 import { ResultPageWithAnalyzing } from '../../_components/ResultPageWithAnalyzing'
 
-export default function TasteTestResultPage() {
-  return <ResultPageWithAnalyzing resultType="PREFERENCE" />
+type PageProps = { searchParams: Promise<{ result_id?: string }> }
+
+export default async function TasteTestResultPage({ searchParams }: PageProps) {
+  const params = await searchParams
+  const resultId = params.result_id ? Number(params.result_id) : null
+
+  let contentBoxProps:
+    | ReturnType<typeof resultDetailToContentBoxProps>
+    | undefined
+  if (resultId != null && Number.isInteger(resultId) && resultId > 0) {
+    try {
+      const res = await fetchProfilingResult(resultId)
+      if (res.success && res.data) {
+        contentBoxProps = resultDetailToContentBoxProps(res.data)
+      }
+    } catch {
+      // fallback: contentBoxProps 없이 더미로 표시
+    }
+  }
+
+  return (
+    <ResultPageWithAnalyzing
+      resultType="PREFERENCE"
+      contentBoxProps={contentBoxProps}
+    />
+  )
 }

--- a/src/app/find-my-scent/taste-test/result/page.tsx
+++ b/src/app/find-my-scent/taste-test/result/page.tsx
@@ -1,9 +1,10 @@
-/** 취향 테스트 결과 페이지 — result_id 있으면 서버에서 조회 후 표시 */
+/** 취향 테스트 결과 페이지 — result_id 있으면 API 조회, 없거나 실패 시 목데이터 */
 import {
   fetchProfilingResult,
   resultDetailToContentBoxProps,
 } from '../../_api/profilingClient'
 import { ResultPageWithAnalyzing } from '../../_components/ResultPageWithAnalyzing'
+import { mockProfilingResultDetail } from '@/mocks/data/profilingResults'
 
 type PageProps = { searchParams: Promise<{ result_id?: string }> }
 
@@ -11,18 +12,22 @@ export default async function TasteTestResultPage({ searchParams }: PageProps) {
   const params = await searchParams
   const resultId = params.result_id ? Number(params.result_id) : null
 
-  let contentBoxProps:
-    | ReturnType<typeof resultDetailToContentBoxProps>
-    | undefined
+  let contentBoxProps: ReturnType<typeof resultDetailToContentBoxProps>
   if (resultId != null && Number.isInteger(resultId) && resultId > 0) {
     try {
       const res = await fetchProfilingResult(resultId)
       if (res.success && res.data) {
         contentBoxProps = resultDetailToContentBoxProps(res.data)
+      } else {
+        contentBoxProps = resultDetailToContentBoxProps(
+          mockProfilingResultDetail
+        )
       }
     } catch {
-      // fallback: contentBoxProps 없이 더미로 표시
+      contentBoxProps = resultDetailToContentBoxProps(mockProfilingResultDetail)
     }
+  } else {
+    contentBoxProps = resultDetailToContentBoxProps(mockProfilingResultDetail)
   }
 
   return (

--- a/src/app/find-my-scent/wellness/loading.tsx
+++ b/src/app/find-my-scent/wellness/loading.tsx
@@ -1,10 +1,10 @@
 import { PageCenter } from '@/components/common/PageCenter'
 
-/** 건강 테스트 질문 로딩 중 (Suspense fallback) */
+/** 건강 테스트 로딩 (Suspense fallback) */
 export default function WellnessLoading() {
   return (
     <PageCenter>
-      <p className="text-neutral-500">질문을 불러오는 중...</p>
+      <div className="h-8 w-8 animate-spin rounded-full border-2 border-neutral-300 border-t-[var(--color-black-primary)]" />
     </PageCenter>
   )
 }

--- a/src/app/find-my-scent/wellness/result/page.tsx
+++ b/src/app/find-my-scent/wellness/result/page.tsx
@@ -1,9 +1,10 @@
-/** 웰니스 테스트 결과 페이지 — result_id 있으면 서버에서 조회 후 표시 */
+/** 웰니스 테스트 결과 페이지 — result_id 있으면 API 조회, 없거나 실패 시 목데이터 */
 import {
   fetchProfilingResult,
   resultDetailToContentBoxProps,
 } from '../../_api/profilingClient'
 import { ResultPageWithAnalyzing } from '../../_components/ResultPageWithAnalyzing'
+import { mockProfilingResultDetail } from '@/mocks/data/profilingResults'
 
 type PageProps = { searchParams: Promise<{ result_id?: string }> }
 
@@ -11,18 +12,22 @@ export default async function WellnessResultPage({ searchParams }: PageProps) {
   const params = await searchParams
   const resultId = params.result_id ? Number(params.result_id) : null
 
-  let contentBoxProps:
-    | ReturnType<typeof resultDetailToContentBoxProps>
-    | undefined
+  let contentBoxProps: ReturnType<typeof resultDetailToContentBoxProps>
   if (resultId != null && Number.isInteger(resultId) && resultId > 0) {
     try {
       const res = await fetchProfilingResult(resultId)
       if (res.success && res.data) {
         contentBoxProps = resultDetailToContentBoxProps(res.data)
+      } else {
+        contentBoxProps = resultDetailToContentBoxProps(
+          mockProfilingResultDetail
+        )
       }
     } catch {
-      // fallback: contentBoxProps 없이 더미로 표시
+      contentBoxProps = resultDetailToContentBoxProps(mockProfilingResultDetail)
     }
+  } else {
+    contentBoxProps = resultDetailToContentBoxProps(mockProfilingResultDetail)
   }
 
   return (

--- a/src/app/find-my-scent/wellness/result/page.tsx
+++ b/src/app/find-my-scent/wellness/result/page.tsx
@@ -1,6 +1,34 @@
-/** 웰니스 테스트 결과 페이지 — 분석 중 UI 후 결과 표시 */
+/** 웰니스 테스트 결과 페이지 — result_id 있으면 서버에서 조회 후 표시 */
+import {
+  fetchProfilingResult,
+  resultDetailToContentBoxProps,
+} from '../../_api/profilingClient'
 import { ResultPageWithAnalyzing } from '../../_components/ResultPageWithAnalyzing'
 
-export default function WellnessResultPage() {
-  return <ResultPageWithAnalyzing resultType="HEALTH" />
+type PageProps = { searchParams: Promise<{ result_id?: string }> }
+
+export default async function WellnessResultPage({ searchParams }: PageProps) {
+  const params = await searchParams
+  const resultId = params.result_id ? Number(params.result_id) : null
+
+  let contentBoxProps:
+    | ReturnType<typeof resultDetailToContentBoxProps>
+    | undefined
+  if (resultId != null && Number.isInteger(resultId) && resultId > 0) {
+    try {
+      const res = await fetchProfilingResult(resultId)
+      if (res.success && res.data) {
+        contentBoxProps = resultDetailToContentBoxProps(res.data)
+      }
+    } catch {
+      // fallback: contentBoxProps 없이 더미로 표시
+    }
+  }
+
+  return (
+    <ResultPageWithAnalyzing
+      resultType="HEALTH"
+      contentBoxProps={contentBoxProps}
+    />
+  )
 }

--- a/src/mocks/data/profilingForms.ts
+++ b/src/mocks/data/profilingForms.ts
@@ -191,5 +191,88 @@ export const mockProfilingFormHEALTH: ProfilingForm = {
         },
       ],
     },
+    {
+      id: 103,
+      question_key: 'stress_level',
+      question_text: '요즘 스트레스 수준은 어느 정도인가요?',
+      selection_type: 'SINGLE',
+      is_required: true,
+      options: [
+        { id: 208, answer_option_key: 'low', answer_option_text: '낮음' },
+        { id: 209, answer_option_key: 'medium', answer_option_text: '보통' },
+        { id: 210, answer_option_key: 'high', answer_option_text: '높음' },
+      ],
+    },
+    {
+      id: 104,
+      question_key: 'usage_place',
+      question_text: '아로마를 주로 사용할 공간은?',
+      selection_type: 'MULTI',
+      is_required: false,
+      options: [
+        { id: 211, answer_option_key: 'bedroom', answer_option_text: '침실' },
+        { id: 212, answer_option_key: 'living', answer_option_text: '거실' },
+        {
+          id: 213,
+          answer_option_key: 'office',
+          answer_option_text: '업무 공간',
+        },
+        { id: 214, answer_option_key: 'bathroom', answer_option_text: '욕실' },
+      ],
+    },
+    {
+      id: 105,
+      question_key: 'scent_preference',
+      question_text: '선호하는 웰니스 향 계열이 있나요?',
+      selection_type: 'SINGLE',
+      is_required: true,
+      options: [
+        {
+          id: 215,
+          answer_option_key: 'lavender',
+          answer_option_text: '라벤더 (진정)',
+        },
+        {
+          id: 216,
+          answer_option_key: 'citrus',
+          answer_option_text: '시트러스 (상쾌)',
+        },
+        {
+          id: 217,
+          answer_option_key: 'woody',
+          answer_option_text: '우디 (안정)',
+        },
+        {
+          id: 218,
+          answer_option_key: 'unknown',
+          answer_option_text: '잘 모르겠음',
+        },
+      ],
+    },
+    {
+      id: 106,
+      question_key: 'goal',
+      question_text: '아로마 테라피로 가장 얻고 싶은 효과는?',
+      selection_type: 'MULTI',
+      is_required: false,
+      options: [
+        {
+          id: 219,
+          answer_option_key: 'better_sleep',
+          answer_option_text: '수면 질 개선',
+        },
+        {
+          id: 220,
+          answer_option_key: 'energy',
+          answer_option_text: '에너지 보충',
+        },
+        { id: 221, answer_option_key: 'calm', answer_option_text: '마음 안정' },
+        {
+          id: 222,
+          answer_option_key: 'concentration',
+          answer_option_text: '집중력 향상',
+        },
+      ],
+    },
   ],
 }

--- a/src/mocks/data/profilingResults.ts
+++ b/src/mocks/data/profilingResults.ts
@@ -1,0 +1,24 @@
+/**
+ * GET /api/v1/profilings/results/:result_id 목 데이터
+ */
+import type { ProfilingResultDetail } from '@/app/find-my-scent/_types'
+
+export const mockProfilingResultDetail: ProfilingResultDetail = {
+  id: 42,
+  input_data_type: 'PREFERENCE',
+  product_type: 'DIFFUSER',
+  input_data_summary:
+    '차분한 무드와 가을 숲을 선호하는 당신에게 포근한 우디 향을 추천합니다.',
+  recommended_blend: {
+    name: '포근한 숲',
+    image_url: '/img/17.svg',
+    description:
+      '따뜻한 우디 향. 깊고 신비로운 오리엔탈 조합 향기가 당신만의 개성을 표현합니다.',
+    contained_elements: [
+      { name: '시더우드', category: { kr: '우디', en: 'Woody' } },
+      { name: '라벤더', category: { kr: '아로마틱', en: 'Aromatic' } },
+    ],
+  },
+  recommended_products: [{ purchase_url: 'https://www.coupang.com/' }],
+  created_at: '2026-02-28T14:30:00Z',
+}

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -13,6 +13,7 @@ import {
   mockProfilingFormPREFERENCE,
   mockProfilingFormHEALTH,
 } from './data/profilingForms'
+import { mockProfilingResultDetail } from './data/profilingResults'
 
 /**
  * 단품 목록 조회 GET /api/v1/scents/elements
@@ -121,17 +122,114 @@ export const blendDetailHandler = http.get(
 /**
  * 향기 성향 테스트 항목 조회 GET /api/v1/profilings/forms/active
  * Query: profiling_type (required) PREFERENCE | HEALTH
+ * - 200: success, 400: 잘못된 파라미터, 404: 활성화된 테스트 없음(목에서는 미사용)
  */
 export const profilingFormActiveHandler = http.get(
   '/api/v1/profilings/forms/active',
   ({ request }) => {
     const url = new URL(request.url)
     const profilingType = url.searchParams.get('profiling_type')
+
+    if (!profilingType) {
+      return HttpResponse.json(
+        {
+          success: false,
+          error: {
+            code: 'INVALID_PARAMETER',
+            message: 'profiling_type은 필수입니다.',
+            details: { field: 'profiling_type', reason: 'required' },
+          },
+        },
+        { status: 400 }
+      )
+    }
+
+    if (profilingType !== 'PREFERENCE' && profilingType !== 'HEALTH') {
+      return HttpResponse.json(
+        {
+          success: false,
+          error: {
+            code: 'INVALID_PARAMETER',
+            message: 'profiling_type은 PREFERENCE 또는 HEALTH여야 합니다.',
+            details: { field: 'profiling_type', reason: 'invalid_value' },
+          },
+        },
+        { status: 400 }
+      )
+    }
+
     const form =
       profilingType === 'HEALTH'
         ? mockProfilingFormHEALTH
         : mockProfilingFormPREFERENCE
     return HttpResponse.json({ success: true, data: form })
+  }
+)
+
+/**
+ * 테스트 제출 POST /api/v1/profilings/submit
+ */
+export const profilingSubmitHandler = http.post(
+  '/api/v1/profilings/submit',
+  async ({ request }) => {
+    const body = (await request.json()) as {
+      profiling_type?: string
+      product_type?: string
+      responses?: unknown[]
+    }
+    if (!body?.profiling_type || !body?.responses) {
+      return HttpResponse.json(
+        {
+          success: false,
+          error: {
+            code: 'BAD_REQUEST',
+            message: '필수 항목이 누락되었습니다.',
+            details: null,
+          },
+        },
+        { status: 400 }
+      )
+    }
+    return HttpResponse.json(
+      {
+        success: true,
+        data: {
+          result_id: mockProfilingResultDetail.id,
+          message: '테스트가 제출되었습니다.',
+        },
+      },
+      { status: 201 }
+    )
+  }
+)
+
+/**
+ * 결과 상세 조회 GET /api/v1/profilings/results/:resultId
+ */
+export const profilingResultDetailHandler = http.get(
+  '/api/v1/profilings/results/:resultId',
+  ({ params }) => {
+    const resultId = params.resultId
+    if (!resultId) {
+      return HttpResponse.json(
+        {
+          success: false,
+          error: {
+            code: 'NOT_FOUND',
+            message: '리소스를 찾을 수 없습니다.',
+            details: null,
+          },
+        },
+        { status: 404 }
+      )
+    }
+    return HttpResponse.json({
+      success: true,
+      data: {
+        ...mockProfilingResultDetail,
+        id: Number(resultId) || mockProfilingResultDetail.id,
+      },
+    })
   }
 )
 
@@ -141,6 +239,8 @@ export const handlers = [
   elementDetailHandler,
   blendDetailHandler,
   profilingFormActiveHandler,
+  profilingSubmitHandler,
+  profilingResultDetailHandler,
   adminTestsHandler,
   adminBlendMapsHandlers,
   adminProductPoolsHandlers,


### PR DESCRIPTION
## ✨ PR 개요
취향/건강 테스트 결과 페이지의 API 연동, MSW·목데이터 추가, 제출 플로우 및 "다른 테스트 하러가기" 모달을 구현했습니다.

## 📌 관련 이슈
<!-- Closes #이슈번호 -->
Closes #91 
Closes #93 

## 🧩 작업 내용 (주요 변경사항)
### API · 타입
- **GET** `/api/v1/profilings/forms/active` — 명세에 맞게 `profiling_type` 검증 및 에러 응답 정리
- **POST** `/api/v1/profilings/submit` — 테스트 제출 API 클라이언트 및 응답(`result_id`) 연동
- **GET** `/api/v1/profilings/results/:result_id` — 결과 상세 조회 및 `ResultContentBox`용 props 매핑
- `ProfilingSubmitRequest` / `ProfilingSubmitResponse` / `ProfilingResultDetail` 등 타입 정의
- `resultDetailToContentBoxProps`: `recommended_products[0].purchase_url` → 추천 상품 버튼 링크, `contained_elements` → 향기 노트·향조 라벨(en 기준)

### 테스트 제출 플로우
- 퀴즈 마지막 단계 "결과 보기" 클릭 시 `buildSubmitPayload` → `submitProfiling` 호출 후 `result_id`로 결과 페이지 이동
- 제출 중 버튼 비활성화 및 "제출 중..." 표시, 실패 시 `ErrorFeedbackModal` 노출
- `useQuizStep`에서 `answers` 노출하여 제출 payload 생성

### 결과 페이지
- 취향/건강 결과 페이지: `searchParams.result_id`로 서버에서 `fetchProfilingResult` 호출 후 API 데이터로 콘텐츠 박스 렌더
- 결과 데이터 없을 때는 더미 데이터로 표시

### 다른 테스트 하러가기 모달
- "다른 테스트 하러가기" 클릭 시 현재 결과 유형(PREFERENCE/HEALTH/AI)을 제외한 2가지 테스트만 노출하는 모달 추가
- **OtherTestModal**: 제목 "다른 테스트 하러가기", 부제 "관심 있는 테스트를 선택해주세요", 닫기 버튼
- **OtherTestCard**: 취향 테스트(`taste.svg`), 웰니스 케어 진단(`wellness.svg`), AI 비주얼 분석(`ai.svg`) 각각 카드 컴포넌트로 링크

### MSW · 목데이터
- `profilingFormActiveHandler`: `profiling_type` 필수·값 검증 후 400 응답
- `profilingSubmitHandler`: POST submit → 201, `result_id` 반환
- `profilingResultDetailHandler`: GET results/:resultId → 목 결과 반환
- `mockProfilingResultDetail`(profilingResults.ts), 건강 테스트 질문 4문항 추가(총 6문항)
- Next API 라우트: `profilings/submit`, `profilings/results/[resultId]` (MSW 미동작 시 fallback)

### 기타
- 로딩: "질문을 불러오는 중..." 문구 제거, 취향/건강 테스트 로딩에 스피너만 표시
- `public/ai.svg` — AI 비주얼 분석 아이콘 추가

## 💬 리뷰 포인트
<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

https://github.com/user-attachments/assets/6d940499-9a71-4c03-bed5-02142fdaa522



## 🧠 기타 참고사항
<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트
- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료
