### PR TITLE
[feat] AI 비주얼 분석 MSW·API 라우트 연동 (#100)

### DIFF
--- a/src/app/api/v1/ai-visual/submit/route.ts
+++ b/src/app/api/v1/ai-visual/submit/route.ts
@@ -1,0 +1,65 @@
+/**
+ * AI 비주얼 분석 제출 (MSW 미가로챔 시 fallback)
+ * POST /api/v1/ai-visual/submit
+ * body: FormData { photo_type: 'INTERIOR' | 'OOTD', file: File }
+ */
+import { NextResponse } from 'next/server'
+import { mockProfilingResultDetail } from '@/mocks/data/profilingResults'
+
+export async function POST(request: Request) {
+  let formData: FormData
+  try {
+    formData = await request.formData()
+  } catch {
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          code: 'BAD_REQUEST',
+          message: '요청 본문이 올바르지 않습니다.',
+        },
+      },
+      { status: 400 }
+    )
+  }
+
+  const photoType = formData.get('photo_type') as string | null
+  const file = formData.get('file')
+
+  if (!photoType || !file || !(file instanceof File)) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          code: 'BAD_REQUEST',
+          message: 'photo_type과 file이 필요합니다.',
+        },
+      },
+      { status: 400 }
+    )
+  }
+
+  if (!['INTERIOR', 'OOTD'].includes(photoType)) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          code: 'BAD_REQUEST',
+          message: 'photo_type은 INTERIOR 또는 OOTD여야 합니다.',
+        },
+      },
+      { status: 400 }
+    )
+  }
+
+  return NextResponse.json(
+    {
+      success: true,
+      data: {
+        result_id: mockProfilingResultDetail.id,
+        message: 'AI 비주얼 분석이 제출되었습니다.',
+      },
+    },
+    { status: 201 }
+  )
+}

--- a/src/app/api/v1/profilings/images/analyze/route.ts
+++ b/src/app/api/v1/profilings/images/analyze/route.ts
@@ -1,0 +1,97 @@
+/**
+ * AI 분석 테스트 제출 (MSW 미가로챔 시 fallback)
+ * POST /api/v1/profilings/images/analyze
+ * Body: { image_url, image_type (OOTD|INTERIOR), product_type (DIFFUSER|PERFUME) }
+ */
+import { NextResponse } from 'next/server'
+import { mockProfilingResultDetail } from '@/mocks/data/profilingResults'
+
+export async function POST(request: Request) {
+  const auth = request.headers.get('Authorization')
+  if (!auth?.startsWith('Bearer ')) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          code: 'UNAUTHORIZED',
+          message: '인증이 필요합니다.',
+          details: null,
+        },
+      },
+      { status: 401 }
+    )
+  }
+
+  let body: {
+    image_url?: string
+    image_type?: string
+    product_type?: string
+  }
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          code: 'BAD_REQUEST',
+          message: '요청 본문이 올바르지 않습니다.',
+          details: null,
+        },
+      },
+      { status: 400 }
+    )
+  }
+
+  const { image_url, image_type, product_type } = body ?? {}
+  if (!image_url || !image_type || !product_type) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          code: 'BAD_REQUEST',
+          message: 'image_url, image_type, product_type은 필수입니다.',
+          details: null,
+        },
+      },
+      { status: 400 }
+    )
+  }
+  if (!['OOTD', 'INTERIOR'].includes(image_type)) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          code: 'BAD_REQUEST',
+          message: 'image_type은 OOTD 또는 INTERIOR여야 합니다.',
+          details: null,
+        },
+      },
+      { status: 400 }
+    )
+  }
+  if (!['DIFFUSER', 'PERFUME'].includes(product_type)) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          code: 'BAD_REQUEST',
+          message: 'product_type은 DIFFUSER 또는 PERFUME이어야 합니다.',
+          details: null,
+        },
+      },
+      { status: 400 }
+    )
+  }
+
+  return NextResponse.json(
+    {
+      success: true,
+      data: {
+        result_id: mockProfilingResultDetail.id,
+        message: '사진 분석이 완료되었습니다.',
+      },
+    },
+    { status: 201 }
+  )
+}

