### PR TITLE
[feat] 향 목록 스켈레톤 UI 및 최소 노출 딜레이 적용 (#120)

### DIFF
--- a/src/app/products/combo/loading.tsx
+++ b/src/app/products/combo/loading.tsx
@@ -1,0 +1,5 @@
+import { ScentListSkeleton } from '@/components/products/ScentListSkeleton'
+
+export default function ComboLoading() {
+  return <ScentListSkeleton />
+}

--- a/src/app/products/combo/page.tsx
+++ b/src/app/products/combo/page.tsx
@@ -1,4 +1,5 @@
 /** 조합 향기 목록: 서버에서 목록 조회 후 클라이언트에 전달 */
+import { SkeletonDelay } from '@/components/products/ScentListSkeleton'
 import { fetchBlends } from '../_api/productsClient'
 import { ComboPageClient } from './ComboPageClient'
 
@@ -7,5 +8,9 @@ export const dynamic = 'force-dynamic'
 
 export default async function ProductsComboPage() {
   const { data } = await fetchBlends({ page: 1, size: 100 })
-  return <ComboPageClient initialItems={data.results} />
+  return (
+    <SkeletonDelay>
+      <ComboPageClient initialItems={data.results} />
+    </SkeletonDelay>
+  )
 }

--- a/src/app/products/single/loading.tsx
+++ b/src/app/products/single/loading.tsx
@@ -1,0 +1,5 @@
+import { ScentListSkeleton } from '@/components/products/ScentListSkeleton'
+
+export default function SingleLoading() {
+  return <ScentListSkeleton />
+}

--- a/src/app/products/single/page.tsx
+++ b/src/app/products/single/page.tsx
@@ -1,4 +1,5 @@
 /** 단품 향기 목록: 서버에서 목록 조회 후 클라이언트에 전달 */
+import { SkeletonDelay } from '@/components/products/ScentListSkeleton'
 import { fetchElements } from '../_api/productsClient'
 import { SinglePageClient } from './SinglePageClient'
 
@@ -7,5 +8,9 @@ export const dynamic = 'force-dynamic'
 
 export default async function ProductsSinglePage() {
   const { data } = await fetchElements({ page: 1, size: 100 })
-  return <SinglePageClient initialItems={data.results} />
+  return (
+    <SkeletonDelay>
+      <SinglePageClient initialItems={data.results} />
+    </SkeletonDelay>
+  )
 }

--- a/src/components/products/ScentListSkeleton.tsx
+++ b/src/components/products/ScentListSkeleton.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+/** 향 목록 로딩 시 스켈레톤 UI (단품/조합 공용) */
+const CARD_COUNT = 8
+
+/** 스켈레톤 최소 노출 시간(ms). 이 시간만큼 지난 뒤 실제 목록 표시 */
+export const SCENT_LIST_SKELETON_DELAY_MS = 3000
+
+type SkeletonDelayProps = {
+  /** 스켈레톤을 보여줄 최소 시간(ms) */
+  delayMs?: number
+  children: React.ReactNode
+}
+
+/** 지정한 시간(ms) 동안 스켈레톤을 보여준 뒤 children 렌더 */
+export function SkeletonDelay({
+  delayMs = SCENT_LIST_SKELETON_DELAY_MS,
+  children,
+}: SkeletonDelayProps) {
+  const [ready, setReady] = useState(false)
+
+  useEffect(() => {
+    const id = window.setTimeout(() => setReady(true), delayMs)
+    return () => window.clearTimeout(id)
+  }, [delayMs])
+
+  if (!ready) return <ScentListSkeleton />
+  return <>{children}</>
+}
+
+function FilterBarSkeleton() {
+  return (
+    <div className="mb-6 flex flex-col overflow-hidden rounded-[20px] bg-white shadow-sm">
+      <div className="flex items-center gap-2 p-2">
+        <div className="h-10 flex-1 animate-pulse rounded-full bg-neutral-200" />
+        <div className="h-10 w-24 animate-pulse rounded-full bg-neutral-200" />
+      </div>
+    </div>
+  )
+}
+
+function CardSkeleton() {
+  return (
+    <div className="rounded-2xl bg-white shadow-md">
+      <div className="aspect-square w-full animate-pulse rounded-t-2xl bg-neutral-200" />
+      <div className="space-y-3 p-3">
+        <div className="h-4 w-3/4 animate-pulse rounded bg-neutral-200" />
+        <div className="flex gap-1">
+          <div className="h-6 w-14 animate-pulse rounded-full bg-neutral-200" />
+          <div className="h-6 w-16 animate-pulse rounded-full bg-neutral-200" />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function ScentListSkeleton() {
+  return (
+    <>
+      <FilterBarSkeleton />
+      <ul className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4">
+        {Array.from({ length: CARD_COUNT }, (_, i) => (
+          <li key={i}>
+            <CardSkeleton />
+          </li>
+        ))}
+      </ul>
+    </>
+  )
+}


### PR DESCRIPTION
## ✨ PR 개요
단품/조합 향기 목록 로딩 시 스켈레톤 UI를 적용하고, 최소 노출 시간을 설정할 수 있도록 했습니다.

## 📌 관련 이슈
Closes #120 

## 🧩 작업 내용 (주요 변경사항)
### 1. 스켈레톤 컴포넌트 (`ScentListSkeleton`)
- **위치**: `src/components/products/ScentListSkeleton.tsx`
- 검색·필터 바 형태의 스켈레톤 (검색창, 필터 버튼 플레이스홀더)
- 카드 그리드 스켈레톤 8개 (단품/조합와 동일한 그리드: 2~4열)
- 카드: 정사각형 이미지 영역 + 제목·태그 영역, `animate-pulse` 적용

### 2. 스켈레톤 딜레이 래퍼 (`SkeletonDelay`)
- **최소 노출 시간**: `SCENT_LIST_SKELETON_DELAY_MS` (기본 1000ms)
- 마운트 후 지정 시간 동안 스켈레톤만 노출, 이후 실제 목록 렌더
- `delayMs` prop으로 페이지별로 시간 조정 가능

### 3. 로딩·페이지 연동
- **`loading.tsx`**: 단품(`/products/single`), 조합(`/products/combo`) 각각 추가  
  → 데이터 fetch 동안 Next.js 기본 로딩으로 스켈레톤 표시
- **페이지**: `SinglePageClient` / `ComboPageClient`를 `SkeletonDelay`로 감싸  
  → 데이터 도착 후에도 최소 `delayMs` 동안 스켈레톤 유지 후 목록 전환

### 4. 사용자 경험
- 목록 진입 시: (1) `loading.tsx` 스켈레톤 → (2) 데이터 로드 후 `SkeletonDelay` 스켈레톤 → (3) 실제 목록
- 딜레이 변경: `ScentListSkeleton.tsx`의 `SCENT_LIST_SKELETON_DELAY_MS` 수정 또는 `<SkeletonDelay delayMs={숫자}>`로 페이지별 지정


## 💬 리뷰 포인트
<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

https://github.com/user-attachments/assets/8d8504fa-8b8c-4bd3-a72c-32e21c81ca01



## 🧠 기타 참고사항
딜레이 3초 적용해두었습니다.

## ✅ PR 체크리스트
- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료
