### PR TITLE
[Feat] 제품 후보군 등록/채택 API 연동 (#156)

### DIFF
--- a/src/app/admin/recommend/_actions/recommendActions.ts
+++ b/src/app/admin/recommend/_actions/recommendActions.ts
@@ -2,9 +2,15 @@
 
 import { revalidatePath } from 'next/cache'
 import { deleteAdminRecommend } from '../_api/adminDeleteRecommend'
-import { patchAdminBlendMapPublish } from '../_api/adminPatchRecommend'
-import { createAdminBlendMap } from '../_api/adminCreateRecommend'
-import { RecommendTabId } from '../_types'
+import {
+  patchAdminBlendMapPublish,
+  patchAdminProductPoolAdopt,
+} from '../_api/adminPatchRecommend'
+import {
+  createAdminBlendMap,
+  createAdminProductPool,
+} from '../_api/adminCreateRecommend'
+import { RecommendTabId, ProductPoolCreateBody } from '../_types'
 
 /**
  * 추천 관련 데이터 삭제 Server Action
@@ -35,8 +41,27 @@ export async function toggleRecommendStatusAction(
   try {
     if (tabId === 'blend-maps') {
       await patchAdminBlendMapPublish(id, status as 'PUBLISHED' | 'UNPUBLISHED')
+    } else if (tabId === 'product-pools') {
+      await patchAdminProductPoolAdopt(id, status as 'ADOPTED' | 'UNADOPTED')
     }
-    // TODO: product-pools, product-maps PATCH 연동 시 추가
+    // TODO: product-maps PATCH 연동 시 추가
+
+    revalidatePath('/admin/recommend')
+    return { success: true }
+  } catch (error) {
+    return {
+      success: false,
+      message: error instanceof Error ? error.message : null,
+    }
+  }
+}
+
+/**
+ * 제품 후보군 생성 Server Action
+ */
+export async function createProductPoolAction(body: ProductPoolCreateBody) {
+  try {
+    await createAdminProductPool(body)
 
     revalidatePath('/admin/recommend')
     return { success: true }

--- a/src/app/admin/recommend/_api/adminCreateRecommend.ts
+++ b/src/app/admin/recommend/_api/adminCreateRecommend.ts
@@ -1,7 +1,14 @@
 import { authFetch } from '@/lib/api'
+import { ProductPoolCreateBody } from '@/app/admin/recommend/_types'
 
 /**
  * 향조합 추천맵 생성 POST API
  */
 export const createAdminBlendMap = (input_type: string) =>
   authFetch.post('/api/v1/admin/matches/blend-maps', { input_type })
+
+/**
+ * 제품 후보군 생성 POST API
+ */
+export const createAdminProductPool = (body: ProductPoolCreateBody) =>
+  authFetch.post('/api/v1/admin/matches/product-pools', body)

--- a/src/app/admin/recommend/_api/adminPatchRecommend.ts
+++ b/src/app/admin/recommend/_api/adminPatchRecommend.ts
@@ -10,3 +10,14 @@ export const patchAdminBlendMapPublish = (
   authFetch.patch(`/api/v1/admin/matches/blend-maps/${id}/publish`, {
     publish_status,
   })
+
+/**
+ * 제품 후보군 채택 설정 PATCH API
+ */
+export const patchAdminProductPoolAdopt = (
+  id: number,
+  adoption_status: 'ADOPTED' | 'UNADOPTED'
+) =>
+  authFetch.patch(`/api/v1/admin/matches/product-pools/${id}/adopt`, {
+    adoption_status,
+  })

--- a/src/app/admin/recommend/_page/ProductPoolsForm.tsx
+++ b/src/app/admin/recommend/_page/ProductPoolsForm.tsx
@@ -20,10 +20,7 @@ export const ProductPoolsForm = ({
             value={formData.crawl_source}
             onChange={(val) => onFieldChange('crawl_source', val)}
             width="w-full"
-            options={[
-              { label: '네이버 스토어', value: 'NAVER_STORE' },
-              { label: '카카오 페이지', value: 'KAKAO_PAGE' },
-            ]}
+            options={[{ label: '네이버 쇼핑', value: 'naver_shopping' }]}
           />
         </div>
         <div className="flex flex-col gap-2">
@@ -59,7 +56,8 @@ export const ProductPoolsForm = ({
               { label: '리뷰 평점순', value: 'REVIEW_RATING' },
               { label: '리뷰 개수순', value: 'REVIEW_COUNT' },
               { label: '판매량순', value: 'SALES_VOLUME' },
-              { label: '낮은 가격순', value: 'PRICE_ASC' },
+              { label: '높은 가격순', value: 'PRICE_HIGH' },
+              { label: '낮은 가격순', value: 'PRICE_LOW' },
             ]}
           />
         </div>

--- a/src/app/admin/recommend/_page/ProductPoolsTab.tsx
+++ b/src/app/admin/recommend/_page/ProductPoolsTab.tsx
@@ -7,7 +7,7 @@ import {
   AdminFirstCell,
   AdminTypeCell,
 } from '@/app/admin/_components'
-import { RecommendDeleteButton } from '../_components/RecommendDeleteButton'
+// import { RecommendDeleteButton } from '../_components/RecommendDeleteButton' // TODO: DELETE API 미개발, 추후 활성화
 import { RecommendStatusCell } from '../_components/RecommendStatusCell'
 import {
   ProductPoolsItemResponse,
@@ -37,7 +37,7 @@ export const ProductPoolsTab = ({
           <AdminDateCell slot={5} date={row.created_at} />
           <AdminDateCell slot={6} date={row.updated_at} />
           <AdminTableCell slot={7}>
-            <RecommendDeleteButton tabId="product-pools" id={row.id} />
+            {/* <RecommendDeleteButton tabId="product-pools" id={row.id} /> TODO: DELETE API 미개발, 추후 활성화 */}
           </AdminTableCell>
         </AdminTableRow>
       ))}

--- a/src/app/admin/recommend/_page/RecommendPostModal.tsx
+++ b/src/app/admin/recommend/_page/RecommendPostModal.tsx
@@ -3,13 +3,20 @@
 import React, { useState, Suspense, useMemo } from 'react'
 import Modal from '@/components/common/Modal/Modal'
 import Button from '@/components/common/Button'
-import { RecommendTabId, RECOMMEND_TABS } from '@/app/admin/recommend/_types'
+import {
+  RecommendTabId,
+  RECOMMEND_TABS,
+  ProductPoolCreateBody,
+} from '@/app/admin/recommend/_types'
 import { RECOMMEND_API } from '@/app/admin/recommend/_api'
 import { BlendMapsForm } from './BlendMapsForm'
 import { ProductPoolsForm } from './ProductPoolsForm'
 import { ProductMapsForm } from './ProductMapsForm'
 import { useModalStore } from '@/store/useModalStore'
-import { createBlendMapAction } from '../_actions/recommendActions'
+import {
+  createBlendMapAction,
+  createProductPoolAction,
+} from '../_actions/recommendActions'
 
 interface RecommendPostModalProps {
   activeTab: RecommendTabId
@@ -34,10 +41,10 @@ export const RecommendPostModal = ({ activeTab }: RecommendPostModalProps) => {
     inputType: 'PREFERENCE',
 
     // 2. 제품 후보군
-    crawl_source: 'NAVER_STORE',
+    crawl_source: 'naver_shopping',
     crawl_count: 50,
-    crawl_sort: 'REVIEW_RATING',
-    product_type: 'DIFFUSER',
+    crawl_sort: 'REVIEW_RATING' as ProductPoolCreateBody['crawl_sort'],
+    product_type: 'DIFFUSER' as ProductPoolCreateBody['product_type'],
     crawl_config: {
       min_price: 10000,
       max_price: 100000,
@@ -82,8 +89,25 @@ export const RecommendPostModal = ({ activeTab }: RecommendPostModalProps) => {
         })
         return
       }
+    } else if (activeTab === 'product-pools') {
+      const result = await createProductPoolAction({
+        crawl_source: formData.crawl_source,
+        crawl_count: formData.crawl_count,
+        crawl_sort: formData.crawl_sort,
+        product_type: formData.product_type,
+        crawl_config: formData.crawl_config,
+      })
+      if (!result.success) {
+        openAlert({
+          type: 'danger',
+          title: '등록 실패',
+          content: result.message ?? '제품 후보군 등록에 실패했습니다.',
+          confirmText: '확인',
+        })
+        return
+      }
     }
-    // TODO: product-pools, product-maps 등록 연동 시 추가
+    // TODO: product-maps 등록 연동 시 추가
 
     closeModal()
   }

--- a/src/app/admin/recommend/_types/ProductPoolsTypes.ts
+++ b/src/app/admin/recommend/_types/ProductPoolsTypes.ts
@@ -1,5 +1,23 @@
 import { RecommendApiResponse } from './RecommendData'
 
+export interface ProductPoolCreateBody {
+  crawl_source: string
+  crawl_count: number
+  crawl_sort:
+    | 'REVIEW_RATING'
+    | 'REVIEW_COUNT'
+    | 'SALES_VOLUME'
+    | 'PRICE_HIGH'
+    | 'PRICE_LOW'
+  product_type: 'DIFFUSER' | 'PERFUME'
+  crawl_config: {
+    min_price: number
+    max_price: number
+    min_rating: number
+    min_review_count: number
+  }
+}
+
 export interface ProductPoolsItemResponse {
   id: number
   product_type: 'DIFFUSER' | 'PERFUME'


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->

 추천 관리 > 제품 후보군의 조회, 등록, 채택 API를 실제 백엔드와 연동
blend-map 여부로 분기하여 Server Action 하나에서 두 케이스를 처리

## 📌 관련 이슈

<!-- Closes #이슈번호 -->

Closes #156 

## 🧩 작업 내용 (주요 변경사항)

- 제품 후보군 (product-pools) POST API 추가
- 제품 후보군 (product-pools) PATCH API 채택 / 비채택 추가
- 채택/비채택 필터링 추가

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

https://github.com/user-attachments/assets/df36de65-48bf-4320-a3c9-6c6fc30bbcbf


## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

- 삭제 기능은 백엔드 API 준비 전까지 버튼 주석 처리 상태로 유지

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 로컬에서 실행 확인 완료
