### PR TITLE
fix: CodeDeploy 2차 수정 (#110)

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+export NVM_DIR="$HOME/.nvm"
+source "$NVM_DIR/nvm.sh"
+
 cd /home/ubuntu/FE
 
 echo "Installing production dependencies..."


### PR DESCRIPTION


## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->

npm, pm2를 못 받아오는 오류 수정 - afterInstall 오류

## 🧩 작업 내용 (주요 변경사항)

- CodeDeploy가 스크립트를 실행할 때 nvm 경로를 읽어 오지 못하는 오류를 deploy.sh에서 nvm을 직접 불러주는 방법으로 해결

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

<img width="1570" height="375" alt="image" src="https://github.com/user-attachments/assets/2e66907b-1c5b-4a90-b2ca-455402489517" />

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

이 후에 ApplicationStart 나 ValidateService 단계에서 오류가 발생할 수도 있는데 다시 수정 작업 바로 진행하겠습니다.
