### PR TITLE
[feat] 쿠키 인증 흐름 정리 login,me,logout 라우트 추가 (#133)

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from 'next/server'
+
+type LoginBody = {
+  accessToken?: string
+  refreshToken?: string
+}
+
+const BASE_COOKIE_OPTIONS = {
+  httpOnly: true,
+  secure: process.env.NODE_ENV === 'production',
+  sameSite: 'lax' as const,
+  path: '/',
+}
+
+export async function POST(request: Request) {
+  try {
+    const { accessToken, refreshToken } = (await request.json()) as LoginBody
+
+    if (!accessToken || !refreshToken) {
+      return NextResponse.json(
+        {
+          success: false,
+          data: null,
+          error: {
+            code: 'INVALID_REQUEST',
+            message: 'accessToken and refreshToken are required.',
+          },
+        },
+        { status: 400 }
+      )
+    }
+
+    const response = NextResponse.json({ success: true, data: null })
+
+    response.cookies.set('access_token', accessToken, {
+      ...BASE_COOKIE_OPTIONS,
+      maxAge: 60 * 60,
+    })
+    response.cookies.set('refresh_token', refreshToken, {
+      ...BASE_COOKIE_OPTIONS,
+      maxAge: 60 * 60 * 24 * 3,
+    })
+
+    return response
+  } catch (error) {
+    console.error('Login API error:', error)
+    return NextResponse.json(
+      {
+        success: false,
+        data: null,
+        error: {
+          code: 'LOGIN_FAILED',
+          message: 'An error occurred during login.',
+        },
+      },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server'
+
+export async function POST() {
+  try {
+    const response = NextResponse.json({
+      success: true,
+      data: null,
+    })
+
+    // 쿠키를 삭제하여 로그아웃 처리
+    response.cookies.set('access_token', '', { maxAge: 0, path: '/' })
+    response.cookies.set('refresh_token', '', { maxAge: 0, path: '/' })
+
+    return response
+  } catch (error) {
+    console.error('Logout API error:', error)
+    return NextResponse.json(
+      {
+        success: false,
+        data: null,
+        error: {
+          code: 'LOGOUT_FAILED',
+          message: 'An error occurred during logout.',
+        },
+      },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -1,0 +1,82 @@
+import { cookies } from 'next/headers'
+import { NextResponse } from 'next/server'
+import type { ApiResponse, User } from '@/types'
+
+export async function GET() {
+  try {
+    const baseUrl = process.env.NEXT_PUBLIC_API_URL?.trim()
+
+    if (!baseUrl) {
+      return NextResponse.json(
+        {
+          success: false,
+          data: null,
+          error: {
+            code: 'MISSING_API_URL',
+            message: 'NEXT_PUBLIC_API_URL is not configured.',
+          },
+        },
+        { status: 500 }
+      )
+    }
+
+    const cookieStore = await cookies()
+    const token = cookieStore.get('access_token')?.value
+
+    if (!token) {
+      return NextResponse.json(
+        {
+          success: false,
+          data: null,
+          error: {
+            code: 'UNAUTHORIZED',
+            message: 'No access token found.',
+          },
+        },
+        { status: 401 }
+      )
+    }
+
+    const response = await fetch(`${baseUrl}/api/v1/auth/me`, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      cache: 'no-store',
+    })
+
+    const data = (await response
+      .json()
+      .catch(() => null)) as ApiResponse<User> | null
+
+    if (!response.ok || !data) {
+      return NextResponse.json(
+        {
+          success: false,
+          data: null,
+          error: {
+            code: data?.error?.code ?? 'ME_FETCH_FAILED',
+            message: data?.error?.message ?? 'Failed to fetch user profile.',
+          },
+        },
+        { status: response.status || 500 }
+      )
+    }
+
+    return NextResponse.json(data, { status: response.status })
+  } catch (error) {
+    console.error('Me API error:', error)
+    return NextResponse.json(
+      {
+        success: false,
+        data: null,
+        error: {
+          code: 'ME_FAILED',
+          message: 'An error occurred while fetching profile.',
+        },
+      },
+      { status: 500 }
+    )
+  }
+}

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -12,7 +12,6 @@ import CloseIcon from '@/assets/icons/close.svg'
 import OpenIcon from '@/assets/icons/open.svg'
 import { useModalStore } from '@/store/useModalStore'
 import Modal from './Modal'
-import { logoutAction } from '@/lib/auth/sessionActions'
 import { useAuthStore } from '@/store/useAuthStore'
 import { useState, useEffect } from 'react'
 
@@ -64,9 +63,7 @@ export function Header() {
   }
   const logout = async () => {
     try {
-      await logoutAction()
-      localStorage.removeItem('user')
-      logoutFromStore()
+      await logoutFromStore()
       router.push('/login')
     } catch (error: any) {
       console.error('Logout Error:', error)

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -1,30 +1,37 @@
-import type { ApiResponse, AuthTokens, AuthorizeUrl } from '@/types'
-
-// 소셜 로그인 및 토큰 관련 API 함수 모음
+import type { ApiResponse, AuthTokens, AuthorizeUrl, User } from '@/types'
+import { apiFetch, appFetch } from './client'
+import { FetchError } from './fetchError'
 
 /**
  * 소셜 로그인/회원가입 URL을 요청합니다.
  * @param provider 소셜 제공자 (e.g., 'kakao')
  * @param state CSRF 방지용 랜덤 문자열
- * @param redirectUri 리디렉션 URI
  */
 export async function getSocialAuthorizeUrl(
   provider: string,
   state: string
 ): Promise<ApiResponse<AuthorizeUrl>> {
   const redirectUri = `${window.location.origin}/login/callback`
-  const backendApiUrl = process.env.NEXT_PUBLIC_API_URL
-  const res = await fetch(
-    `${backendApiUrl}/api/v1/auth/social/${provider}/authorize-url?state=${state}&redirect_uri=${encodeURIComponent(redirectUri)}`
-  )
 
-  if (!res.ok) {
-    const errorData = await res.json().catch(() => null) // 에러 응답이 JSON이 아닐 수도 있음
-    console.error('Error fetching authorize URL:', errorData)
-    throw new Error('Failed to fetch authorize URL')
+  try {
+    return await apiFetch.get<ApiResponse<AuthorizeUrl>>(
+      `/api/v1/auth/social/${provider}/authorize-url`,
+      {
+        params: { state, redirect_uri: redirectUri },
+      }
+    )
+  } catch (error) {
+    // 백엔드 경로가 /auth/{provider}/authorize-url 인 환경을 fallback으로 지원
+    if (error instanceof FetchError && error.status === 404) {
+      return apiFetch.get<ApiResponse<AuthorizeUrl>>(
+        `/api/v1/auth/${provider}/authorize-url`,
+        {
+          params: { state, redirect_uri: redirectUri },
+        }
+      )
+    }
+    throw error
   }
-
-  return res.json()
 }
 
 /**
@@ -61,54 +68,28 @@ export async function postSocialCallback(
 }
 
 /**
- * 토큰 재발급을 요청합니다.
- * @param refreshToken 리프레시 토큰
+ * 로그인 세션 쿠키 저장을 요청합니다.
  */
-export async function postTokenRefresh(
+export function postSessionLogin(
+  accessToken: string,
   refreshToken: string
-): Promise<ApiResponse<Pick<AuthTokens, 'access_token'>>> {
-  const backendApiUrl = process.env.NEXT_PUBLIC_API_URL
-  const res = await fetch(`${backendApiUrl}/api/v1/auth/token/refresh`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ refresh_token: refreshToken }),
+): Promise<ApiResponse<null>> {
+  return appFetch.post<ApiResponse<null>>('/api/auth/login', {
+    accessToken,
+    refreshToken,
   })
-
-  if (!res.ok) {
-    const errorData = await res.json().catch(() => null)
-    console.error('Error refreshing token:', errorData)
-    throw new Error('Failed to refresh token')
-  }
-
-  return res.json()
 }
 
 /**
  * 로그아웃을 요청합니다.
- * @param accessToken 액세스 토큰
- * @param refreshToken 리프레시 토큰
  */
-export async function postLogout(
-  accessToken: string,
-  refreshToken: string
-): Promise<ApiResponse<null>> {
-  const backendApiUrl = process.env.NEXT_PUBLIC_API_URL
-  const response = await fetch(`${backendApiUrl}/api/v1/auth/logout`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${accessToken}`,
-    },
-    body: JSON.stringify({
-      refresh_token: refreshToken,
-    }),
-  })
+export function postLogout(): Promise<ApiResponse<null>> {
+  return appFetch.post<ApiResponse<null>>('/api/auth/logout')
+}
 
-  const data = await response.json().catch(() => ({})) // 응답이 JSON이 아닐 수도 있음
-
-  if (!response.ok) {
-    throw new Error(data.error?.message || 'Failed to logout')
-  }
-
-  return data
+/**
+ * 현재 로그인된 사용자 정보를 가져옵니다.
+ */
+export function getMe(): Promise<ApiResponse<User>> {
+  return appFetch.get<ApiResponse<User>>('/api/auth/me')
 }

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -1,6 +1,6 @@
 import { createFetch } from './createFetch'
 import { FetchError } from './fetchError'
-import { ApiErrorResponse } from './types'
+import type { ApiErrorResponse } from './types'
 
 const BASE_URL =
   process.env.NEXT_PUBLIC_API_URL?.trim() || 'http://localhost:3000'
@@ -38,9 +38,8 @@ export const apiFetch = createFetch({
   },
 })
 
-// 인증이 필요한 Fetch 요청
-export const authFetch = createFetch({
-  baseUrl: BASE_URL,
+export const appFetch = createFetch({
+  baseUrl: '',
   headers: DEFAULT_HEADERS,
   interceptors: {
     request: async (args) => {
@@ -63,3 +62,5 @@ export const authFetch = createFetch({
     response: handleResponse,
   },
 })
+
+export const authFetch = appFetch

--- a/src/lib/auth/sessionActions.ts
+++ b/src/lib/auth/sessionActions.ts
@@ -1,11 +1,7 @@
 'use server'
 
 import { cookies } from 'next/headers'
-import {
-  postSocialCallback,
-  postLogout,
-  postTokenRefresh,
-} from '@/lib/api/auth'
+import { postSocialCallback, postLogout } from '@/lib/api/auth'
 import type { User } from '@/types'
 
 type LoginResult =
@@ -62,38 +58,16 @@ export async function loginWithKakaoAction(
 }
 
 /**
- * 토큰 재발급 Server Action
- * - 쿠키의 refresh_token으로 새 access_token 발급
- * - 새 access_token을 httpOnly 쿠키에 저장
- */
-export async function refreshTokenAction(): Promise<void> {
-  const cookieStore = await cookies()
-  const refreshToken = cookieStore.get('refresh_token')?.value
-
-  if (!refreshToken) {
-    throw new Error('refresh_token이 없습니다.')
-  }
-
-  const data = await postTokenRefresh(refreshToken)
-  cookieStore.set('access_token', data.data.access_token, BASE_COOKIE_OPTIONS)
-}
-
-/**
  * 로그아웃 Server Action
  * - 백엔드 로그아웃 API 호출
  * - httpOnly 쿠키 삭제
  */
 export async function logoutAction(): Promise<void> {
   const cookieStore = await cookies()
-  const accessToken = cookieStore.get('access_token')?.value
-  const refreshToken = cookieStore.get('refresh_token')?.value
-
-  if (accessToken && refreshToken) {
-    try {
-      await postLogout(accessToken, refreshToken)
-    } catch {
-      // 백엔드 로그아웃 실패해도 쿠키는 반드시 삭제
-    }
+  try {
+    await postLogout()
+  } catch {
+    // 백엔드 로그아웃 실패해도 쿠키는 반드시 삭제
   }
 
   cookieStore.delete('access_token')

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -3,7 +3,8 @@ import { logoutAction } from '@/lib/auth/sessionActions'
 import type { User } from '@/types'
 
 interface AuthState {
-  isLoggedIn?: boolean // undefined: 초기 상태, true: 로그인, false: 로그아웃
+  isInitialized: boolean
+  isLoggedIn?: boolean
   user: User | null
   login: (user: User) => void
   logout: () => Promise<void>
@@ -11,6 +12,7 @@ interface AuthState {
 }
 
 export const useAuthStore = create<AuthState>((set) => ({
+  isInitialized: false,
   isLoggedIn: undefined,
   user: null,
   login: (user) => set({ isLoggedIn: true, user }),


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->
로그인/로그아웃 인증 흐름을 로컬스토리지 중심에서 httpOnly 쿠키 중심으로 정리하고, Next 내부 인증 라우트(login, me, logout)를 추가해 인증 처리 책임을 서버 측으로 일원화했습니다.
## 📌 관련 이슈

<!-- Closes #이슈번호 -->

Closes #133 

## 🧩 작업 내용 (주요 변경사항)

- Next 내부 인증 API 라우트 추가
- /api/auth/login 라우트 추가: access_token, refresh_token 쿠키 설정
- /api/auth/me 라우트 추가: access_token 기반 사용자 정보 조회 프록시
- /api/auth/logout 라우트 추가: 인증 쿠키 삭제 처리
- 인증 API 레이어 정리
- auth API 함수 시그니처를 쿠키 기반 흐름에 맞게 정리
- 소셜 authorize-url 요청에 경로 fallback 처리 추가
- API base 환경변수 사용을 NEXT_PUBLIC_API_URL로 통일
- 로그아웃 흐름 단순화
- Header에서 중복 로그아웃 호출 제거
- store logout 단일 경로로 실행하도록 정리
- sessionActions의 로그아웃 호출부를 현재 API 계약에 맞게 수정
- 상태 관리 보강
- auth store에 초기화 상태 플래그 추가 및 초기화 흐름 정리
## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->
작업하던 사항중에 이전 pr을 받아서 하다보니 오류가 나서 고친부분이 좀 있습니다 확인부탁드립니다.

## ✅ PR 체크리스트

- [ ] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [ ] 불필요한 console.log 제거
- [ ] 로컬에서 실행 확인 완료
