### PR TITLE
어드민 관리 탭 별 검색 + 필터링 + 삭제 로직 추가 (#117)

### DIFF
--- a/src/app/admin/_components/AdminSearchBar.tsx
+++ b/src/app/admin/_components/AdminSearchBar.tsx
@@ -6,25 +6,31 @@ import AdminSearchIcon from '@/assets/icons/adminSearch.svg'
 import { AdminSelect } from './AdminSelect'
 
 interface AdminFilterBarProps {
+  searchValue?: string
+  filterValue?: string
   searchPlaceholder?: string
   filterOptions?: { label: string; value: string }[]
   onSearchChange?: (val: string) => void
   onFilterChange?: (val: string) => void
 }
 
-export const AdminFilterBar = ({
+export const AdminSearchBar = ({
+  searchValue,
+  filterValue,
   searchPlaceholder = '검색',
   filterOptions,
   onSearchChange,
   onFilterChange,
 }: AdminFilterBarProps) => {
-  // 현재 선택된 필터 값 관리 (기본값: 첫 번째 옵션이 있다면 그 값)
-  const [currentFilter, setCurrentFilter] = useState(
-    filterOptions && filterOptions.length > 0 ? filterOptions[0].value : ''
-  )
+  // 내부 필터 값
+  const [internalFilter, setInternalFilter] = useState('')
+
+  // 외부 필터 값이 있으면 그것을 우선 사용
+  const activeFilterValue =
+    filterValue !== undefined ? filterValue : internalFilter
 
   const handleFilterChange = (val: string) => {
-    setCurrentFilter(val)
+    setInternalFilter(val)
     onFilterChange?.(val)
   }
 
@@ -32,6 +38,7 @@ export const AdminFilterBar = ({
     <div className="mb-6 flex gap-3">
       <div className="relative flex-1">
         <Input
+          value={searchValue}
           placeholder={searchPlaceholder}
           className="h-12 w-full rounded-xl border-neutral-200 bg-white pl-11 text-sm transition-all outline-none focus:border-violet-300"
           onChange={(e) => onSearchChange?.(e.target.value)}
@@ -43,7 +50,7 @@ export const AdminFilterBar = ({
       {filterOptions && (
         <AdminSelect
           options={filterOptions}
-          value={currentFilter}
+          value={activeFilterValue}
           onChange={handleFilterChange}
           width="w-32"
         />

--- a/src/app/admin/_components/AdminTable.tsx
+++ b/src/app/admin/_components/AdminTable.tsx
@@ -84,32 +84,44 @@ export const AdminStatusCell = ({
   onClick,
 }: {
   slot: number
-  status: 'PUBLISHED' | 'UNPUBLISHED'
+  status: 'PUBLISHED' | 'UNPUBLISHED' | 'ADOPTED' | 'UNADOPTED'
   trueLabel?: string
   falseLabel?: string
-  onClick: () => void
+  onClick?: () => void
 }) => {
-  const isPublished = status === 'PUBLISHED'
+  const isPublished = status === 'PUBLISHED' || status === 'ADOPTED'
+  const content = (
+    <>
+      <div
+        className={cn(
+          'h-1.5 w-1.5 rounded-full',
+          isPublished ? 'bg-status-success-text' : 'bg-status-neutral-text'
+        )}
+      />
+      {isPublished ? trueLabel : falseLabel}
+    </>
+  )
+
+  const statusClass = cn(
+    'inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-bold transition-colors',
+    isPublished
+      ? 'bg-status-success-bg text-status-success-text'
+      : 'bg-status-neutral-bg text-status-neutral-text'
+  )
+
   return (
     <AdminTableCell slot={slot}>
-      <button
-        type="button"
-        onClick={onClick}
-        className={cn(
-          'inline-flex cursor-pointer items-center gap-1.5 rounded-full px-3 py-1 text-xs font-bold',
-          isPublished
-            ? 'bg-status-success-bg text-status-success-text'
-            : 'bg-status-neutral-bg text-status-neutral-text'
-        )}
-      >
-        <div
-          className={cn(
-            'h-1.5 w-1.5 rounded-full',
-            isPublished ? 'bg-status-success-text' : 'bg-status-neutral-text'
-          )}
-        />
-        {isPublished ? trueLabel : falseLabel}
-      </button>
+      {onClick ? (
+        <button
+          type="button"
+          onClick={onClick}
+          className={cn(statusClass, 'cursor-pointer')}
+        >
+          {content}
+        </button>
+      ) : (
+        <div className={statusClass}>{content}</div>
+      )}
     </AdminTableCell>
   )
 }

--- a/src/app/admin/_hooks/useAdminSearch.ts
+++ b/src/app/admin/_hooks/useAdminSearch.ts
@@ -1,0 +1,59 @@
+'use client'
+
+import { useState, useEffect, startTransition } from 'react'
+import { useRouter, useSearchParams, usePathname } from 'next/navigation'
+import { useDebounce } from '@/hooks'
+
+/**
+ * 검색어와 URL 쿼리 파라미터(q)를 동기화하는 훅
+ * @param delay 디바운스 지연 시간 (기본값: 300ms)
+ */
+export function useAdminSearch(delay = 300) {
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+
+  const [searchTerm, setSearchTerm] = useState(searchParams.get('q') || '')
+  const debouncedSearchTerm = useDebounce(searchTerm, delay)
+
+  // URL의 q 파라미터가 외부에서 변경되면(예: 탭 전환) 로컬 상태를 즉시 동기화합니다.
+  useEffect(() => {
+    const currentParamQ = searchParams.get('q') || ''
+    if (currentParamQ !== searchTerm) {
+      startTransition(() => {
+        setSearchTerm(currentParamQ)
+      })
+    }
+  }, [searchParams])
+
+  useEffect(() => {
+    const currentQ = searchParams.get('q') || ''
+
+    // 디바운스된 값이 현재 URL과 다르고,
+    // 현재 입력 중인 값(searchTerm)과 디바운스된 값이 일치할 때만(즉, 디바운스가 완료되었을 때만)
+    // URL을 업데이트합니다. 이 조건이 탭 전환 시 이전 값이 URL을 덮어쓰는 것을 방지합니다.
+    if (
+      debouncedSearchTerm !== currentQ &&
+      debouncedSearchTerm === searchTerm
+    ) {
+      const params = new URLSearchParams(searchParams.toString())
+
+      if (debouncedSearchTerm) {
+        params.set('q', debouncedSearchTerm)
+      } else {
+        params.delete('q')
+      }
+
+      if (params.has('page')) {
+        params.delete('page')
+      }
+
+      router.push(`${pathname}?${params.toString()}`)
+    }
+  }, [debouncedSearchTerm, pathname, router, searchParams, searchTerm])
+
+  return {
+    searchTerm,
+    setSearchTerm,
+  }
+}

--- a/src/app/admin/category/_api/adminDeleteCategory.ts
+++ b/src/app/admin/category/_api/adminDeleteCategory.ts
@@ -1,0 +1,10 @@
+import { authFetch } from '@/lib/api/client'
+
+/**
+ * 어드민 카테고리 삭제 API
+ */
+export const deleteAdminCategory = (
+  categoryId: number
+): Promise<{ success: boolean }> => {
+  return authFetch.delete(`/api/v1/admin/scents/categories/${categoryId}`)
+}

--- a/src/app/admin/category/_components/CategoryDeleteButton.tsx
+++ b/src/app/admin/category/_components/CategoryDeleteButton.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import React from 'react'
+import Button from '@/components/common/Button'
+import TrashIcon from '@/assets/icons/trash.svg'
+import { deleteCategoryAction } from '../_lib/postCategoryAction'
+import { useModalStore } from '@/store/useModalStore'
+
+interface CategoryDeleteButtonProps {
+  categoryId: number
+}
+
+export function CategoryDeleteButton({
+  categoryId,
+}: CategoryDeleteButtonProps) {
+  const { openAlert, closeModal } = useModalStore()
+
+  const handleDelete = async () => {
+    openAlert({
+      type: 'danger',
+      title: '카테고리 삭제',
+      content: '해당 카테고리를 정말 삭제하시겠습니까?',
+      confirmText: '삭제',
+      onConfirm: async () => {
+        try {
+          const result = await deleteCategoryAction(categoryId)
+          if (result.success) {
+            closeModal()
+          } else {
+            alert('삭제에 실패했습니다.')
+          }
+        } catch {
+          alert('삭제 중 오류가 발생했습니다.')
+        }
+      },
+    })
+  }
+
+  return (
+    <Button color="none" size="w32h32" rounded="sm" onClick={handleDelete}>
+      <TrashIcon
+        width={16}
+        height={16}
+        className="hover:text-black-primary text-gray-400 transition-colors"
+      />
+    </Button>
+  )
+}

--- a/src/app/admin/category/_components/CategoryTableServer.tsx
+++ b/src/app/admin/category/_components/CategoryTableServer.tsx
@@ -7,22 +7,36 @@ import {
   AdminDateCell,
   AdminTableEmpty,
 } from '@/app/admin/_components'
-import Button from '@/components/common/Button'
-import TrashIcon from '@/assets/icons/trash.svg'
 import AdminCategoryIcon from '@/assets/icons/adminCategory.svg'
+
+import { CategoryDeleteButton } from './CategoryDeleteButton'
 
 interface CategoryTableServerProps {
   activeTab: CategoryTabId
+  searchParams: {
+    q?: string
+  }
 }
 
 export async function CategoryTableServer({
   activeTab,
+  searchParams,
 }: CategoryTableServerProps) {
   const response = await fetchAdminCategories({ root_category: activeTab })
 
   // response.data.categories[0] 계층 구조
   const rootCategory = response?.data?.categories?.[0]
-  const items = rootCategory?.children || []
+  const allItems = rootCategory?.children || []
+
+  // 로컬 필터링 (명칭 검색)
+  const items = allItems.filter((item) => {
+    if (!searchParams.q) return true
+    const q = searchParams.q.toLowerCase()
+    return (
+      item.name.kr.toLowerCase().includes(q) ||
+      item.name.en.toLowerCase().includes(q)
+    )
+  })
 
   if (!items.length) {
     return <AdminTableEmpty />
@@ -52,13 +66,7 @@ export async function CategoryTableServer({
 
           <AdminTableCell slot={7}>
             <div className="flex justify-center">
-              <Button color="none" size="w32h32" rounded="sm">
-                <TrashIcon
-                  width={16}
-                  height={16}
-                  className="hover:text-black-primary text-gray-400 transition-colors"
-                />
-              </Button>
+              <CategoryDeleteButton categoryId={item.category_id} />
             </div>
           </AdminTableCell>
         </AdminTableRow>

--- a/src/app/admin/product/_api/adminDeleteProduct.ts
+++ b/src/app/admin/product/_api/adminDeleteProduct.ts
@@ -1,0 +1,16 @@
+import { authFetch } from '@/lib/api/client'
+import { ProductTabId } from '../_types/AdminProductType'
+
+/**
+ * 어드민 상품 삭제 API
+ */
+export const deleteAdminProduct = (
+  type: ProductTabId,
+  id: number
+): Promise<{ success: boolean }> => {
+  const endpoint =
+    type === 'ELEMENT'
+      ? `/api/v1/scents/elements/${id}`
+      : `/api/v1/scents/blends/${id}`
+  return authFetch.delete(endpoint)
+}

--- a/src/app/admin/product/_components/ProductDeleteButton.tsx
+++ b/src/app/admin/product/_components/ProductDeleteButton.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import React from 'react'
+import Button from '@/components/common/Button'
+import TrashIcon from '@/assets/icons/trash.svg'
+import { deleteProductAction } from '../_lib/productActions'
+import { useModalStore } from '@/store/useModalStore'
+import { ProductTabId } from '../_types/AdminProductType'
+
+interface ProductDeleteButtonProps {
+  type: ProductTabId
+  id: number
+}
+
+export function ProductDeleteButton({ type, id }: ProductDeleteButtonProps) {
+  const { openAlert, closeModal } = useModalStore()
+
+  const handleDelete = async () => {
+    openAlert({
+      type: 'danger',
+      title: '상품 삭제',
+      content: `해당 상품을 정말 삭제하시겠습니까?`,
+      confirmText: '삭제',
+      onConfirm: async () => {
+        try {
+          const result = await deleteProductAction(type, id)
+          if (result.success) {
+            closeModal()
+          } else {
+            alert('삭제에 실패했습니다.')
+          }
+        } catch {
+          alert('삭제 중 오류가 발생했습니다.')
+        }
+      },
+    })
+  }
+
+  return (
+    <Button color="none" size="w32h32" rounded="sm" onClick={handleDelete}>
+      <TrashIcon
+        width={16}
+        height={16}
+        className="hover:text-danger text-gray-400 transition-colors"
+      />
+    </Button>
+  )
+}

--- a/src/app/admin/product/_components/ProductTableServer.tsx
+++ b/src/app/admin/product/_components/ProductTableServer.tsx
@@ -4,8 +4,6 @@ import {
   AdminTableCell,
   AdminTableEmpty,
 } from '@/app/admin/_components'
-import Button from '@/components/common/Button'
-import PenIcon from '@/assets/icons/pen.svg'
 import { fetchAdminProductList } from '../_api/adminFetchProductList'
 import type {
   ProductTabId,
@@ -17,15 +15,27 @@ import {
   ACCORD_LABEL_PILL_SM_CLASS,
 } from '@/constants/accordLabelStyles'
 
+import { ProductDeleteButton } from './ProductDeleteButton'
+
 interface ProductTableServerProps {
   activeTab: ProductTabId
+  searchParams: { q?: string; scent_category_id?: string; [key: string]: any }
 }
 
 export async function ProductTableServer({
   activeTab,
+  searchParams,
 }: ProductTableServerProps) {
+  // Option 없이 전체 데이터를 가져옵니다 (Next.js 캐싱 활용)
   const response = await fetchAdminProductList(activeTab)
-  const items = response?.data?.results || []
+
+  const allItems = response?.data?.results || []
+
+  // 받아온 데이터를 기반으로 직접 필터링
+  const items = allItems.filter((item) => {
+    if (!searchParams.q) return true
+    return item.name.toLowerCase().includes(searchParams.q.toLowerCase())
+  })
 
   if (!items.length) {
     return <AdminTableEmpty />
@@ -97,9 +107,7 @@ export async function ProductTableServer({
             </AdminTableCell>
 
             <AdminTableCell slot={7}>
-              <Button color="none" size="w32h32" rounded="sm">
-                <PenIcon width={16} height={16} />
-              </Button>
+              <ProductDeleteButton type={activeTab} id={item.id} />
             </AdminTableCell>
           </AdminTableRow>
         )

--- a/src/app/admin/recommend/_api/adminDeleteRecommend.ts
+++ b/src/app/admin/recommend/_api/adminDeleteRecommend.ts
@@ -1,0 +1,12 @@
+import { authFetch } from '@/lib/api'
+import { RecommendTabId } from '../_types'
+
+/**
+ * 어드민 추천 데이터 삭제 API
+ */
+export const deleteAdminRecommend = (
+  tabId: RecommendTabId,
+  id: number
+): Promise<{ success: boolean }> => {
+  return authFetch.delete(`/api/v1/admin/matches/${tabId}/${id}`)
+}

--- a/src/app/admin/recommend/_components/RecommendDeleteButton.tsx
+++ b/src/app/admin/recommend/_components/RecommendDeleteButton.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import React from 'react'
+import Button from '@/components/common/Button'
+import TrashIcon from '@/assets/icons/trash.svg'
+import { deleteRecommendAction } from '../_actions/recommendActions'
+import { useModalStore } from '@/store/useModalStore'
+import { RecommendTabId } from '../_types'
+
+interface RecommendDeleteButtonProps {
+  tabId: RecommendTabId
+  id: number
+}
+
+export function RecommendDeleteButton({
+  tabId,
+  id,
+}: RecommendDeleteButtonProps) {
+  const { openAlert, closeModal } = useModalStore()
+
+  const handleDelete = async () => {
+    openAlert({
+      type: 'danger',
+      title: `${tabId === 'product-pools' ? '후보군' : '추천맵'} 삭제`,
+      content: `선택한 ${tabId === 'product-pools' ? '후보군' : '추천맵'}을 삭제하시겠습니까?`,
+      confirmText: '삭제',
+      onConfirm: async () => {
+        try {
+          const result = await deleteRecommendAction(tabId, id)
+          if (result.success) {
+            closeModal()
+          } else {
+            alert('삭제에 실패했습니다.')
+          }
+        } catch (error) {
+          console.error('Delete error:', error)
+          alert('삭제 중 오류가 발생했습니다.')
+        }
+      },
+    })
+  }
+
+  return (
+    <Button color="none" size="w32h32" rounded="sm" onClick={handleDelete}>
+      <TrashIcon
+        width={16}
+        height={16}
+        className="hover:text-danger text-gray-400 transition-colors"
+      />
+    </Button>
+  )
+}

--- a/src/app/admin/recommend/_page/BlendMapsTab.tsx
+++ b/src/app/admin/recommend/_page/BlendMapsTab.tsx
@@ -8,8 +8,7 @@ import {
   AdminStatusCell,
   AdminTypeCell,
 } from '@/app/admin/_components'
-import Button from '@/components/common/Button'
-import TrashIcon from '@/assets/icons/trash.svg'
+import { RecommendDeleteButton } from '../_components/RecommendDeleteButton'
 import {
   BlendMapsItemResponse,
   RecommendTabProps,
@@ -30,20 +29,16 @@ export const BlendMapsTab = ({
           <AdminStatusCell
             slot={3}
             status={row.publish_status}
-            onClick={() => onTogglePublish(row.id)}
+            onClick={
+              onTogglePublish ? () => onTogglePublish(row.id) : undefined
+            }
           />
 
           <AdminTableCell slot={4} />
           <AdminDateCell slot={5} date={row.created_at} />
           <AdminDateCell slot={6} date={row.updated_at} />
           <AdminTableCell slot={7}>
-            <Button color="none" size="w32h32" rounded="sm">
-              <TrashIcon
-                width={16}
-                height={16}
-                className="hover:text-red-500"
-              />
-            </Button>
+            <RecommendDeleteButton tabId="blend-maps" id={row.id} />
           </AdminTableCell>
         </AdminTableRow>
       ))}

--- a/src/app/admin/recommend/_page/ProductMapsTab.tsx
+++ b/src/app/admin/recommend/_page/ProductMapsTab.tsx
@@ -7,8 +7,7 @@ import {
   AdminFirstCell,
   AdminStatusCell,
 } from '@/app/admin/_components'
-import Button from '@/components/common/Button'
-import TrashIcon from '@/assets/icons/trash.svg'
+import { RecommendDeleteButton } from '../_components/RecommendDeleteButton'
 import {
   ProductMapsItemResponse,
   RecommendTabProps,
@@ -27,20 +26,16 @@ export const ProductMapsTab = ({
           <AdminStatusCell
             slot={3}
             status={row.publish_status}
-            onClick={() => onTogglePublish(row.id)}
+            onClick={
+              onTogglePublish ? () => onTogglePublish(row.id) : undefined
+            }
           />
 
           <AdminTableCell slot={4} />
           <AdminDateCell slot={5} date={row.created_at} />
           <AdminDateCell slot={6} date={row.updated_at} />
           <AdminTableCell slot={7}>
-            <Button color="none" size="w32h32" rounded="sm">
-              <TrashIcon
-                width={16}
-                height={16}
-                className="hover:text-red-500"
-              />
-            </Button>
+            <RecommendDeleteButton tabId="product-maps" id={row.id} />
           </AdminTableCell>
         </AdminTableRow>
       ))}

--- a/src/app/admin/recommend/_page/ProductPoolsTab.tsx
+++ b/src/app/admin/recommend/_page/ProductPoolsTab.tsx
@@ -8,8 +8,7 @@ import {
   AdminStatusCell,
   AdminTypeCell,
 } from '@/app/admin/_components'
-import Button from '@/components/common/Button'
-import TrashIcon from '@/assets/icons/trash.svg'
+import { RecommendDeleteButton } from '../_components/RecommendDeleteButton'
 import {
   ProductPoolsItemResponse,
   RecommendTabProps,
@@ -29,25 +28,19 @@ export const ProductPoolsTab = ({
 
           <AdminStatusCell
             slot={3}
-            status={
-              row.adoption_status === 'ADOPTED' ? 'PUBLISHED' : 'UNPUBLISHED'
-            }
+            status={row.adoption_status === 'ADOPTED' ? 'ADOPTED' : 'UNADOPTED'}
             trueLabel="채택"
             falseLabel="미채택"
-            onClick={() => onTogglePublish(row.id)}
+            onClick={
+              onTogglePublish ? () => onTogglePublish(row.id) : undefined
+            }
           />
 
           <AdminTableCell slot={4} />
           <AdminDateCell slot={5} date={row.created_at} />
           <AdminDateCell slot={6} date={row.updated_at} />
           <AdminTableCell slot={7}>
-            <Button color="none" size="w32h32" rounded="sm">
-              <TrashIcon
-                width={16}
-                height={16}
-                className="hover:text-red-500"
-              />
-            </Button>
+            <RecommendDeleteButton tabId="product-pools" id={row.id} />
           </AdminTableCell>
         </AdminTableRow>
       ))}

--- a/src/app/admin/test/_api/adminDeleteTest.ts
+++ b/src/app/admin/test/_api/adminDeleteTest.ts
@@ -1,0 +1,10 @@
+import { authFetch } from '@/lib/api'
+
+/**
+ * 어드민 테스트 삭제 API
+ */
+export const deleteAdminTest = (
+  form_id: number
+): Promise<{ success: boolean }> => {
+  return authFetch.delete(`/api/v1/admin/profilings/forms/${form_id}`)
+}

--- a/src/app/admin/test/_components/TestDeleteButton.tsx
+++ b/src/app/admin/test/_components/TestDeleteButton.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import React from 'react'
+import Button from '@/components/common/Button'
+import TrashIcon from '@/assets/icons/trash.svg'
+import { deleteTestAction } from '../_actions/testActions'
+import { useModalStore } from '@/store/useModalStore'
+
+interface TestDeleteButtonProps {
+  testId: number
+}
+
+export function TestDeleteButton({ testId }: TestDeleteButtonProps) {
+  const { openAlert, closeModal } = useModalStore()
+
+  const handleDelete = async () => {
+    openAlert({
+      type: 'danger',
+      title: '테스트 삭제',
+      content: '해당 테스트를 삭제하시겠습니까?',
+      confirmText: '삭제',
+      onConfirm: async () => {
+        try {
+          const result = await deleteTestAction(testId)
+          if (result.success) {
+            closeModal()
+          } else {
+            alert('삭제에 실패했습니다.')
+          }
+        } catch {
+          alert('삭제 중 오류가 발생했습니다.')
+        }
+      },
+    })
+  }
+
+  return (
+    <Button color="none" size="w32h32" rounded="sm" onClick={handleDelete}>
+      <TrashIcon
+        width={16}
+        height={16}
+        className="hover:text-danger text-gray-400 transition-colors"
+      />
+    </Button>
+  )
+}

--- a/src/app/admin/test/_components/TestTableServer.tsx
+++ b/src/app/admin/test/_components/TestTableServer.tsx
@@ -1,0 +1,70 @@
+import React from 'react'
+import {
+  AdminTableRow,
+  AdminTableCell,
+  AdminFirstCell,
+  AdminDateCell,
+  AdminTypeCell,
+  AdminTableEmpty,
+} from '@/app/admin/_components'
+import { fetchAdminTests } from '../_api/adminFetchTest'
+import { TestDeleteButton } from './TestDeleteButton'
+import { TestStatusCell } from './TestStatusCell'
+
+interface TestTableServerProps {
+  searchParams: {
+    q?: string
+    profiling_type?: string
+    publish_status?: string
+  }
+}
+
+export async function TestTableServer({ searchParams }: TestTableServerProps) {
+  const response = await fetchAdminTests()
+
+  const allTests = response?.data?.content || []
+
+  // 받아온 데이터를 기반으로 직접 필터링 (필요 시)
+  const tests = allTests.filter((test) => {
+    const matchesSearch = searchParams.q
+      ? test.name.toLowerCase().includes(searchParams.q.toLowerCase())
+      : true
+    const matchesType = searchParams.profiling_type
+      ? test.profiling_type === searchParams.profiling_type
+      : true
+    const matchesStatus = searchParams.publish_status
+      ? test.publish_status === searchParams.publish_status
+      : true
+    return matchesSearch && matchesType && matchesStatus
+  })
+
+  if (!tests.length) {
+    return <AdminTableEmpty />
+  }
+
+  return (
+    <>
+      {tests.map((test) => (
+        <AdminTableRow key={test.id}>
+          <AdminFirstCell>{test.name}</AdminFirstCell>
+
+          <AdminTypeCell slot={2} type={test.profiling_type} />
+
+          <TestStatusCell testId={test.id} status={test.publish_status} />
+
+          <AdminTableCell slot={4} className="text-black-secondary">
+            -
+          </AdminTableCell>
+
+          <AdminDateCell slot={5} date={test.created_at} />
+
+          <AdminDateCell slot={6} date={test.updated_at} />
+
+          <AdminTableCell slot={7}>
+            <TestDeleteButton testId={test.id} />
+          </AdminTableCell>
+        </AdminTableRow>
+      ))}
+    </>
+  )
+}

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * 디바운스 훅
+ * @param value 디바운스할 값
+ * @param delay 지연 시간 (ms)
+ * @returns 지연된 값
+ */
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value)
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value)
+    }, delay)
+
+    return () => {
+      clearTimeout(handler)
+    }
+  }, [value, delay])
+
+  return debouncedValue
+}


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->

어드민 관리페이지에는 4가지 관리 탭이 존재 하는데 각각 관리 탭에서 정보들을 조회할 때 사용되는 어드민 공통 검색 + 필터 + 삭제 컴포넌트에 실제 로직을 추가
-> 파일 변경 양이 너무 많아서 로직만 추가할려고 했는데 실제 페이지에 적용이 안된부분이 있어서 오류가 날수도 있어서 바로 다음 PR에 올리겠습니다.


## 📌 관련 이슈

<!-- Closes #이슈번호 -->

Closes #117 

## 🧩 작업 내용 (주요 변경사항)

- AdminFilterBar.tsx를 AdminSearchBar.tsx로 이름 변경 + searchValue는 부모가 항상 제어 + filterValue는 외부 값이 있으면 우선
사용, 없으면 내부 state로 사용하게 변경 + usedebounce 훅 생성
- 각 어드민 페이지(테스트, 상품, 카테고리, 추천)에 항목 삭제 로직을 추가하여 도메인별 삭제 API 함수와 함수를 받는 deleteButton을 추가
-  작성한 delete 버튼을 각각 페이지의 클라이언트 컴포넌트에 적용
## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

PR 한번에 너무 많이 올릴거 같아서 나눠서 올리겠습니다 다음 PR에서 적용 스크린샷 함께 올리겠습니다!

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 로컬에서 실행 확인 완료