--- a/src/app/api/v1/profilings/images/mock-upload/route.ts
+++ b/src/app/api/v1/profilings/images/mock-upload/route.ts
@@ -1,0 +1,9 @@
+/**
+ * Mock 이미지 업로드 수신 (presigned_url로 PUT 시, MSW 미가로챔 시 fallback)
+ * PUT /api/v1/profilings/images/mock-upload
+ */
+import { NextResponse } from 'next/server'
+
+export async function PUT() {
+  return new NextResponse(null, { status: 200 })
+}

--- a/src/app/api/v1/profilings/images/presigned-url/route.ts
+++ b/src/app/api/v1/profilings/images/presigned-url/route.ts
@@ -1,0 +1,96 @@
+/**
+ * 이미지 업로드용 presigned URL 발급 (MSW 미가로챔 시 fallback)
+ * PUT /api/v1/profilings/images/presigned-url
+ * Body: { file_name, image_format (jpeg|jpg|png|webp), file_size }
+ */
+import { NextResponse } from 'next/server'
+
+const ALLOWED_FORMATS = ['jpeg', 'jpg', 'png', 'webp']
+const MOCK_IMAGE_URL = 'https://cdn.example.com/images/ai-visual-mock.jpg'
+const MOCK_KEY = 'images/ai-visual-mock.jpg'
+
+function getOrigin(request: Request): string {
+  try {
+    return new URL(request.url).origin
+  } catch {
+    return process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000'
+  }
+}
+
+export async function PUT(request: Request) {
+  const auth = request.headers.get('Authorization')
+  if (!auth?.startsWith('Bearer ')) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          code: 'UNAUTHORIZED',
+          message: '인증이 필요합니다.',
+          details: null,
+        },
+      },
+      { status: 401 }
+    )
+  }
+
+  let body: { file_name?: string; image_format?: string; file_size?: number }
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          code: 'BAD_REQUEST',
+          message: '요청 본문이 올바르지 않습니다.',
+          details: null,
+        },
+      },
+      { status: 400 }
+    )
+  }
+
+  const { file_name, image_format, file_size } = body ?? {}
+  if (!file_name || !image_format || file_size == null) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          code: 'BAD_REQUEST',
+          message: 'file_name, image_format, file_size는 필수입니다.',
+          details: null,
+        },
+      },
+      { status: 400 }
+    )
+  }
+  if (!ALLOWED_FORMATS.includes(image_format.toLowerCase())) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          code: 'BAD_REQUEST',
+          message: '허용되지 않는 파일 형식입니다.',
+          details: null,
+        },
+      },
+      { status: 400 }
+    )
+  }
+
+  const origin = getOrigin(request)
+  const presigned_url = `${origin}/api/v1/profilings/images/mock-upload`
+
+  return NextResponse.json(
+    {
+      success: true,
+      data: {
+        presigned_url,
+        image_url: MOCK_IMAGE_URL,
+        key: MOCK_KEY,
+        expires_in: 300,
+      },
+    },
+    { status: 201 }
+  )
+}

