### PR TITLE
[Refactor] 로그아웃 + 토큰 재발급 로직에 쿠키 설정에서 받아온 토큰 추가 (#140)

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -12,7 +12,7 @@ import CloseIcon from '@/assets/icons/close.svg'
 import OpenIcon from '@/assets/icons/open.svg'
 import { useModalStore } from '@/store/useModalStore'
 import Modal from './Modal'
-import { postLogout } from '@/lib/api/auth'
+import { logoutAction } from '@/lib/auth/sessionActions'
 import { useAuthStore } from '@/store/useAuthStore'
 import { useState, useEffect } from 'react'
 
@@ -63,21 +63,8 @@ export function Header() {
     )
   }
   const logout = async () => {
-    const accessToken = localStorage.getItem('accessToken')
-    const refreshToken = localStorage.getItem('refreshToken')
-
-    if (!accessToken || !refreshToken) {
-      alert('로그인 정보가 없습니다.')
-      logoutFromStore()
-      router.push('/login')
-      return
-    }
-
     try {
-      await postLogout(accessToken, refreshToken)
-      alert('로그아웃되었습니다.')
-      localStorage.removeItem('accessToken')
-      localStorage.removeItem('refreshToken')
+      await logoutAction()
       localStorage.removeItem('user')
       logoutFromStore()
       router.push('/login')

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -3,7 +3,7 @@ import { FetchError } from './fetchError'
 import { ApiErrorResponse } from './types'
 
 const BASE_URL =
-  process.env.NEXT_PUBLIC_API_BASE_URL?.trim() || 'http://localhost:3000'
+  process.env.NEXT_PUBLIC_API_URL?.trim() || 'http://localhost:3000'
 
 const DEFAULT_HEADERS: Record<string, string> = {
   'Content-Type': 'application/json',
@@ -50,6 +50,7 @@ export const authFetch = createFetch({
         const { cookies } = await import('next/headers')
         const cookieStore = await cookies()
         const token = cookieStore.get('access_token')?.value
+
         if (token) {
           args.options.headers = {
             ...args.options.headers,

--- a/src/lib/auth/sessionActions.ts
+++ b/src/lib/auth/sessionActions.ts
@@ -1,7 +1,11 @@
 'use server'
 
 import { cookies } from 'next/headers'
-import { postSocialCallback, postLogout } from '@/lib/api/auth'
+import {
+  postSocialCallback,
+  postLogout,
+  postTokenRefresh,
+} from '@/lib/api/auth'
 import type { User } from '@/types'
 
 type LoginResult =
@@ -10,11 +14,15 @@ type LoginResult =
 
 const BASE_COOKIE_OPTIONS = {
   httpOnly: true,
-  secure: true,
-  expires: 3600,
-  refresh_expires: 259200,
+  secure: false,
+  maxAge: 3600,
   sameSite: 'lax' as const,
   path: '/',
+}
+
+const REFRESH_COOKIE_OPTIONS = {
+  ...BASE_COOKIE_OPTIONS,
+  maxAge: 259200,
 }
 
 /**
@@ -43,8 +51,7 @@ export async function loginWithKakaoAction(
     const cookieStore = await cookies()
 
     cookieStore.set('access_token', access_token, BASE_COOKIE_OPTIONS)
-    cookieStore.set('refresh_token', refresh_token, BASE_COOKIE_OPTIONS)
-
+    cookieStore.set('refresh_token', refresh_token, REFRESH_COOKIE_OPTIONS)
     return { success: true, user }
   } catch (error: any) {
     return {
@@ -52,6 +59,23 @@ export async function loginWithKakaoAction(
       error: error.message || '로그인 처리 중 오류가 발생했습니다.',
     }
   }
+}
+
+/**
+ * 토큰 재발급 Server Action
+ * - 쿠키의 refresh_token으로 새 access_token 발급
+ * - 새 access_token을 httpOnly 쿠키에 저장
+ */
+export async function refreshTokenAction(): Promise<void> {
+  const cookieStore = await cookies()
+  const refreshToken = cookieStore.get('refresh_token')?.value
+
+  if (!refreshToken) {
+    throw new Error('refresh_token이 없습니다.')
+  }
+
+  const data = await postTokenRefresh(refreshToken)
+  cookieStore.set('access_token', data.data.access_token, BASE_COOKIE_OPTIONS)
 }
 
 /**


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->

로그아웃 + 토큰 재발급 로직에서 localStorage에서 토큰 값들을 받아오는 것이 아닌 서버 액션을 통해 쿠키에서 토큰을 꺼내와 진행 

## 📌 관련 이슈

<!-- Closes #이슈번호 -->

Closes #140

## 🧩 작업 내용 (주요 변경사항)

- sessionAction에 로그아웃 액션 + 재발급 액션 에서 쿠키에서 토큰 값들을 Get하여 요청

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->
1. 로그인 시 <img width="913" height="361" alt="image" src="https://github.com/user-attachments/assets/5bcdb608-0026-4c41-b75e-b20605e892ec" />

2. 로그아웃 시 
<img width="896" height="366" alt="image" src="https://github.com/user-attachments/assets/e2fe50df-ff1f-401f-a07c-60785194ba18" />

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->
배포 환경에서 테스트 해봐야 합니다.

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 로컬에서 실행 확인 완료
