### PR TITLE
fix: 단품/조합 페이지 빌드 시 프리렌더 제거로 ECONNREFUSED 방지 (#109)

### DIFF
--- a/src/app/products/combo/page.tsx
+++ b/src/app/products/combo/page.tsx
@@ -2,6 +2,9 @@
 import { fetchBlends } from '../_api/productsClient'
 import { ComboPageClient } from './ComboPageClient'
 
+/** 빌드 시 프리렌더 스킵 — 배포 환경에서 fetch 실패(ECONNREFUSED) 방지 */
+export const dynamic = 'force-dynamic'
+
 export default async function ProductsComboPage() {
   const { data } = await fetchBlends({ page: 1, size: 100 })
   return <ComboPageClient initialItems={data.results} />

--- a/src/app/products/single/page.tsx
+++ b/src/app/products/single/page.tsx
@@ -2,6 +2,9 @@
 import { fetchElements } from '../_api/productsClient'
 import { SinglePageClient } from './SinglePageClient'
 
+/** 빌드 시 프리렌더 스킵 — 배포 환경에서 fetch 실패(ECONNREFUSED) 방지 */
+export const dynamic = 'force-dynamic'
+
 export default async function ProductsSinglePage() {
   const { data } = await fetchElements({ page: 1, size: 100 })
   return <SinglePageClient initialItems={data.results} />


### PR DESCRIPTION
## ✨ PR 개요
배포 환경에서 `npm run build` 시 `/products/combo` 프리렌더 단계에서 `fetch`가 실패하며 `ECONNREFUSED`가 발생하는 문제를 수정했습니다.

## 원인
- `/products/combo`, `/products/single`이 **정적 프리렌더** 대상이라 빌드 시점에 서버 컴포넌트에서 `fetchBlends` / `fetchElements` 호출
- 배포 빌드 환경에서는 아직 서버가 떠 있지 않아 API 요청이 연결 거부(ECONNREFUSED)로 실패


## 📌 관련 이슈
<!-- Closes #이슈번호 -->
Closes #109 

## 🧩 작업 내용 (주요 변경사항)
## 변경 사항
- **`src/app/products/combo/page.tsx`**: `export const dynamic = 'force-dynamic'` 추가
- **`src/app/products/single/page.tsx`**: `export const dynamic = 'force-dynamic'` 추가

두 페이지를 **빌드 시 프리렌더하지 않고**, 요청 시점에만 서버에서 렌더링되도록 변경했습니다. 상품 목록 fetch는 배포된 서버가 요청을 처리할 때만 실행되어 빌드 단계에서의 연결 오류가 발생하지 않습니다.


## 💬 리뷰 포인트
<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->
<img width="1502" height="758" alt="스크린샷 2026-03-11 오후 4 13 09" src="https://github.com/user-attachments/assets/ba01ca40-8383-481e-a97a-ee3b356cbe51" />


## 🧠 기타 참고사항
<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트
- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료
