### PR TITLE
[feat] 로그인 및 로그아웃 api연동 (#130)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { Header } from '@/components/common/Header'
 import { Footer } from '@/components/common/Footer'
 import { MockProvider } from '@/mocks/MockProvider'
 import { GlobalModal } from '@/components/common/Modal/GlobalModal'
+import ClientLayoutInitializer from '@/components/common/ClientLayoutInitializer'
 import './globals.css'
 
 const pretendard = localFont({
@@ -29,11 +30,13 @@ export default function RootLayout({
         className={`${pretendard.variable} flex min-h-screen flex-col antialiased`}
       >
         <MockProvider>
-          <Header />
-          <main className="flex-1">{children}</main>
-          <Footer />
-          <div id="modal-root" />
-          <GlobalModal />
+          <ClientLayoutInitializer>
+            <Header />
+            <main className="flex-1">{children}</main>
+            <Footer />
+            <div id="modal-root" />
+            <GlobalModal />
+          </ClientLayoutInitializer>
         </MockProvider>
       </body>
     </html>

--- a/src/app/login/callback/CallbackClient.tsx
+++ b/src/app/login/callback/CallbackClient.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useSearchParams, useRouter } from 'next/navigation'
+import { LoadingSpinner } from '@/components/common/LoadingSpinner'
+import { postSocialCallback } from '@/lib/api/auth'
+import { useAuthStore } from '@/store/useAuthStore'
+
+export default function CallbackClient() {
+  const searchParams = useSearchParams()
+  const router = useRouter()
+  const { login } = useAuthStore()
+
+  useEffect(() => {
+    const code = searchParams.get('code')
+    const state = searchParams.get('state') // 백엔드에서 state 검증을 요구할 경우를 대비해 함께 전달
+
+    const handleLogin = async () => {
+      if (!code) {
+        alert('인증 코드가 없습니다. 다시 시도해 주세요.')
+        router.replace('/login')
+        return
+      }
+
+      try {
+        const data = await postSocialCallback('kakao', code, state)
+
+        if (data.success) {
+          const { access_token, refresh_token, user } = data.data
+          localStorage.setItem('accessToken', access_token)
+          localStorage.setItem('refreshToken', refresh_token)
+          localStorage.setItem('user', JSON.stringify(user))
+          login(user)
+
+          alert(`${user.nickname}님, 환영합니다!`)
+          router.replace('/')
+        } else {
+          throw new Error(data.error?.message || '로그인에 실패했습니다.')
+        }
+      } catch (error: any) {
+        alert(error.message || '로그인 처리 중 오류가 발생했습니다.')
+        router.replace('/login')
+      }
+    }
+
+    handleLogin()
+  }, [searchParams, router, login])
+
+  return (
+    <div className="flex h-screen w-full flex-col items-center justify-center gap-4">
+      <LoadingSpinner />
+      <p>로그인 처리 중입니다. 잠시만 기다려주세요...</p>
+    </div>
+  )
+}

--- a/src/app/login/callback/page.tsx
+++ b/src/app/login/callback/page.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useSearchParams, useRouter } from 'next/navigation'
+import { LoadingSpinner } from '@/components/common/LoadingSpinner'
+import { postSocialCallback } from '@/lib/api/auth'
+import { useAuthStore } from '@/store/useAuthStore'
+
+export default function KakaoCallbackPage() {
+  const searchParams = useSearchParams()
+  const router = useRouter()
+  const { login } = useAuthStore()
+
+  useEffect(() => {
+    const code = searchParams.get('code')
+    const state = searchParams.get('state') // 백엔드에서 state 검증을 요구할 경우를 대비해 함께 전달
+
+    const handleLogin = async () => {
+      if (!code) {
+        alert('인증 코드가 없습니다. 다시 시도해 주세요.')
+        router.replace('/login')
+        return
+      }
+
+      try {
+        const data = await postSocialCallback('kakao', code, state)
+
+        if (data.success) {
+          const { access_token, refresh_token, user } = data.data
+          localStorage.setItem('accessToken', access_token)
+          localStorage.setItem('refreshToken', refresh_token)
+          localStorage.setItem('user', JSON.stringify(user))
+          login(user)
+
+          alert(`${user.nickname}님, 환영합니다!`)
+          router.replace('/')
+        } else {
+          throw new Error(data.error?.message || '로그인에 실패했습니다.')
+        }
+      } catch (error: any) {
+        alert(error.message || '로그인 처리 중 오류가 발생했습니다.')
+        router.replace('/login')
+      }
+    }
+
+    handleLogin()
+  }, [searchParams, router, login])
+
+  return (
+    <div className="flex h-screen w-full flex-col items-center justify-center gap-4">
+      <LoadingSpinner />
+      <p>로그인 처리 중입니다. 잠시만 기다려주세요...</p>
+    </div>
+  )
+}

--- a/src/app/login/callback/page.tsx
+++ b/src/app/login/callback/page.tsx
@@ -1,55 +1,18 @@
-'use client'
-
-import { useEffect } from 'react'
-import { useSearchParams, useRouter } from 'next/navigation'
+import { Suspense } from 'react'
+import CallbackClient from './CallbackClient'
 import { LoadingSpinner } from '@/components/common/LoadingSpinner'
-import { postSocialCallback } from '@/lib/api/auth'
-import { useAuthStore } from '@/store/useAuthStore'
 
 export default function KakaoCallbackPage() {
-  const searchParams = useSearchParams()
-  const router = useRouter()
-  const { login } = useAuthStore()
-
-  useEffect(() => {
-    const code = searchParams.get('code')
-    const state = searchParams.get('state') // 백엔드에서 state 검증을 요구할 경우를 대비해 함께 전달
-
-    const handleLogin = async () => {
-      if (!code) {
-        alert('인증 코드가 없습니다. 다시 시도해 주세요.')
-        router.replace('/login')
-        return
-      }
-
-      try {
-        const data = await postSocialCallback('kakao', code, state)
-
-        if (data.success) {
-          const { access_token, refresh_token, user } = data.data
-          localStorage.setItem('accessToken', access_token)
-          localStorage.setItem('refreshToken', refresh_token)
-          localStorage.setItem('user', JSON.stringify(user))
-          login(user)
-
-          alert(`${user.nickname}님, 환영합니다!`)
-          router.replace('/')
-        } else {
-          throw new Error(data.error?.message || '로그인에 실패했습니다.')
-        }
-      } catch (error: any) {
-        alert(error.message || '로그인 처리 중 오류가 발생했습니다.')
-        router.replace('/login')
-      }
-    }
-
-    handleLogin()
-  }, [searchParams, router, login])
-
   return (
-    <div className="flex h-screen w-full flex-col items-center justify-center gap-4">
-      <LoadingSpinner />
-      <p>로그인 처리 중입니다. 잠시만 기다려주세요...</p>
-    </div>
+    <Suspense
+      fallback={
+        <div className="flex h-screen w-full flex-col items-center justify-center gap-4">
+          <LoadingSpinner />
+          <p>로그인 페이지를 준비 중입니다...</p>
+        </div>
+      }
+    >
+      <CallbackClient />
+    </Suspense>
   )
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,10 +1,29 @@
+'use client'
+
 import Button from '@/components/common/Button'
 import KakaoIcon from '@/assets/icons/kakao.svg'
 import IdIcon from '@/assets/icons/loginId.svg'
 import PwIcon from '@/assets/icons/loginPassword.svg'
 import Input from '@/components/common/Input'
+import { getSocialAuthorizeUrl } from '@/lib/api/auth'
 
 export default function LoginPage() {
+  const handleKakaoLogin = async () => {
+    try {
+      const state = Math.random().toString(36).substring(2)
+
+      const data = await getSocialAuthorizeUrl('kakao', state)
+
+      if (data.success && data.data.authorize_url) {
+        window.location.href = data.data.authorize_url
+      } else {
+        throw new Error(data.error?.message || '카카오 로그인에 실패했습니다.')
+      }
+    } catch (error) {
+      alert('로그인 처리 중 오류가 발생했습니다.')
+    }
+  }
+
   return (
     <div className="flex flex-col items-center justify-around">
       <div className="flex flex-col items-center">
@@ -48,7 +67,12 @@ export default function LoginPage() {
           </span>
           <div className="h-px flex-1 bg-gray-200" />
         </div>
-        <Button color="kakao" size="w382h48" className="font-medium">
+        <Button
+          color="kakao"
+          size="w382h48"
+          className="font-medium"
+          onClick={handleKakaoLogin}
+        >
           <KakaoIcon className="mr-2" />
           카카오로 시작하기
         </Button>

--- a/src/components/common/ClientLayoutInitializer.tsx
+++ b/src/components/common/ClientLayoutInitializer.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useAuthStore } from '@/store/useAuthStore'
+
+export default function ClientLayoutInitializer({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  useEffect(() => {
+    useAuthStore.getState().initialize()
+  }, [])
+
+  return <>{children}</>
+}

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -209,7 +209,6 @@ export function Dropdown({
                 index={index}
                 variant={variant}
                 onClose={() => handleItemClick(item)}
-                onClick={() => handleItemClick(item)}
               />
             ))}
           </ul>

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -12,6 +12,9 @@ import CloseIcon from '@/assets/icons/close.svg'
 import OpenIcon from '@/assets/icons/open.svg'
 import { useModalStore } from '@/store/useModalStore'
 import Modal from './Modal'
+import { postLogout } from '@/lib/api/auth'
+import { useAuthStore } from '@/store/useAuthStore'
+import { useState, useEffect } from 'react'
 
 const styles = {
   header:
@@ -28,7 +31,7 @@ const styles = {
   chevronWrap: 'ml-0.5 shrink-0',
 } as const
 export function Header() {
-  // useModalStore만 사용하도록 변경
+  const { isLoggedIn, user, logout: logoutFromStore } = useAuthStore()
   const router = useRouter()
 
   const { openModal, closeModal, closeAll } = useModalStore()
@@ -59,14 +62,92 @@ export function Header() {
       </Modal>
     )
   }
-  const logout = () => {
-    // TODO: 실제 로그아웃 로직 구현
-    router.push('/login')
+  const logout = async () => {
+    const accessToken = localStorage.getItem('accessToken')
+    const refreshToken = localStorage.getItem('refreshToken')
+
+    if (!accessToken || !refreshToken) {
+      alert('로그인 정보가 없습니다.')
+      logoutFromStore()
+      router.push('/login')
+      return
+    }
+
+    try {
+      await postLogout(accessToken, refreshToken)
+      alert('로그아웃되었습니다.')
+      localStorage.removeItem('accessToken')
+      localStorage.removeItem('refreshToken')
+      localStorage.removeItem('user')
+      logoutFromStore()
+      router.push('/login')
+    } catch (error: any) {
+      console.error('Logout Error:', error)
+      alert(error.message || '로그아웃 처리 중 오류가 발생했습니다.')
+    }
   }
 
   const handleProfileMenu = (action: string | undefined) => {
     if (action === 'openProfileModal') openProfileModal()
     if (action === 'logout') logout()
+  }
+
+  const renderRightMenu = () => {
+    // 개발 환경에서는 로그인 상태와 관계없이 로그인 링크와 프로필 메뉴를 모두 보여줌
+    if (process.env.NODE_ENV === 'development') {
+      return (
+        <>
+          <Link href="/login" className={styles.rightLink}>
+            로그인
+          </Link>
+          <Dropdown
+            trigger={
+              <Image
+                src="/profile.svg"
+                alt="프로필 메뉴"
+                width={36}
+                height={36}
+                className="size-9"
+                aria-hidden
+              />
+            }
+            items={headerNavLinks.profile}
+            variant="profile"
+            menuMinWidth="min-w-[200px]"
+            aria-label="프로필 메뉴"
+            onProfileAction={handleProfileMenu}
+          />
+        </>
+      )
+    }
+
+    if (isLoggedIn) {
+      return (
+        <Dropdown
+          trigger={
+            <Image
+              src="/profile.svg"
+              alt="프로필 메뉴"
+              width={36}
+              height={36}
+              className="size-9"
+              aria-hidden
+            />
+          }
+          items={headerNavLinks.profile}
+          variant="profile"
+          menuMinWidth="min-w-[200px]"
+          aria-label="프로필 메뉴"
+          onProfileAction={handleProfileMenu}
+        />
+      )
+    }
+
+    return (
+      <Link href="/login" className={styles.rightLink}>
+        로그인
+      </Link>
+    )
   }
 
   return (
@@ -137,28 +218,7 @@ export function Header() {
             </nav>
           </div>
 
-          <div className={styles.rightMenu}>
-            <Link href="/login" className={styles.rightLink}>
-              로그인
-            </Link>
-            <Dropdown
-              trigger={
-                <Image
-                  src="/profile.svg"
-                  alt=""
-                  width={36}
-                  height={36}
-                  className="size-9"
-                  aria-hidden
-                />
-              }
-              items={headerNavLinks.profile}
-              variant="profile"
-              menuMinWidth="min-w-[200px]"
-              aria-label="프로필 메뉴"
-              onProfileAction={handleProfileMenu}
-            />
-          </div>
+          <div className={styles.rightMenu}>{renderRightMenu()}</div>
         </div>
       </header>
       {/* useModalStore에서 모달 렌더링, Header에서는 직접 렌더링하지 않음 */}

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -1,0 +1,117 @@
+import type { ApiResponse, AuthTokens, AuthorizeUrl } from '@/types'
+
+// 소셜 로그인 및 토큰 관련 API 함수 모음
+
+/**
+ * 소셜 로그인/회원가입 URL을 요청합니다.
+ * @param provider 소셜 제공자 (e.g., 'kakao')
+ * @param state CSRF 방지용 랜덤 문자열
+ * @param redirectUri 리디렉션 URI
+ */
+export async function getSocialAuthorizeUrl(
+  provider: string,
+  state: string
+): Promise<ApiResponse<AuthorizeUrl>> {
+  const redirectUri = `${window.location.origin}/login/callback`
+  const backendApiUrl = process.env.NEXT_PUBLIC_API_URL
+  const res = await fetch(
+    `${backendApiUrl}/api/v1/auth/social/${provider}/authorize-url?state=${state}&redirect_uri=${encodeURIComponent(redirectUri)}`
+  )
+
+  if (!res.ok) {
+    const errorData = await res.json().catch(() => null) // 에러 응답이 JSON이 아닐 수도 있음
+    console.error('Error fetching authorize URL:', errorData)
+    throw new Error('Failed to fetch authorize URL')
+  }
+
+  return res.json()
+}
+
+/**
+ * 소셜 로그인/회원가입 처리를 요청합니다.
+ * @param provider 소셜 제공자 (e.g., 'kakao')
+ * @param code 인가 코드
+ * @param state CSRF 방지용 state 값 (선택)
+ */
+export async function postSocialCallback(
+  provider: string,
+  code: string,
+  state: string | null
+): Promise<ApiResponse<AuthTokens>> {
+  const redirectUri = `${window.location.origin}/login/callback`
+  const backendApiUrl = process.env.NEXT_PUBLIC_API_URL
+  const response = await fetch(
+    `${backendApiUrl}/api/v1/auth/${provider}/callback`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        code,
+        state,
+        redirect_uri: redirectUri,
+      }),
+    }
+  )
+
+  const data = await response.json()
+
+  if (!response.ok) {
+    console.error('Error in social callback:', data)
+    throw new Error(data.error?.message || 'Failed to process social callback')
+  }
+
+  return data
+}
+
+/**
+ * 토큰 재발급을 요청합니다.
+ * @param refreshToken 리프레시 토큰
+ */
+export async function postTokenRefresh(
+  refreshToken: string
+): Promise<ApiResponse<Pick<AuthTokens, 'access_token'>>> {
+  const backendApiUrl = process.env.NEXT_PUBLIC_API_URL
+  const res = await fetch(`${backendApiUrl}/api/v1/auth/token/refresh`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ refresh_token: refreshToken }),
+  })
+
+  if (!res.ok) {
+    const errorData = await res.json().catch(() => null)
+    console.error('Error refreshing token:', errorData)
+    throw new Error('Failed to refresh token')
+  }
+
+  return res.json()
+}
+
+/**
+ * 로그아웃을 요청합니다.
+ * @param accessToken 액세스 토큰
+ * @param refreshToken 리프레시 토큰
+ */
+export async function postLogout(
+  accessToken: string,
+  refreshToken: string
+): Promise<ApiResponse<null>> {
+  const backendApiUrl = process.env.NEXT_PUBLIC_API_URL
+  const response = await fetch(`${backendApiUrl}/api/v1/auth/logout`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify({
+      refresh_token: refreshToken,
+    }),
+  })
+
+  const data = await response.json().catch(() => ({})) // 응답이 JSON이 아닐 수도 있음
+
+  if (!response.ok) {
+    throw new Error(data.error?.message || 'Failed to logout')
+  }
+
+  return data
+}

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -1,0 +1,33 @@
+import { create } from 'zustand'
+import type { User } from '@/types'
+
+interface AuthState {
+  isLoggedIn?: boolean // undefined: 초기 상태, true: 로그인, false: 로그아웃
+  user: User | null
+  login: (user: User) => void
+  logout: () => void
+  initialize: () => void
+}
+
+export const useAuthStore = create<AuthState>((set) => ({
+  isLoggedIn: undefined,
+  user: null,
+  login: (user) => set({ isLoggedIn: true, user }),
+  logout: () => set({ isLoggedIn: false, user: null }),
+  initialize: () => {
+    if (typeof window !== 'undefined') {
+      const token = localStorage.getItem('accessToken')
+      const storedUser = localStorage.getItem('user')
+      let user = null
+      try {
+        if (storedUser) {
+          user = JSON.parse(storedUser)
+        }
+      } catch (e) {
+        console.error('Failed to parse user from localStorage', e)
+        localStorage.removeItem('user')
+      }
+      set({ isLoggedIn: !!token, user })
+    }
+  },
+}))

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,1 +1,42 @@
-export {}
+export interface AccordLabelStyle {
+  label: string
+  style: string
+}
+
+/**
+ * API 응답의 공통적인 구조를 정의합니다.
+ */
+export interface ApiResponse<T> {
+  success: boolean
+  data: T
+  error?: {
+    code: string
+    message: string
+  }
+}
+
+/**
+ * 사용자 정보 타입을 정의합니다.
+ */
+export interface User {
+  id: number // 또는 string, 백엔드 데이터 타입에 따라 조절
+  nickname: string
+  email?: string
+  profileImageUrl?: string
+}
+
+/**
+ * 소셜 로그인 콜백 API 응답의 data 타입을 정의합니다.
+ */
+export interface AuthTokens {
+  access_token: string
+  refresh_token: string
+  user: User
+}
+
+/**
+ * 소셜 로그인 URL 요청 API 응답의 data 타입을 정의합니다.
+ */
+export interface AuthorizeUrl {
+  authorize_url: string
+}


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->
로그인 및 로그아웃 api연동 했습니다

## 📌 관련 이슈

<!-- Closes #이슈번호 -->

Closes #130 

## 🧩 작업 내용 (주요 변경사항)

- 소셜 로그인, 로그아웃 api연동 
- 

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->
개발 환경에선 로그인버튼과 아이콘 버튼이 같이 뜨도록 설정해뒀습니다
## ✅ PR 체크리스트

- [ ] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [ ] 불필요한 console.log 제거
- [ ] 로컬에서 실행 확인 완료
