### PR TITLE
[Feat] 어드민 카테고리 관리 페이지 API 연동 완성 (#145)

### DIFF
--- a/src/app/admin/category/_api/adminCreateCategory.ts
+++ b/src/app/admin/category/_api/adminCreateCategory.ts
@@ -2,16 +2,18 @@ import { authFetch } from '@/lib/api/client'
 import type {
   CreateCategoryRequest,
   AdminCreateCategoryResponse,
+  RootCategory,
 } from '../_types/AdminCategoryType'
 
 /**
  * 어드민 카테고리 등록 API
  */
 export const createAdminCategory = (
+  rootCategory: RootCategory,
   payload: CreateCategoryRequest
 ): Promise<AdminCreateCategoryResponse> => {
   return authFetch.post<AdminCreateCategoryResponse>(
-    '/api/v1/scents/categories',
+    `/api/v1/admin/scents/categories/${rootCategory}`,
     payload
   )
 }

--- a/src/app/admin/category/_api/adminDeleteCategory.ts
+++ b/src/app/admin/category/_api/adminDeleteCategory.ts
@@ -1,10 +1,14 @@
 import { authFetch } from '@/lib/api/client'
+import type { RootCategory } from '../_types/AdminCategoryType'
 
 /**
  * 어드민 카테고리 삭제 API
  */
 export const deleteAdminCategory = (
+  rootCategory: RootCategory,
   categoryId: number
-): Promise<{ success: boolean }> => {
-  return authFetch.delete(`/api/v1/admin/scents/categories/${categoryId}`)
+): Promise<{ success: boolean; data: null }> => {
+  return authFetch.delete(
+    `/api/v1/admin/scents/categories/${rootCategory}/${categoryId}`
+  )
 }

--- a/src/app/admin/category/_components/CategoryDeleteButton.tsx
+++ b/src/app/admin/category/_components/CategoryDeleteButton.tsx
@@ -4,12 +4,15 @@ import Button from '@/components/common/Button'
 import TrashIcon from '@/assets/icons/trash.svg'
 import { deleteCategoryAction } from '@/app/admin/category/_lib/categoryAction'
 import { useModalStore } from '@/store/useModalStore'
+import type { RootCategory } from '@/app/admin/category/_types/AdminCategoryType'
 
 interface CategoryDeleteButtonProps {
+  rootCategory: RootCategory
   categoryId: number
 }
 
 export function CategoryDeleteButton({
+  rootCategory,
   categoryId,
 }: CategoryDeleteButtonProps) {
   const { openAlert, closeModal } = useModalStore()
@@ -22,14 +25,26 @@ export function CategoryDeleteButton({
       confirmText: '삭제',
       onConfirm: async () => {
         try {
-          const result = await deleteCategoryAction(categoryId)
+          const result = await deleteCategoryAction(rootCategory, categoryId)
           if (result.success) {
             closeModal()
           } else {
-            alert('삭제에 실패했습니다.')
+            openAlert({
+              type: 'danger',
+              title: '카테고리 삭제 실패',
+              content:
+                result.message ??
+                '카테고리 삭제에 실패했습니다. 다시 시도해 주세요.',
+              confirmText: '확인',
+            })
           }
         } catch {
-          alert('삭제 중 오류가 발생했습니다.')
+          openAlert({
+            type: 'danger',
+            title: '카테고리 삭제 실패',
+            content: '네트워크 오류가 발생했습니다. 다시 시도해 주세요.',
+            confirmText: '확인',
+          })
         }
       },
     })

--- a/src/app/admin/category/_components/CategoryPostModal.tsx
+++ b/src/app/admin/category/_components/CategoryPostModal.tsx
@@ -1,39 +1,53 @@
 'use client'
 
-import React, { useState } from 'react'
+import React, { use, useState } from 'react'
 import Modal from '@/components/common/Modal/Modal'
 import Input from '@/components/common/Input'
 import Button from '@/components/common/Button'
 import { useModalStore } from '@/store/useModalStore'
-import type { CategoryTabId } from '@/app/admin/category/_types/AdminCategoryType'
+import type {
+  AdminCategoryListResponse,
+  RootCategory,
+} from '@/app/admin/category/_types/AdminCategoryType'
 import { postCategoryAction } from '@/app/admin/category/_lib/categoryAction'
 
 const LABEL_CLASS = 'flex flex-col gap-2 font-semibold'
 
 export function CategoryPostModal({
-  activeTab,
-  onSuccess,
+  rootCategory,
+  categoryResponsePromise,
 }: {
-  activeTab: CategoryTabId
-  onSuccess: () => void
+  rootCategory: RootCategory
+  categoryResponsePromise: Promise<AdminCategoryListResponse>
 }) {
-  const { closeModal } = useModalStore()
+  const categoryResponse = use(categoryResponsePromise)
+  const rootCategoryId = categoryResponse?.data?.categories?.[0]?.category_id
+
+  const { closeModal, openAlert } = useModalStore()
   const [nameKr, setNameKr] = useState('')
   const [nameEn, setNameEn] = useState('')
   const [isLoading, setIsLoading] = useState(false)
 
-  const isElement = activeTab === 'ELEMENT'
+  const isElement = rootCategory === 'element'
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    if (!nameKr || !nameEn) return
+    if (!nameKr || !nameEn || rootCategoryId === undefined) return
+
+    if (nameEn.includes(' ')) {
+      openAlert({
+        type: 'danger',
+        title: '영문명 오류',
+        content: '영문명에 공백이 포함되어 있습니다. 공백을 제거해 주세요.',
+        confirmText: '확인',
+      })
+      return
+    }
 
     setIsLoading(true)
     try {
-      const parent_id = activeTab === 'ELEMENT' ? 1 : 2
-
-      const result = await postCategoryAction({
-        parent_id,
+      const result = await postCategoryAction(rootCategory, {
+        parent_id: rootCategoryId,
         level: '소분류',
         name: {
           kr: nameKr,
@@ -42,13 +56,24 @@ export function CategoryPostModal({
       })
 
       if (result.success) {
-        onSuccess() // 추가적인 클라이언트 로직이 필요할 경우 호출
         closeModal()
-        setNameKr('')
-        setNameEn('')
+      } else {
+        openAlert({
+          type: 'danger',
+          title: '카테고리 등록 실패',
+          content:
+            result.message ??
+            '카테고리 등록에 실패했습니다. 다시 시도해 주세요.',
+          confirmText: '확인',
+        })
       }
     } catch {
-      // 여기서는 로딩 해제만
+      openAlert({
+        type: 'danger',
+        title: '카테고리 등록 실패',
+        content: '네트워크 오류가 발생했습니다. 다시 시도해 주세요.',
+        confirmText: '확인',
+      })
     } finally {
       setIsLoading(false)
     }

--- a/src/app/admin/category/_components/CategoryTableServer.tsx
+++ b/src/app/admin/category/_components/CategoryTableServer.tsx
@@ -1,10 +1,8 @@
-import {
-  fetchAdminElementCategories,
-  fetchAdminBlendCategories,
-} from '@/app/admin/category/_api/adminFetchCategory'
+import { use } from 'react'
 import type {
+  AdminCategoryListResponse,
   CategoryChild,
-  CategoryTabId,
+  RootCategory,
 } from '@/app/admin/category/_types/AdminCategoryType'
 import {
   AdminTableRow,
@@ -19,24 +17,21 @@ import { processCategoryItems } from '@/app/admin/category/_utils/categoryUtils'
 import { CategoryDeleteButton } from './CategoryDeleteButton'
 
 interface CategoryTableServerProps {
-  activeTab: CategoryTabId
+  rootCategory: RootCategory
+  categoryResponsePromise: Promise<AdminCategoryListResponse>
   searchParams: {
     q?: string
   }
 }
 
-export async function CategoryTableServer({
-  activeTab,
+export function CategoryTableServer({
+  rootCategory,
+  categoryResponsePromise,
   searchParams,
 }: CategoryTableServerProps) {
-  const response =
-    activeTab === 'ELEMENT'
-      ? await fetchAdminElementCategories()
-      : await fetchAdminBlendCategories()
-
-  // response.data.categories[0] 계층 구조
-  const rootCategory = response?.data?.categories?.[0]
-  const rootCategoryItems = rootCategory?.children || []
+  const categoryResponse = use(categoryResponsePromise)
+  const rootCategoryData = categoryResponse?.data?.categories?.[0]
+  const rootCategoryItems = rootCategoryData?.children || []
 
   // 카테고리는 페이징이 현재 UI상 없어도 로직상 안전하게 처리
   const { items } = processCategoryItems(rootCategoryItems, {
@@ -70,7 +65,10 @@ export async function CategoryTableServer({
 
           <AdminTableCell slot={7}>
             <div className="flex justify-center">
-              <CategoryDeleteButton categoryId={item.category_id} />
+              <CategoryDeleteButton
+                rootCategory={rootCategory}
+                categoryId={item.category_id}
+              />
             </div>
           </AdminTableCell>
         </AdminTableRow>

--- a/src/app/admin/category/_lib/categoryAction.ts
+++ b/src/app/admin/category/_lib/categoryAction.ts
@@ -3,30 +3,41 @@
 import { revalidatePath } from 'next/cache'
 import { createAdminCategory } from '../_api/adminCreateCategory'
 import { deleteAdminCategory } from '../_api/adminDeleteCategory'
-import { CreateCategoryRequest } from '../_types/AdminCategoryType'
+import type {
+  CreateCategoryRequest,
+  RootCategory,
+} from '../_types/AdminCategoryType'
 
 /**
  * 카테고리 생성 Server Action
  */
-export async function postCategoryAction(payload: CreateCategoryRequest) {
+export async function postCategoryAction(
+  rootCategory: RootCategory,
+  payload: CreateCategoryRequest
+) {
   try {
-    await createAdminCategory(payload)
+    await createAdminCategory(rootCategory, payload)
     revalidatePath('/admin/category')
     return { success: true }
   } catch (error) {
-    return { success: false, error }
+    const message = error instanceof Error ? error.message : null
+    return { success: false, message }
   }
 }
 
 /**
  * 카테고리 삭제 Server Action
  */
-export async function deleteCategoryAction(categoryId: number) {
+export async function deleteCategoryAction(
+  rootCategory: RootCategory,
+  categoryId: number
+) {
   try {
-    await deleteAdminCategory(categoryId)
+    await deleteAdminCategory(rootCategory, categoryId)
     revalidatePath('/admin/category')
     return { success: true }
   } catch (error) {
-    return { success: false, error }
+    const message = error instanceof Error ? error.message : null
+    return { success: false, message }
   }
 }

--- a/src/app/admin/category/_page/CategoryAdminContent.tsx
+++ b/src/app/admin/category/_page/CategoryAdminContent.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React, { ReactNode, Suspense } from 'react'
+import type { AdminCategoryListResponse } from '@/app/admin/category/_types/AdminCategoryType'
 import {
   AdminPageHeader,
   AdminTabGroup,
@@ -10,7 +11,7 @@ import {
   AdminTableError,
   AdminTableLoading,
 } from '@/app/admin/_components'
-import type { CategoryTabId } from '@/app/admin/category/_types/AdminCategoryType'
+import type { RootCategory } from '@/app/admin/category/_types/AdminCategoryType'
 import { CATEGORY_TABLE_HEADERS } from '@/constants/admin'
 import { ErrorBoundary } from 'react-error-boundary'
 import { CategoryPostModal } from '@/app/admin/category/_components/CategoryPostModal'
@@ -18,19 +19,21 @@ import { useModalStore } from '@/store/useModalStore'
 import { useAdminTable } from '@/app/admin/_hooks/useAdminTable'
 import { cn } from '@/lib/cn'
 
-export const CATEGORY_TABS: { id: CategoryTabId; label: string }[] = [
-  { id: 'ELEMENT', label: '단품 관리' },
-  { id: 'BLEND', label: '조합 관리' },
+export const CATEGORY_TABS: { id: RootCategory; label: string }[] = [
+  { id: 'element', label: '단품 관리' },
+  { id: 'blend', label: '조합 관리' },
 ]
 
 interface CategoryAdminContentProps {
-  activeTab: CategoryTabId
+  rootCategory: RootCategory
+  categoryResponsePromise: Promise<AdminCategoryListResponse>
   children: ReactNode
   searchParams: { [key: string]: string | undefined }
 }
 
 export default function CategoryAdminContent({
-  activeTab,
+  rootCategory,
+  categoryResponsePromise,
   children,
   searchParams,
 }: CategoryAdminContentProps) {
@@ -40,10 +43,6 @@ export default function CategoryAdminContent({
     resetParamsOnTabChange: ['category_id'],
   })
 
-  const handleCreateSuccess = () => {
-    // TODO: 모달 띄우기
-  }
-
   return (
     <AdminListCard className={cn(isPending && 'pointer-events-none')}>
       <AdminPageHeader
@@ -51,10 +50,13 @@ export default function CategoryAdminContent({
         buttonText="카테고리 등록"
         onButtonClick={() =>
           openModal(
-            <CategoryPostModal
-              activeTab={activeTab}
-              onSuccess={handleCreateSuccess}
-            />
+            // Promise가 미해결인 채로 모달이 열릴 경우를 대비한 Suspense
+            <Suspense fallback={null}>
+              <CategoryPostModal
+                rootCategory={rootCategory}
+                categoryResponsePromise={categoryResponsePromise}
+              />
+            </Suspense>
           )
         }
       />
@@ -67,14 +69,14 @@ export default function CategoryAdminContent({
 
       <AdminTabGroup
         tabs={CATEGORY_TABS}
-        activeTab={activeTab}
+        activeTab={rootCategory}
         onChange={onTabChange}
       />
 
       <AdminTable headers={CATEGORY_TABLE_HEADERS}>
         <ErrorBoundary fallback={<AdminTableError />}>
           <Suspense
-            key={`${activeTab}-${JSON.stringify(searchParams)}`}
+            key={`${rootCategory}-${JSON.stringify(searchParams)}`}
             fallback={<AdminTableLoading />}
           >
             {children}

--- a/src/app/admin/category/_types/AdminCategoryType.ts
+++ b/src/app/admin/category/_types/AdminCategoryType.ts
@@ -1,4 +1,4 @@
-export type CategoryTabId = 'ELEMENT' | 'BLEND'
+export type RootCategory = 'element' | 'blend'
 
 export interface CategoryName {
   kr: string

--- a/src/app/admin/category/page.tsx
+++ b/src/app/admin/category/page.tsx
@@ -1,8 +1,12 @@
 import { Suspense } from 'react'
 import type { Metadata } from 'next'
 import CategoryAdminContent from './_page/CategoryAdminContent'
-import type { CategoryTabId } from './_types/AdminCategoryType'
+import type { RootCategory } from './_types/AdminCategoryType'
 import { CategoryTableServer } from './_components/CategoryTableServer'
+import {
+  fetchAdminElementCategories,
+  fetchAdminBlendCategories,
+} from './_api/adminFetchCategory'
 import { notFound } from 'next/navigation'
 
 export const metadata: Metadata = {
@@ -19,18 +23,32 @@ export default async function CategoryAdminPage({
   const params = await searchParams
 
   const tabParam = params?.tab
-  const isValidTab = !tabParam || tabParam === 'ELEMENT' || tabParam === 'BLEND'
+  const isValidTab = !tabParam || tabParam === 'element' || tabParam === 'blend'
 
   if (!isValidTab) {
     notFound()
   }
 
-  const activeTab: CategoryTabId = (tabParam as CategoryTabId) || 'ELEMENT'
+  const rootCategory: RootCategory = (tabParam as RootCategory) || 'element'
+
+  // Promise만 생성
+  const categoryResponsePromise =
+    rootCategory === 'element'
+      ? fetchAdminElementCategories()
+      : fetchAdminBlendCategories()
 
   return (
     <Suspense fallback={null}>
-      <CategoryAdminContent activeTab={activeTab} searchParams={params}>
-        <CategoryTableServer activeTab={activeTab} searchParams={params} />
+      <CategoryAdminContent
+        rootCategory={rootCategory}
+        categoryResponsePromise={categoryResponsePromise}
+        searchParams={params}
+      >
+        <CategoryTableServer
+          rootCategory={rootCategory}
+          categoryResponsePromise={categoryResponsePromise}
+          searchParams={params}
+        />
       </CategoryAdminContent>
     </Suspense>
   )

--- a/src/app/admin/product/_components/product-post/ImageUploadField.tsx
+++ b/src/app/admin/product/_components/product-post/ImageUploadField.tsx
@@ -1,4 +1,5 @@
 import type { RefObject } from 'react'
+import Image from 'next/image'
 
 const LABEL_CLASS = 'flex flex-col gap-2 font-semibold'
 const REQUIRED_MARK = <span className="ml-0.5 text-red-500">*</span>
@@ -33,7 +34,7 @@ export function ImageUploadField({
       />
       {imagePreview ? (
         <div className="relative w-full overflow-hidden rounded-lg border border-neutral-200">
-          <img
+          <Image
             src={imagePreview}
             alt="미리보기"
             className="h-36 w-full object-cover"

--- a/src/components/common/Modal/GlobalModal.tsx
+++ b/src/components/common/Modal/GlobalModal.tsx
@@ -28,7 +28,7 @@ export const GlobalModal = () => {
           >
             <ModalOverlay onClose={handleOverlayClose}>
               {modal.alertConfig ? (
-                <div onClick={(e) => e.stopPropagation()}>
+                <div className="contents" onClick={(e) => e.stopPropagation()}>
                   <AlertModal
                     isOpen
                     onClose={closeModal}
@@ -36,7 +36,9 @@ export const GlobalModal = () => {
                   />
                 </div>
               ) : modal.content ? (
-                <div onClick={(e) => e.stopPropagation()}>{modal.content}</div>
+                <div className="contents" onClick={(e) => e.stopPropagation()}>
+                  {modal.content}
+                </div>
               ) : null}
             </ModalOverlay>
           </div>


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->

어드민 카테고리 관리 페이지의 조회, 등록, 삭제 API를 실제 백엔드와 연동

## 📌 관련 이슈

<!-- Closes #이슈번호 -->

Closes #145 

## 🧩 작업 내용 (주요 변경사항)

- 카테고리 생성, 등록 API를 rootCategory 값에 알맞게 요청될 수 있도록 수정하였습니다.
- 어드민 카테고리 Page에 API 연동 하며 미리 목록조회의 값을 SSR로 받아올 수 있도록 하여 카테고리 값과 부모 카테고리 ID를 최상단에서 Props로 내려주는 방식으로 변경 후 ActiveTab을 rootCategory로 변경하여 가독성 향상 및 중복되는 로직 제거 + 에러 모달 창 추가
- GlobalModal 변경 안된 부분 과 img 태그 수정

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

 page.tsx → categoryResponsePromise (하나의 Promise)
      ├── CategoryTableServer(Server) -  use(categoryResponsePromise)  ← 같은 Promise
      └── CategoryPostModal(Client) -  use(categoryResponsePromise)  ← 같은 Promise
  
 하나의 Promise를 생성하여 CategoryPostModal에는 use로 바로 조회 요청을 통해 값을 받아올 수 있었고
 CategoryTableServer에는 데이터 테이블에 대한 Suspense를 가질 수 있었다.

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

https://github.com/user-attachments/assets/324a69ba-7f10-40dd-a3d9-fd4e44c0a992


## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 로컬에서 실행 확인 완료