--- a/src/app/find-my-scent/_api/aiVisualClient.ts
+++ b/src/app/find-my-scent/_api/aiVisualClient.ts
@@ -1,0 +1,157 @@
+/**
+ * AI 비주얼 분석 API (명세 기준)
+ * 1. PUT presigned-url → 2. PUT 파일 업로드 → 3. POST analyze → result_id
+ * - MSW: /api/v1/profilings/images/*, /api/v1/profilings/results/:id
+ */
+
+export type PhotoType = 'INTERIOR' | 'OOTD'
+export type ProductType = 'DIFFUSER' | 'PERFUME'
+
+const ALLOWED_FORMATS = ['jpeg', 'jpg', 'png', 'webp'] as const
+type ImageFormat = (typeof ALLOWED_FORMATS)[number]
+
+function getImageFormatFromFile(file: File): ImageFormat {
+  const type = file.type?.toLowerCase() ?? ''
+  if (type === 'image/jpeg' || type === 'image/jpg') return 'jpeg'
+  if (type === 'image/png') return 'png'
+  if (type === 'image/webp') return 'webp'
+  const ext = file.name.split('.').pop()?.toLowerCase() ?? ''
+  if (ext === 'jpg' || ext === 'jpeg') return 'jpeg'
+  if (ext === 'png') return 'png'
+  if (ext === 'webp') return 'webp'
+  return 'jpeg'
+}
+
+/** 개발/MSW용 토큰 (실서비스에서는 인증 컨텍스트에서 주입) */
+function getAuthHeader(): Record<string, string> {
+  const token =
+    typeof window !== 'undefined'
+      ? (window as unknown as { __AI_VISUAL_TOKEN?: string }).__AI_VISUAL_TOKEN
+      : undefined
+  return {
+    Authorization: token ? `Bearer ${token}` : 'Bearer mock_token',
+  }
+}
+
+type PresignedUrlResponse = {
+  success: boolean
+  data?: {
+    presigned_url: string
+    image_url: string
+    key: string
+    expires_in: number
+  }
+  error?: { code: string; message: string; details?: unknown }
+}
+
+type AnalyzeResponse = {
+  success: boolean
+  data?: { result_id: number; message: string }
+  error?: { code: string; message: string; details?: unknown }
+}
+
+/**
+ * 1. presigned URL 발급
+ * PUT /api/v1/profilings/images/presigned-url
+ */
+async function getPresignedUrl(
+  file_name: string,
+  image_format: ImageFormat,
+  file_size: number
+): Promise<{ presigned_url: string; image_url: string }> {
+  const res = await fetch('/api/v1/profilings/images/presigned-url', {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      ...getAuthHeader(),
+    },
+    body: JSON.stringify({ file_name, image_format, file_size }),
+  })
+
+  const json: PresignedUrlResponse = await res.json().catch(() => ({
+    success: false,
+    error: { code: 'UNKNOWN', message: '응답을 파싱할 수 없습니다.' },
+  }))
+
+  if (!res.ok || !json.success || !json.data) {
+    throw new Error(
+      json.error?.message ?? `presigned URL 발급 실패 (${res.status})`
+    )
+  }
+
+  return {
+    presigned_url: json.data.presigned_url,
+    image_url: json.data.image_url,
+  }
+}
+
+/**
+ * 2. presigned URL로 파일 업로드
+ */
+async function uploadToPresignedUrl(
+  presigned_url: string,
+  file: File
+): Promise<void> {
+  const res = await fetch(presigned_url, {
+    method: 'PUT',
+    body: file,
+    headers: {
+      'Content-Type': file.type || 'application/octet-stream',
+    },
+  })
+  if (!res.ok) {
+    throw new Error(`이미지 업로드 실패 (${res.status})`)
+  }
+}
+
+/**
+ * 3. AI 분석 제출
+ * POST /api/v1/profilings/images/analyze
+ */
+async function submitAnalyze(
+  image_url: string,
+  image_type: PhotoType,
+  product_type: ProductType
+): Promise<number> {
+  const res = await fetch('/api/v1/profilings/images/analyze', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...getAuthHeader(),
+    },
+    body: JSON.stringify({ image_url, image_type, product_type }),
+  })
+
+  const json: AnalyzeResponse = await res.json().catch(() => ({
+    success: false,
+    error: { code: 'UNKNOWN', message: '응답을 파싱할 수 없습니다.' },
+  }))
+
+  if (!res.ok || !json.success || json.data?.result_id == null) {
+    throw new Error(json.error?.message ?? `분석 제출 실패 (${res.status})`)
+  }
+
+  return json.data.result_id
+}
+
+/**
+ * AI 비주얼 분석 전체 플로우: presigned URL 발급 → 업로드 → 분석 제출 → result_id 반환
+ */
+export async function submitAiVisualAnalysis(
+  photoType: PhotoType,
+  file: File,
+  productType: ProductType = 'DIFFUSER'
+): Promise<number> {
+  const image_format = getImageFormatFromFile(file)
+  const file_name = file.name || `upload.${image_format}`
+
+  const { presigned_url, image_url } = await getPresignedUrl(
+    file_name,
+    image_format,
+    file.size
+  )
+
+  await uploadToPresignedUrl(presigned_url, file)
+
+  return submitAnalyze(image_url, photoType, productType)
+}

