### PR TITLE
[feat] 토큰 재발급 실패 시 알러트와 로그인페이지 이동 (#150)

### DIFF
--- a/src/app/api/auth/refresh/route.ts
+++ b/src/app/api/auth/refresh/route.ts
@@ -15,7 +15,7 @@ export async function POST() {
     const refreshToken = cookieStore.get('refresh_token')?.value
 
     if (!refreshToken) {
-      return NextResponse.json(
+      const response = NextResponse.json(
         {
           success: false,
           data: null,
@@ -26,6 +26,11 @@ export async function POST() {
         },
         { status: 401 }
       )
+
+      response.cookies.set('access_token', '', { maxAge: 0, path: '/' })
+      response.cookies.set('refresh_token', '', { maxAge: 0, path: '/' })
+
+      return response
     }
 
     const refreshed = await postTokenRefresh(refreshToken)

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -13,6 +13,14 @@ const DEFAULT_HEADERS: Record<string, string> = {
 const AUTH_REFRESH_PATH = '/api/auth/refresh'
 const RETRY_HEADER = 'x-auth-retried'
 
+type RefreshErrorPayload = {
+  success?: boolean
+  error?: {
+    code?: string
+    message?: string
+  }
+}
+
 // 공통 Response Interceptor
 export const handleResponse = async (response: Response): Promise<Response> => {
   if (response.ok) return response
@@ -94,6 +102,23 @@ export const appFetch = createFetch({
 
             return handleResponse(retryResponse)
           }
+
+          const refreshError = (await refreshResponse
+            .json()
+            .catch(() => null)) as RefreshErrorPayload | null
+
+          const { useModalStore } = await import('@/store/useModalStore')
+          useModalStore.getState().openAlert({
+            type: 'danger',
+            title: '인증이 만료되었습니다.',
+            content:
+              refreshError?.error?.message ||
+              '세션이 만료되었습니다. 다시 로그인해 주세요.',
+            confirmText: '로그인으로 이동',
+            onConfirm: () => {
+              window.location.href = '/login'
+            },
+          })
         }
       }
 


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->
토큰 재발급 실패 시 사용자에게 오류를 AlertModal로 안내하고, 로그인 페이지로 이동하도록 처리했습니다.
## 📌 관련 이슈

<!-- Closes #이슈번호 -->

Closes #150 

## 🧩 작업 내용 (주요 변경사항)

- 401 응답 후 재발급 실패 시 alert 대신 공통 AlertModal을 띄우도록 변경
- AlertModal 확인버튼 클릭 시 로그인 페이지로 리다이렉트
- 토큰이 없거나 재발급 실패 시 쿠키르 정리 후 401 응답을 반환하도록 구현

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트

- [ ] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [ ] 불필요한 console.log 제거
- [ ] 로컬에서 실행 확인 완료
