### PR TITLE
[feat] 401 응답시 토큰 재발급 및 요청 재시도(#146)

### DIFF
--- a/src/app/api/auth/refresh/route.ts
+++ b/src/app/api/auth/refresh/route.ts
@@ -1,0 +1,79 @@
+import { cookies } from 'next/headers'
+import { NextResponse } from 'next/server'
+import { postTokenRefresh } from '@/lib/api/auth'
+
+const BASE_COOKIE_OPTIONS = {
+  httpOnly: true,
+  secure: process.env.NODE_ENV === 'production',
+  sameSite: 'lax' as const,
+  path: '/',
+}
+
+export async function POST() {
+  try {
+    const cookieStore = await cookies()
+    const refreshToken = cookieStore.get('refresh_token')?.value
+
+    if (!refreshToken) {
+      return NextResponse.json(
+        {
+          success: false,
+          data: null,
+          error: {
+            code: 'UNAUTHORIZED',
+            message: 'No refresh token found.',
+          },
+        },
+        { status: 401 }
+      )
+    }
+
+    const refreshed = await postTokenRefresh(refreshToken)
+
+    if (!refreshed.success) {
+      return NextResponse.json(
+        {
+          success: false,
+          data: null,
+          error: refreshed.error ?? {
+            code: 'REFRESH_FAILED',
+            message: 'Failed to refresh token.',
+          },
+        },
+        { status: 401 }
+      )
+    }
+
+    const response = NextResponse.json({ success: true, data: null })
+
+    response.cookies.set('access_token', refreshed.data.access_token, {
+      ...BASE_COOKIE_OPTIONS,
+      maxAge: refreshed.data.expires_in,
+    })
+    response.cookies.set('refresh_token', refreshed.data.refresh_token, {
+      ...BASE_COOKIE_OPTIONS,
+      maxAge: refreshed.data.refresh_expires_in,
+    })
+
+    return response
+  } catch (error) {
+    console.error('Refresh API error:', error)
+
+    const response = NextResponse.json(
+      {
+        success: false,
+        data: null,
+        error: {
+          code: 'AUTH_FAILED_TOKEN_REFRESH',
+          message: '토큰 재발급에 실패했습니다.',
+        },
+      },
+      { status: 401 }
+    )
+
+    response.cookies.set('access_token', '', { maxAge: 0, path: '/' })
+    response.cookies.set('refresh_token', '', { maxAge: 0, path: '/' })
+
+    return response
+  }
+}

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -2,6 +2,14 @@ import type { ApiResponse, AuthTokens, AuthorizeUrl, User } from '@/types'
 import { apiFetch, appFetch } from './client'
 import { FetchError } from './fetchError'
 
+type TokenRefreshData = {
+  access_token: string
+  refresh_token: string
+  token_type: string
+  expires_in: number
+  refresh_expires_in: number
+}
+
 /**
  * 소셜 로그인/회원가입 URL을 요청합니다.
  * @param provider 소셜 제공자 (e.g., 'kakao')
@@ -78,6 +86,30 @@ export function postSessionLogin(
     accessToken,
     refreshToken,
   })
+}
+
+/**
+ * 리프레시 토큰으로 토큰 재발급을 요청합니다.
+ */
+export async function postTokenRefresh(
+  refreshToken: string
+): Promise<ApiResponse<TokenRefreshData>> {
+  const baseUrl = process.env.NEXT_PUBLIC_API_URL
+  const response = await fetch(`${baseUrl}/api/v1/auth/token/refresh`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ refresh_token: refreshToken }),
+  })
+
+  const data = (await response
+    .json()
+    .catch(() => null)) as ApiResponse<TokenRefreshData> | null
+
+  if (!response.ok || !data) {
+    throw new Error(data?.error?.message || 'Failed to refresh token')
+  }
+
+  return data
 }
 
 /**

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -10,6 +10,9 @@ const DEFAULT_HEADERS: Record<string, string> = {
   Accept: 'application/json',
 }
 
+const AUTH_REFRESH_PATH = '/api/auth/refresh'
+const RETRY_HEADER = 'x-auth-retried'
+
 // 공통 Response Interceptor
 export const handleResponse = async (response: Response): Promise<Response> => {
   if (response.ok) return response
@@ -59,7 +62,43 @@ export const appFetch = createFetch({
       }
       return args
     },
-    response: handleResponse,
+    response: async (response, requestArgs) => {
+      if (
+        response.status === 401 &&
+        typeof window !== 'undefined' &&
+        !requestArgs.url.includes(AUTH_REFRESH_PATH)
+      ) {
+        const headers = new Headers(requestArgs.options.headers as HeadersInit)
+        const hasRetried = headers.get(RETRY_HEADER) === '1'
+
+        if (!hasRetried) {
+          const refreshResponse = await fetch(AUTH_REFRESH_PATH, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Accept: 'application/json',
+            },
+          })
+
+          if (refreshResponse.ok) {
+            headers.set(RETRY_HEADER, '1')
+
+            const retryResponse = await fetch(requestArgs.url, {
+              ...requestArgs.options,
+              headers: Object.fromEntries(headers.entries()),
+            })
+
+            if (retryResponse.ok) {
+              return retryResponse
+            }
+
+            return handleResponse(retryResponse)
+          }
+        }
+      }
+
+      return handleResponse(response)
+    },
   },
 })
 


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->
401 응답 시 refresh token으로 토큰 재발급을 수행하고, 성공 시 기존 요청을 1회 재시도하도록 인증 흐름을 개선했습니다.
## 📌 관련 이슈

<!-- Closes #이슈번호 -->

Closes #146 

## 🧩 작업 내용 (주요 변경사항)

-refresh_token 쿠키를 사용해 백엔드 재발급 API를 호출하고, 성공 시 access_token/refresh_token 쿠키를 갱신하도록 구현했습니다.
- appFetch 요청에서 401 응답 수신 시 /api/auth/refresh를 호출하고, 재발급 성공 시 원요청을 1회 재시도하도록 처리했습니다.
- 무한 재시도 방지를 위해 재시도 플래그 헤더를 적용했습니다.

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트

- [ ] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [ ] 불필요한 console.log 제거
- [ ] 로컬에서 실행 확인 완료
