### PR TITLE
[Refactor]인증 토큰 저장 방식을 httpOnly 쿠키로 전환 (#140)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,8 @@ jobs:
       - name: Create .env file
         run: |
           echo "NEXT_PUBLIC_USE_MOCK_API=${{ secrets.NEXT_PUBLIC_USE_MOCK_API }}" >> .env
-  
+          echo "NEXT_PUBLIC_API_URL=${{ secrets.NEXT_PUBLIC_API_URL }}" >> .env
+          echo "NEXT_PUBLIC_SITE_URL=${{ secrets.NEXT_PUBLIC_SITE_URL }}" >> .env
 
       - name: Build project
         run: npm run build

--- a/src/app/login/callback/CallbackClient.tsx
+++ b/src/app/login/callback/CallbackClient.tsx
@@ -1,19 +1,23 @@
 'use client'
 
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { useSearchParams, useRouter } from 'next/navigation'
 import { LoadingSpinner } from '@/components/common/LoadingSpinner'
-import { postSocialCallback } from '@/lib/api/auth'
+import { loginWithKakaoAction } from '@/lib/auth/sessionActions'
 import { useAuthStore } from '@/store/useAuthStore'
 
 export default function CallbackClient() {
   const searchParams = useSearchParams()
   const router = useRouter()
   const { login } = useAuthStore()
+  const hasHandled = useRef(false)
 
   useEffect(() => {
+    if (hasHandled.current) return
+    hasHandled.current = true
+
     const code = searchParams.get('code')
-    const state = searchParams.get('state') // 백엔드에서 state 검증을 요구할 경우를 대비해 함께 전달
+    const state = searchParams.get('state')
 
     const handleLogin = async () => {
       if (!code) {
@@ -23,19 +27,18 @@ export default function CallbackClient() {
       }
 
       try {
-        const data = await postSocialCallback('kakao', code, state)
+        // 토큰은 httpOnly 쿠키에 저장, user 정보만 반환
+        const result = await loginWithKakaoAction(code, state)
 
-        if (data.success) {
-          const { access_token, refresh_token, user } = data.data
-          localStorage.setItem('accessToken', access_token)
-          localStorage.setItem('refreshToken', refresh_token)
-          localStorage.setItem('user', JSON.stringify(user))
-          login(user)
+        if (result.success) {
+          // user 정보는 UI 표시용으로 localStorage에 저장
+          localStorage.setItem('user', JSON.stringify(result.user))
+          login(result.user)
 
-          alert(`${user.nickname}님, 환영합니다!`)
+          alert(`${result.user.nickname}님, 환영합니다!`)
           router.replace('/')
         } else {
-          throw new Error(data.error?.message || '로그인에 실패했습니다.')
+          throw new Error(result.error)
         }
       } catch (error: any) {
         alert(error.message || '로그인 처리 중 오류가 발생했습니다.')

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -36,22 +36,19 @@ export async function getSocialAuthorizeUrl(
 export async function postSocialCallback(
   provider: string,
   code: string,
-  state: string | null
+  state: string | null,
+  redirect_uri: string
 ): Promise<ApiResponse<AuthTokens>> {
-  const redirectUri = `${window.location.origin}/login/callback`
-  const backendApiUrl = process.env.NEXT_PUBLIC_API_URL
-  const response = await fetch(
-    `${backendApiUrl}/api/v1/auth/${provider}/callback`,
-    {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        code,
-        state,
-        redirect_uri: redirectUri,
-      }),
-    }
-  )
+  const baseUrl = process.env.NEXT_PUBLIC_API_URL
+  const response = await fetch(`${baseUrl}/api/v1/auth/${provider}/callback`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      code,
+      state,
+      redirect_uri,
+    }),
+  })
 
   const data = await response.json()
 

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -2,21 +2,8 @@ import { createFetch } from './createFetch'
 import { FetchError } from './fetchError'
 import { ApiErrorResponse } from './types'
 
-// 서버(RSC/빌드)에서는 상대 URL을 쓸 수 없어, base가 비면 절대 URL로 보정
-const getBaseUrl = () => {
-  const env = process.env.NEXT_PUBLIC_API_BASE_URL?.trim()
-  if (env) return env
-  if (typeof window === 'undefined') {
-    const site = process.env.NEXT_PUBLIC_SITE_URL?.trim()
-    if (site) return site
-    // 빌드/프리렌더 시 fetch에 절대 URL 필요 (상대 URL 파싱 불가)
-    return process.env.VERCEL_URL
-      ? `https://${process.env.VERCEL_URL}`
-      : 'http://localhost:3000'
-  }
-  return ''
-}
-const BASE_URL = getBaseUrl()
+const BASE_URL =
+  process.env.NEXT_PUBLIC_API_BASE_URL?.trim() || 'http://localhost:3000'
 
 const DEFAULT_HEADERS: Record<string, string> = {
   'Content-Type': 'application/json',
@@ -57,10 +44,19 @@ export const authFetch = createFetch({
   headers: DEFAULT_HEADERS,
   interceptors: {
     request: async (args) => {
-      // TODO: 로그인 구현 후 토큰 주입
-      // if (token) {
-      //   args.options.headers = { ...args.options.headers, Authorization: `Bearer ${token}` }
-      // }
+      // Server Action 컨텍스트에서만 실행 (typeof window === 'undefined')
+      // next/headers는 서버 전용 → dynamic import로 클라이언트 번들 오염 방지
+      if (typeof window === 'undefined') {
+        const { cookies } = await import('next/headers')
+        const cookieStore = await cookies()
+        const token = cookieStore.get('access_token')?.value
+        if (token) {
+          args.options.headers = {
+            ...args.options.headers,
+            Authorization: `Bearer ${token}`,
+          }
+        }
+      }
       return args
     },
     response: handleResponse,

--- a/src/lib/auth/sessionActions.ts
+++ b/src/lib/auth/sessionActions.ts
@@ -1,0 +1,77 @@
+'use server'
+
+import { cookies } from 'next/headers'
+import { postSocialCallback, postLogout } from '@/lib/api/auth'
+import type { User } from '@/types'
+
+type LoginResult =
+  | { success: true; user: User }
+  | { success: false; error: string }
+
+const BASE_COOKIE_OPTIONS = {
+  httpOnly: true,
+  secure: true,
+  expires: 3600,
+  refresh_expires: 259200,
+  sameSite: 'lax' as const,
+  path: '/',
+}
+
+/**
+ * 소셜 로그인 콜백 처리 Server Action
+ * - 백엔드에서 토큰 발급
+ * - access_token, refresh_token을 httpOnly 쿠키에 저장
+ * - user 정보를 반환 (클라이언트에서 localStorage에 저장)
+ */
+export async function loginWithKakaoAction(
+  code: string,
+  state: string | null
+): Promise<LoginResult> {
+  try {
+    const siteUrl =
+      process.env.NODE_ENV === 'production'
+        ? process.env.NEXT_PUBLIC_SITE_URL
+        : 'http://localhost:3000'
+    const redirectUri = `${siteUrl}/login/callback`
+    const data = await postSocialCallback('kakao', code, state, redirectUri)
+
+    if (!data.success) {
+      throw new Error(data.error?.message || '로그인에 실패했습니다.')
+    }
+
+    const { access_token, refresh_token, user } = data.data
+    const cookieStore = await cookies()
+
+    cookieStore.set('access_token', access_token, BASE_COOKIE_OPTIONS)
+    cookieStore.set('refresh_token', refresh_token, BASE_COOKIE_OPTIONS)
+
+    return { success: true, user }
+  } catch (error: any) {
+    return {
+      success: false,
+      error: error.message || '로그인 처리 중 오류가 발생했습니다.',
+    }
+  }
+}
+
+/**
+ * 로그아웃 Server Action
+ * - 백엔드 로그아웃 API 호출
+ * - httpOnly 쿠키 삭제
+ */
+export async function logoutAction(): Promise<void> {
+  const cookieStore = await cookies()
+  const accessToken = cookieStore.get('access_token')?.value
+  const refreshToken = cookieStore.get('refresh_token')?.value
+
+  if (accessToken && refreshToken) {
+    try {
+      await postLogout(accessToken, refreshToken)
+    } catch {
+      // 백엔드 로그아웃 실패해도 쿠키는 반드시 삭제
+    }
+  }
+
+  cookieStore.delete('access_token')
+  cookieStore.delete('refresh_token')
+}

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -1,11 +1,12 @@
 import { create } from 'zustand'
+import { logoutAction } from '@/lib/auth/sessionActions'
 import type { User } from '@/types'
 
 interface AuthState {
   isLoggedIn?: boolean // undefined: 초기 상태, true: 로그인, false: 로그아웃
   user: User | null
   login: (user: User) => void
-  logout: () => void
+  logout: () => Promise<void>
   initialize: () => void
 }
 
@@ -13,10 +14,15 @@ export const useAuthStore = create<AuthState>((set) => ({
   isLoggedIn: undefined,
   user: null,
   login: (user) => set({ isLoggedIn: true, user }),
-  logout: () => set({ isLoggedIn: false, user: null }),
+  logout: async () => {
+    // httpOnly 쿠키 삭제는 Server Action에서만 가능
+    await logoutAction()
+    localStorage.removeItem('user')
+    set({ isLoggedIn: false, user: null })
+  },
   initialize: () => {
     if (typeof window !== 'undefined') {
-      const token = localStorage.getItem('accessToken')
+      // user 정보만 localStorage에 저장
       const storedUser = localStorage.getItem('user')
       let user = null
       try {
@@ -27,7 +33,7 @@ export const useAuthStore = create<AuthState>((set) => ({
         console.error('Failed to parse user from localStorage', e)
         localStorage.removeItem('user')
       }
-      set({ isLoggedIn: !!token, user })
+      set({ isLoggedIn: !!user, user })
     }
   },
 }))

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -31,6 +31,8 @@ export interface User {
 export interface AuthTokens {
   access_token: string
   refresh_token: string
+  expires_in: number // access_token 만료 시간 (초)
+  refresh_expires_in: number // refresh_token 만료 시간 (초)
   user: User
 }
 


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->

 인증 토큰(access_token, refresh_token) 저장 방식을 localStorage에서 httpOnly 쿠키로 전환
 XSS 공격으로부터 토큰을 보호하고, Next.js Server Action 기반의 인증 흐름을 구축
  
  
## 📌 관련 이슈

<!-- Closes #이슈번호 -->

Closes #140 

## 🧩 작업 내용 (주요 변경사항)

- access_token/refresh_token을 localStorage 대신 httpOnly 쿠키에 저장authFetch 인터셉터에서 쿠키 자동 주입
- CallbackClient에서 Server Action 호출로 전환 및 useRef 이중실행 방지 적용
- AuthTokens 타입에 expires_in, refresh_expires_in 필드 추가
- loginWithKakaoAction/logoutAction Server Action 신규 생성,


## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

1. next/headers가 클라이언트 번들에 포함되지 않도록 처리
2. sessionActions.ts의 쿠키 옵션
```
const BASE_COOKIE_OPTIONS = {
  httpOnly: true,
  secure: true,
  expires: 3600,
  refresh_expires: 259200,
  sameSite: 'lax' as const,
  path: '/',
}
```
 보안 설정 검토

3. redirectUri 분기 로직: NODE_ENV === 'production' → NEXT_PUBLIC_SITE_URL, 그 외 → http://localhost:3000

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

user 표시 정보는 기존과 동일하게 localStorage에 유지시켰습니다.
토큰 자체는 JS에서 접근 불가합니다.


## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 로컬에서 실행 확인 완료