--- a/src/app/find-my-scent/_components/AIVisualModal.tsx
+++ b/src/app/find-my-scent/_components/AIVisualModal.tsx
@@ -38,7 +38,8 @@ const PHOTO_TYPE_CONFIG: Record<
 export type AIVisualModalProps = {
   isOpen: boolean
   onClose: () => void
-  onAnalyze?: (photoType: PhotoType, file: File) => void
+  /** 제출 후 결과 페이지로 이동 등; Promise 반환 시 제출 중 버튼 비활성화 */
+  onAnalyze?: (photoType: PhotoType, file: File) => void | Promise<void>
 }
 
 const styles = {
@@ -78,9 +79,9 @@ const styles = {
   step2Title: 'text-lg font-semibold text-[var(--color-black-primary)]',
   step2Desc: 'mt-1.5 text-sm leading-relaxed text-neutral-600',
   uploadZone:
-    'mt-6 flex min-h-[240px] flex-1 flex-col items-center justify-center rounded-xl border-2 border-dashed border-neutral-300 bg-neutral-50/80 p-8 transition-colors hover:border-neutral-400 hover:bg-neutral-100/80 -mx-10 w-[calc(100%+5rem)]',
+    'mt-6 flex min-h-[240px] flex-1 flex-col items-center justify-center rounded-xl border-2 border-dashed border-neutral-300 bg-neutral-50/80 transition-colors hover:border-neutral-400 hover:bg-neutral-100/80 -mx-10 w-[calc(100%+5rem)]',
   uploadZoneFilled:
-    'flex min-h-[240px] flex-1 flex-col border-solid border-neutral-200 p-2 -mx-10 w-[calc(100%+5rem)]',
+    'flex min-h-[240px] flex-1 flex-col border-solid border-neutral-200 p-2 -mx-5 w-[calc(100%+3rem)]',
   uploadIcon: 'relative h-20 w-20 shrink-0',
   uploadText: 'mt-4 text-sm font-medium text-neutral-700',
   uploadHint: 'mt-2 text-xs text-neutral-500',
@@ -110,6 +111,8 @@ export function AIVisualModal({
   const [file, setFile] = useState<File | null>(null)
   const [previewUrl, setPreviewUrl] = useState<string | null>(null)
   const [uploadError, setUploadError] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [submitError, setSubmitError] = useState<string | null>(null)
   const inputRef = useRef<HTMLInputElement>(null)
   const router = useRouter()
 
@@ -128,6 +131,7 @@ export function AIVisualModal({
     }
     setPreviewUrl(null)
     setUploadError(null)
+    setSubmitError(null)
   }
 
   const handleClose = () => {
@@ -185,11 +189,21 @@ export function AIVisualModal({
     }
   }
 
-  const handleAnalyze = () => {
+  const handleAnalyze = async () => {
     if (step !== 2 || !photoType || !file) return
     if (onAnalyze) {
-      onAnalyze(photoType, file)
-      handleClose()
+      setSubmitError(null)
+      setIsSubmitting(true)
+      try {
+        await onAnalyze(photoType, file)
+        // onAnalyze에서 결과 페이지로 이동하므로 handleClose() 호출하지 않음 (history.back() 방지)
+      } catch (err) {
+        setSubmitError(
+          err instanceof Error ? err.message : '제출에 실패했습니다.'
+        )
+      } finally {
+        setIsSubmitting(false)
+      }
     } else {
       router.push('/find-my-scent/ai-visual/result')
       handleClose()
@@ -361,6 +375,9 @@ export function AIVisualModal({
                 {uploadError && (
                   <p className="mt-3 text-sm text-red-600">{uploadError}</p>
                 )}
+                {submitError && (
+                  <p className="mt-3 text-sm text-red-600">{submitError}</p>
+                )}
               </div>
             )}
           </div>
@@ -387,10 +404,10 @@ export function AIVisualModal({
                 <button
                   type="button"
                   onClick={handleAnalyze}
-                  disabled={!file}
-                  className={`${styles.btnNext} ${file ? styles.btnNextActive : styles.btnNextInactive}`}
+                  disabled={!file || isSubmitting}
+                  className={`${styles.btnNext} ${file && !isSubmitting ? styles.btnNextActive : styles.btnNextInactive}`}
                 >
-                  분석 시작
+                  {isSubmitting ? '제출 중...' : '분석 시작'}
                 </button>
               </>
             )}

--- a/src/app/find-my-scent/ai-visual/AIVisualClient.tsx
+++ b/src/app/find-my-scent/ai-visual/AIVisualClient.tsx
@@ -1,11 +1,14 @@
 'use client'
 
 /** AI 비주얼 분석 페이지 — 모달로 진입 (클라이언트 마운트 후 렌더로 hydration 회피) */
+import { useRouter } from 'next/navigation'
 import { useState, useEffect } from 'react'
+import { submitAiVisualAnalysis } from '../_api/aiVisualClient'
 import { AIVisualModal } from '../_components/AIVisualModal'
 
 export function AIVisualClient() {
   const [mounted, setMounted] = useState(false)
+  const router = useRouter()
 
   useEffect(() => {
     // 클라이언트에서만 모달 렌더하여 SSR/hydration 불일치 방지
@@ -13,7 +16,18 @@ export function AIVisualClient() {
     setMounted(true)
   }, [])
 
+  const handleAnalyze = async (photoType: 'INTERIOR' | 'OOTD', file: File) => {
+    const resultId = await submitAiVisualAnalysis(photoType, file)
+    router.push(`/find-my-scent/ai-visual/result?result_id=${resultId}`)
+  }
+
   if (!mounted) return null
 
-  return <AIVisualModal isOpen onClose={() => window.history.back()} />
+  return (
+    <AIVisualModal
+      isOpen
+      onClose={() => window.history.back()}
+      onAnalyze={handleAnalyze}
+    />
+  )
 }

--- a/src/app/find-my-scent/ai-visual/result/page.tsx
+++ b/src/app/find-my-scent/ai-visual/result/page.tsx
@@ -1,12 +1,35 @@
-/** AI 조합 향기 분석 결과 페이지 — API 미연동 시 목데이터 표시 */
-import { resultDetailToContentBoxProps } from '../../_api/profilingClient'
+/** AI 비주얼 분석 결과 페이지 — result_id 있으면 API 조회, 없거나 실패 시 목데이터 */
+import {
+  fetchProfilingResult,
+  resultDetailToContentBoxProps,
+} from '../../_api/profilingClient'
 import { ResultPageWithAnalyzing } from '../../_components/ResultPageWithAnalyzing'
 import { mockProfilingResultDetail } from '@/mocks/data/profilingResults'
 
-export default function AIResultPage() {
-  const contentBoxProps = resultDetailToContentBoxProps(
-    mockProfilingResultDetail
-  )
+type PageProps = { searchParams: Promise<{ result_id?: string }> }
+
+export default async function AIResultPage({ searchParams }: PageProps) {
+  const params = await searchParams
+  const resultId = params.result_id ? Number(params.result_id) : null
+
+  let contentBoxProps: ReturnType<typeof resultDetailToContentBoxProps>
+  if (resultId != null && Number.isInteger(resultId) && resultId > 0) {
+    try {
+      const res = await fetchProfilingResult(resultId)
+      if (res.success && res.data) {
+        contentBoxProps = resultDetailToContentBoxProps(res.data)
+      } else {
+        contentBoxProps = resultDetailToContentBoxProps(
+          mockProfilingResultDetail
+        )
+      }
+    } catch {
+      contentBoxProps = resultDetailToContentBoxProps(mockProfilingResultDetail)
+    }
+  } else {
+    contentBoxProps = resultDetailToContentBoxProps(mockProfilingResultDetail)
+  }
+
   return (
     <ResultPageWithAnalyzing
       resultType="AI"

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -234,6 +234,207 @@ export const profilingResultDetailHandler = http.get(
   }
 )
 
+// --- AI 비주얼 분석 (이미지 업로드 → 분석 제출 → 결과 조회) ---
+
+const MOCK_AI_IMAGE_URL = 'https://cdn.example.com/images/ai-visual-mock.jpg'
+const MOCK_AI_IMAGE_KEY = 'images/ai-visual-mock.jpg'
+
+/**
+ * 1. 이미지 업로드용 presigned URL 발급
+ * PUT /api/v1/profilings/images/presigned-url
+ * Body: { file_name, image_format (jpeg|jpg|png|webp), file_size }
+ */
+export const presignedUrlHandler = http.put(
+  '/api/v1/profilings/images/presigned-url',
+  async ({ request }) => {
+    const auth = request.headers.get('Authorization')
+    if (!auth?.startsWith('Bearer ')) {
+      return HttpResponse.json(
+        {
+          success: false,
+          error: {
+            code: 'UNAUTHORIZED',
+            message: '인증이 필요합니다.',
+            details: null,
+          },
+        },
+        { status: 401 }
+      )
+    }
+
+    let body: { file_name?: string; image_format?: string; file_size?: number }
+    try {
+      body = (await request.json()) as typeof body
+    } catch {
+      return HttpResponse.json(
+        {
+          success: false,
+          error: {
+            code: 'BAD_REQUEST',
+            message: '요청 본문이 올바르지 않습니다.',
+            details: null,
+          },
+        },
+        { status: 400 }
+      )
+    }
+
+    const { file_name, image_format, file_size } = body ?? {}
+    const allowedFormats = ['jpeg', 'jpg', 'png', 'webp']
+    if (!file_name || !image_format || file_size == null) {
+      return HttpResponse.json(
+        {
+          success: false,
+          error: {
+            code: 'BAD_REQUEST',
+            message: 'file_name, image_format, file_size는 필수입니다.',
+            details: null,
+          },
+        },
+        { status: 400 }
+      )
+    }
+    if (!allowedFormats.includes(image_format.toLowerCase())) {
+      return HttpResponse.json(
+        {
+          success: false,
+          error: {
+            code: 'BAD_REQUEST',
+            message: '허용되지 않는 파일 형식입니다.',
+            details: { field: 'image_format', reason: 'invalid' },
+          },
+        },
+        { status: 400 }
+      )
+    }
+
+    // 클라이언트가 같은 출처로 PUT 할 수 있도록 mock 업로드 경로 반환 (상대 URL)
+    const presigned_url = '/api/v1/profilings/images/mock-upload'
+
+    return HttpResponse.json(
+      {
+        success: true,
+        data: {
+          presigned_url,
+          image_url: MOCK_AI_IMAGE_URL,
+          key: MOCK_AI_IMAGE_KEY,
+          expires_in: 300,
+        },
+      },
+      { status: 201 }
+    )
+  }
+)
+
+/**
+ * 1-2. Mock 업로드 수신 (presigned_url로 PUT 시)
+ * PUT /api/v1/profilings/images/mock-upload
+ */
+export const mockUploadHandler = http.put(
+  '/api/v1/profilings/images/mock-upload',
+  () => {
+    return new HttpResponse(null, { status: 200 })
+  }
+)
+
+/**
+ * 2. AI 분석 테스트 제출
+ * POST /api/v1/profilings/images/analyze
+ * Body: { image_url, image_type (OOTD|INTERIOR), product_type (DIFFUSER|PERFUME) }
+ */
+export const imagesAnalyzeHandler = http.post(
+  '/api/v1/profilings/images/analyze',
+  async ({ request }) => {
+    const auth = request.headers.get('Authorization')
+    if (!auth?.startsWith('Bearer ')) {
+      return HttpResponse.json(
+        {
+          success: false,
+          error: {
+            code: 'UNAUTHORIZED',
+            message: '인증이 필요합니다.',
+            details: null,
+          },
+        },
+        { status: 401 }
+      )
+    }
+
+    let body: {
+      image_url?: string
+      image_type?: string
+      product_type?: string
+    }
+    try {
+      body = (await request.json()) as typeof body
+    } catch {
+      return HttpResponse.json(
+        {
+          success: false,
+          error: {
+            code: 'BAD_REQUEST',
+            message: '요청 본문이 올바르지 않습니다.',
+            details: null,
+          },
+        },
+        { status: 400 }
+      )
+    }
+
+    const { image_url, image_type, product_type } = body ?? {}
+    if (!image_url || !image_type || !product_type) {
+      return HttpResponse.json(
+        {
+          success: false,
+          error: {
+            code: 'BAD_REQUEST',
+            message: 'image_url, image_type, product_type은 필수입니다.',
+            details: null,
+          },
+        },
+        { status: 400 }
+      )
+    }
+    if (!['OOTD', 'INTERIOR'].includes(image_type)) {
+      return HttpResponse.json(
+        {
+          success: false,
+          error: {
+            code: 'BAD_REQUEST',
+            message: 'image_type은 OOTD 또는 INTERIOR여야 합니다.',
+            details: { field: 'image_type', reason: 'invalid' },
+          },
+        },
+        { status: 400 }
+      )
+    }
+    if (!['DIFFUSER', 'PERFUME'].includes(product_type)) {
+      return HttpResponse.json(
+        {
+          success: false,
+          error: {
+            code: 'BAD_REQUEST',
+            message: 'product_type은 DIFFUSER 또는 PERFUME이어야 합니다.',
+            details: { field: 'product_type', reason: 'invalid' },
+          },
+        },
+        { status: 400 }
+      )
+    }
+
+    return HttpResponse.json(
+      {
+        success: true,
+        data: {
+          result_id: mockProfilingResultDetail.id,
+          message: '사진 분석이 완료되었습니다.',
+        },
+      },
+      { status: 201 }
+    )
+  }
+)
+
 export const handlers = [
   elementsHandler,
   blendsHandler,
@@ -242,6 +443,9 @@ export const handlers = [
   profilingFormActiveHandler,
   profilingSubmitHandler,
   profilingResultDetailHandler,
+  presignedUrlHandler,
+  mockUploadHandler,
+  imagesAnalyzeHandler,
   adminTestsHandler,
   adminBlendMapsHandlers,
   adminProductPoolsHandlers,


### PR DESCRIPTION
## ✨ PR 개요
AI 비주얼 분석(모달 → 결과 페이지) 플로우를 API 명세에 맞춰 연동하고, MSW 핸들러와 Next.js API 폴백 라우트를 추가했습니다.


## 📌 관련 이슈
Closes #98 
Closes #100 

## 🧩 작업 내용 (주요 변경사항)
### 1. API 반영
- **이미지 업로드 (presigned URL)**  
  `PUT /api/v1/profilings/images/presigned-url`  
  - Request: `Authorization: Bearer`, Body `file_name`, `image_format`, `file_size`  
  - Response: `presigned_url`, `image_url`, `key`, `expires_in`  
  - 201 / 400 / 401
- **AI 분석 제출**  
  `POST /api/v1/profilings/images/analyze`  
  - Request: `Authorization`, Body `image_url`, `image_type`(OOTD|INTERIOR), `product_type`(DIFFUSER|PERFUME)  
  - Response: `result_id`, `message`  
  - 201 / 400 / 401
- **분석 결과 상세**  
  기존 `GET /api/v1/profilings/results/{result_id}` 활용

### 2. MSW 핸들러
- `presignedUrlHandler`: PUT presigned-url, 검증 후 mock 업로드 URL·image_url 반환
- `mockUploadHandler`: PUT mock-upload, 파일 업로드 수신 후 200
- `imagesAnalyzeHandler`: POST analyze, 검증 후 `result_id` 반환
- 에러: 400(필수/형식), 401(Authorization) 명세 형식

### 3. 클라이언트 (aiVisualClient)
- 플로우: presigned URL 발급 → presigned URL로 파일 PUT → analyze 제출 → `result_id` 반환
- `submitAiVisualAnalysis(photoType, file, productType?)` 로 전체 플로우 처리
- Authorization: 개발용 `Bearer mock_token` (실서비스 시 토큰 교체 대상)

### 4. Next.js API 폴백 (MSW 미사용 시)
- `PUT /api/v1/profilings/images/presigned-url`
- `PUT /api/v1/profilings/images/mock-upload`
- `POST /api/v1/profilings/images/analyze`

### 5. 사용자 플로우
1. AI 비주얼 모달에서 사진 유형 선택 → 파일 업로드 → **분석 시작** 클릭  
2. presigned URL 발급 → 파일 업로드 → analyze 제출  
3. `result_id` 수신 후 `/find-my-scent/ai-visual/result?result_id=xxx` 이동  
4. 결과 페이지에서 기존 결과 상세 API로 데이터 조회 후 표시  


## 💬 리뷰 포인트
<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항
<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트
- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료
