### PR TITLE
feat: 향수·디퓨저 선택 및 프로파일링 제출 필드 확장(#159)

### DIFF
--- a/src/app/api/v1/profilings/submit/route.ts
+++ b/src/app/api/v1/profilings/submit/route.ts
@@ -3,10 +3,15 @@
  * POST /api/v1/profilings/submit
  */
 import { NextResponse } from 'next/server'
+import { MOCK_PIPELINE_SNAPSHOT_ID } from '@/mocks/data/profilingConstants'
 import { mockProfilingResultDetail } from '@/mocks/data/profilingResults'
+
+const PRODUCT_TYPES = ['DIFFUSER', 'PERFUME'] as const
+const PROFILING_TYPES = ['PREFERENCE', 'HEALTH'] as const
 
 export async function POST(request: Request) {
   let body: {
+    pipeline_snapshot_id?: number
     profiling_type?: string
     product_type?: string
     responses?: unknown[]
@@ -27,7 +32,13 @@ export async function POST(request: Request) {
     )
   }
 
-  if (!body?.profiling_type || !Array.isArray(body?.responses)) {
+  if (
+    body?.pipeline_snapshot_id == null ||
+    typeof body.pipeline_snapshot_id !== 'number' ||
+    !body?.profiling_type ||
+    !body?.product_type ||
+    !Array.isArray(body?.responses)
+  ) {
     return NextResponse.json(
       {
         success: false,
@@ -35,6 +46,59 @@ export async function POST(request: Request) {
           code: 'BAD_REQUEST',
           message: '필수 항목이 누락되었습니다.',
           details: null,
+        },
+      },
+      { status: 400 }
+    )
+  }
+
+  if (
+    !PRODUCT_TYPES.includes(body.product_type as (typeof PRODUCT_TYPES)[number])
+  ) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          code: 'BAD_REQUEST',
+          message: 'product_type이 올바르지 않습니다.',
+          details: { field: 'product_type', reason: 'invalid' },
+        },
+      },
+      { status: 400 }
+    )
+  }
+
+  if (
+    !PROFILING_TYPES.includes(
+      body.profiling_type as (typeof PROFILING_TYPES)[number]
+    )
+  ) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          code: 'BAD_REQUEST',
+          message: 'profiling_type이 올바르지 않습니다.',
+          details: { field: 'profiling_type', reason: 'invalid' },
+        },
+      },
+      { status: 400 }
+    )
+  }
+
+  const expectedSnapshot =
+    body.profiling_type === 'HEALTH'
+      ? MOCK_PIPELINE_SNAPSHOT_ID.HEALTH
+      : MOCK_PIPELINE_SNAPSHOT_ID.PREFERENCE
+  if (body.pipeline_snapshot_id !== expectedSnapshot) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          code: 'BAD_REQUEST',
+          message:
+            'pipeline_snapshot_id가 활성 폼과 일치하지 않습니다. 최신 폼을 다시 불러오세요.',
+          details: { field: 'pipeline_snapshot_id', reason: 'invalid' },
         },
       },
       { status: 400 }

--- a/src/app/find-my-scent/_api/profilingClient.ts
+++ b/src/app/find-my-scent/_api/profilingClient.ts
@@ -54,12 +54,14 @@ export async function fetchProfilingFormActive(
 
 /**
  * 퀴즈 답변(questions + answers)을 API 제출용 payload로 변환
+ * pipeline_snapshot_id는 활성 폼 조회 응답의 data.pipeline_snapshot_id와 동일해야 함
  */
 export function buildSubmitPayload(
   questions: QuizQuestion[],
   answers: AnswersState,
+  pipelineSnapshotId: number,
   profilingType: ProfilingType,
-  productType: 'DIFFUSER' | 'PERFUME' = 'DIFFUSER'
+  productType: 'DIFFUSER' | 'PERFUME'
 ): ProfilingSubmitRequest {
   const responses = questions.map((q) => {
     const selectedIds = answers[q.id] ?? []
@@ -68,7 +70,12 @@ export function buildSubmitPayload(
       .filter((k): k is string => Boolean(k))
     return { question_key: q.questionKey ?? q.id, answer_option_keys }
   })
-  return { profiling_type: profilingType, product_type: productType, responses }
+  return {
+    pipeline_snapshot_id: pipelineSnapshotId,
+    profiling_type: profilingType,
+    product_type: productType,
+    responses,
+  }
 }
 
 /**

--- a/src/app/find-my-scent/_components/ProductTypeSelectModal.tsx
+++ b/src/app/find-my-scent/_components/ProductTypeSelectModal.tsx
@@ -1,0 +1,156 @@
+'use client'
+
+/** 테스트 진입 전: 향수(퍼퓸) vs 디퓨저 추천 유형 선택 */
+import Image from 'next/image'
+import { ModalOverlay, ModalPortal } from '@/components/common/Modal'
+
+export type ProductTypeChoice = 'DIFFUSER' | 'PERFUME'
+
+type ProductTypeSelectModalProps = {
+  isOpen: boolean
+  onSelect: (productType: ProductTypeChoice) => void
+  /** X 버튼 — 보통 이전 페이지로 이동 */
+  onClose: () => void
+}
+
+/** 향수(병) 아이콘 */
+function PerfumeIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 48 48"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden
+    >
+      <path
+        d="M18 8h12v4h-2v2h2c2.2 0 4 1.8 4 4v22c0 2.2-1.8 4-4 4H18c-2.2 0-4-1.8-4-4V18c0-2.2 1.8-4 4-4h2v-2h-2V8z"
+        stroke="currentColor"
+        strokeWidth="2"
+        fill="none"
+      />
+      <path
+        d="M22 6h4v4h-4V6z"
+        stroke="currentColor"
+        strokeWidth="2"
+        fill="none"
+      />
+      <path
+        d="M20 26c0-4 2-6 4-6s4 2 4 6"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+    </svg>
+  )
+}
+
+/** 디퓨저(스틱) 아이콘 */
+function DiffuserIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 48 48"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden
+    >
+      <ellipse
+        cx="24"
+        cy="38"
+        rx="12"
+        ry="4"
+        stroke="currentColor"
+        strokeWidth="2"
+      />
+      <path
+        d="M16 38V22c0-2 1.5-3.5 3.5-3.5h9C30.5 18.5 32 20 32 22v16"
+        stroke="currentColor"
+        strokeWidth="2"
+      />
+      <path
+        d="M20 14v6M24 10v10M28 14v6"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+    </svg>
+  )
+}
+
+const styles = {
+  panel: 'relative w-full max-w-lg rounded-2xl bg-white p-6 pt-12 shadow-lg',
+  closeBtn:
+    'absolute right-3 top-3 flex h-14 w-14 items-center justify-center rounded-full text-neutral-500 transition-colors hover:bg-neutral-100 hover:text-black',
+  title: 'pr-12 text-lg font-bold text-[var(--color-black-primary)]',
+  sub: 'mt-2 text-sm leading-relaxed text-neutral-600',
+  /** 가로: 두 선택지 나란히 */
+  row: 'mt-6 flex w-full flex-row gap-3 sm:gap-4',
+  btn: 'flex min-h-[120px] flex-1 flex-col items-center justify-center gap-3 rounded-xl border-2 border-[var(--color-black-primary)] bg-[var(--color-black-primary)] px-3 py-5 text-sm font-semibold text-white transition-opacity hover:opacity-90',
+  iconWrap: 'relative h-12 w-12 shrink-0 text-white',
+} as const
+
+export function ProductTypeSelectModal({
+  isOpen,
+  onSelect,
+  onClose,
+}: ProductTypeSelectModalProps) {
+  if (!isOpen) return null
+
+  return (
+    <ModalPortal>
+      <ModalOverlay onClose={() => undefined} closeOnBackdrop={false}>
+        <div
+          className={styles.panel}
+          onClick={(e) => e.stopPropagation()}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="product-type-modal-title"
+        >
+          <button
+            type="button"
+            onClick={onClose}
+            className={styles.closeBtn}
+            aria-label="닫기"
+          >
+            <Image
+              src="/modalClose.svg"
+              alt=""
+              width={32}
+              height={32}
+              unoptimized
+            />
+          </button>
+          <h2 id="product-type-modal-title" className={styles.title}>
+            어떤 종류로 추천받겠습니까?
+          </h2>
+          <p className={styles.sub}>
+            추천 결과에 맞는 상품 유형을 선택해 주세요.
+          </p>
+          <div className={styles.row}>
+            <button
+              type="button"
+              className={styles.btn}
+              onClick={() => onSelect('PERFUME')}
+            >
+              <div className={styles.iconWrap}>
+                <PerfumeIcon className="h-full w-full" />
+              </div>
+              <span className="text-center leading-tight">향수</span>
+            </button>
+            <button
+              type="button"
+              className={styles.btn}
+              onClick={() => onSelect('DIFFUSER')}
+            >
+              <div className={styles.iconWrap}>
+                <DiffuserIcon className="h-full w-full" />
+              </div>
+              <span className="text-center leading-tight">디퓨저</span>
+            </button>
+          </div>
+        </div>
+      </ModalOverlay>
+    </ModalPortal>
+  )
+}

--- a/src/app/find-my-scent/_components/ProfilingQuizClient.tsx
+++ b/src/app/find-my-scent/_components/ProfilingQuizClient.tsx
@@ -2,16 +2,28 @@
 
 /** 서버에서 받은 질문으로 퀴즈만 렌더 (로딩/에러는 서버·loading/error에서 처리) */
 import type { QuizQuestion, TestType } from '../_types'
+import type { ProductTypeChoice } from './ProductTypeSelectModal'
 import { QuizView } from './QuizView'
 
 type ProfilingQuizClientProps = {
   testType: TestType
   initialQuestions: QuizQuestion[]
+  pipelineSnapshotId: number
+  productType: ProductTypeChoice
 }
 
 export function ProfilingQuizClient({
   testType,
   initialQuestions,
+  pipelineSnapshotId,
+  productType,
 }: ProfilingQuizClientProps) {
-  return <QuizView testType={testType} questions={initialQuestions} />
+  return (
+    <QuizView
+      testType={testType}
+      questions={initialQuestions}
+      pipelineSnapshotId={pipelineSnapshotId}
+      productType={productType}
+    />
+  )
 }

--- a/src/app/find-my-scent/_components/ProfilingTestPage.tsx
+++ b/src/app/find-my-scent/_components/ProfilingTestPage.tsx
@@ -1,8 +1,13 @@
 'use client'
 
-/** 취향/건강 테스트 공통 페이지 */
+/** 취향/건강 테스트 공통 페이지 — 진입 전 제품 유형(향수/디퓨저) 선택 후 퀴즈 */
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
 import { PageCenter } from '@/components/common/PageCenter'
+import { LoadingSpinner } from '@/components/common/LoadingSpinner'
 import { ErrorFeedbackModal } from '@/components/common/ErrorFeedback'
+import { ProductTypeSelectModal } from './ProductTypeSelectModal'
+import type { ProductTypeChoice } from './ProductTypeSelectModal'
 import { QuizView } from './QuizView'
 import { useProfilingForm } from '../_hooks/useProfilingForm'
 import { useErrorPopup } from '../_hooks/useErrorPopup'
@@ -15,7 +20,10 @@ const styles = {
 } as const
 
 export function ProfilingTestPage({ testType }: { testType: TestType }) {
-  const { questions, isLoading, error, refetch } = useProfilingForm(testType)
+  const router = useRouter()
+  const { questions, pipelineSnapshotId, isLoading, error, refetch } =
+    useProfilingForm(testType)
+  const [productType, setProductType] = useState<ProductTypeChoice | null>(null)
   const { isOpen: showErrorPopup, close: closeErrorPopup } =
     useErrorPopup(error)
 
@@ -44,7 +52,15 @@ export function ProfilingTestPage({ testType }: { testType: TestType }) {
     )
   }
 
-  if (questions.length === 0) {
+  if (isLoading) {
+    return (
+      <PageCenter>
+        <LoadingSpinner />
+      </PageCenter>
+    )
+  }
+
+  if (questions.length === 0 || pipelineSnapshotId == null) {
     return (
       <PageCenter>
         <p className={styles.emptyText}>진행 중인 테스트가 없어요.</p>
@@ -52,5 +68,21 @@ export function ProfilingTestPage({ testType }: { testType: TestType }) {
     )
   }
 
-  return <QuizView testType={testType} questions={questions} />
+  return (
+    <>
+      <ProductTypeSelectModal
+        isOpen={productType === null}
+        onSelect={setProductType}
+        onClose={() => router.back()}
+      />
+      {productType != null && (
+        <QuizView
+          testType={testType}
+          questions={questions}
+          pipelineSnapshotId={pipelineSnapshotId}
+          productType={productType}
+        />
+      )}
+    </>
+  )
 }

--- a/src/app/find-my-scent/_components/QuizView.tsx
+++ b/src/app/find-my-scent/_components/QuizView.tsx
@@ -2,7 +2,8 @@
 
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
-import type { QuizQuestion, TestType } from '../_types'
+import type { ProfilingType, QuizQuestion, TestType } from '../_types'
+import type { ProductTypeChoice } from './ProductTypeSelectModal'
 import { useQuizStep } from '../_hooks'
 import { buildSubmitPayload, submitProfiling } from '../_api/profilingClient'
 import { ErrorFeedbackModal } from '@/components/common/ErrorFeedback'
@@ -36,9 +37,15 @@ const styles = {
 export function QuizView({
   testType,
   questions,
+  pipelineSnapshotId,
+  productType,
 }: {
   testType: TestType
   questions: QuizQuestion[]
+  /** 활성 폼 조회 응답의 pipeline_snapshot_id */
+  pipelineSnapshotId: number
+  /** 진입 전 모달에서 선택한 추천 유형 */
+  productType: ProductTypeChoice
 }) {
   const {
     question,
@@ -67,8 +74,9 @@ export function QuizView({
         const payload = buildSubmitPayload(
           questions,
           answers,
-          testType,
-          'DIFFUSER'
+          pipelineSnapshotId,
+          testType as ProfilingType,
+          productType
         )
         const res = await submitProfiling(payload)
         if (!res.success || !res.data?.result_id) {

--- a/src/app/find-my-scent/_hooks/useProfilingForm.ts
+++ b/src/app/find-my-scent/_hooks/useProfilingForm.ts
@@ -11,6 +11,9 @@ import type { ProfilingType, QuizQuestion } from '../_types'
 
 export function useProfilingForm(profilingType: ProfilingType) {
   const [questions, setQuestions] = useState<QuizQuestion[]>([])
+  const [pipelineSnapshotId, setPipelineSnapshotId] = useState<number | null>(
+    null
+  )
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<Error | null>(null)
   const loadRef = useRef<() => void | Promise<void>>(() => {})
@@ -20,15 +23,18 @@ export function useProfilingForm(profilingType: ProfilingType) {
     loadRef.current = async () => {
       setError(null)
       setQuestions([])
+      setPipelineSnapshotId(null)
       setIsLoading(true)
       try {
         const res = await fetchProfilingFormActive(profilingType)
         if (cancelled) return
         setQuestions(toQuizQuestions(res.data))
+        setPipelineSnapshotId(res.data.pipeline_snapshot_id)
       } catch (err) {
         if (!cancelled)
           setError(err instanceof FetchError ? err : new Error(String(err)))
         if (!cancelled) setQuestions([])
+        if (!cancelled) setPipelineSnapshotId(null)
       } finally {
         if (!cancelled) setIsLoading(false)
       }
@@ -41,6 +47,7 @@ export function useProfilingForm(profilingType: ProfilingType) {
 
   return {
     questions,
+    pipelineSnapshotId,
     isLoading,
     error,
     refetch: () => loadRef.current?.(),

--- a/src/app/find-my-scent/_types/index.ts
+++ b/src/app/find-my-scent/_types/index.ts
@@ -26,6 +26,8 @@ export type ProfilingQuestion = {
 /** API 응답 - 질문 폼 구조 (활성 폼 조회 응답의 data) */
 export type ProfilingForm = {
   form_id: number
+  /** 제출 시 POST submit에 동일 값으로 포함 */
+  pipeline_snapshot_id: number
   name: string
   profiling_type: ProfilingType
   questions: ProfilingQuestion[]
@@ -54,6 +56,7 @@ export type QuizQuestion = {
 
 /** POST /api/v1/profilings/submit 요청 */
 export type ProfilingSubmitRequest = {
+  pipeline_snapshot_id: number
   profiling_type: ProfilingType
   product_type: 'DIFFUSER' | 'PERFUME'
   responses: { question_key: string; answer_option_keys: string[] }[]

--- a/src/mocks/data/profilingConstants.ts
+++ b/src/mocks/data/profilingConstants.ts
@@ -1,0 +1,9 @@
+/**
+ * 프로파일링 목데이터 공통 상수
+ * - GET forms/active 응답의 pipeline_snapshot_id와 동일해야 함
+ * - POST submit 시 body.pipeline_snapshot_id 검증(MSW)에 사용
+ */
+export const MOCK_PIPELINE_SNAPSHOT_ID = {
+  PREFERENCE: 1,
+  HEALTH: 2,
+} as const

--- a/src/mocks/data/profilingForms.ts
+++ b/src/mocks/data/profilingForms.ts
@@ -1,12 +1,17 @@
 /**
  * 향기 성향 테스트 항목 조회 목 데이터
- * API 명세: GET /api/v1/profilings/forms/active?profiling_type=PREFERENCE|HEALTH
+ *
+ * GET /api/v1/profilings/forms/active?profiling_type=PREFERENCE|HEALTH
+ * Response data: ProfilingForm
+ * - pipeline_snapshot_id: 제출(POST /profilings/submit) 시 동일 값을 pipeline_snapshot_id로 전달
  */
 import type { ProfilingForm } from '@/app/find-my-scent/_types'
+import { MOCK_PIPELINE_SNAPSHOT_ID } from './profilingConstants'
 
 /** 취향 테스트(PREFERENCE) 활성 폼 목 데이터 */
 export const mockProfilingFormPREFERENCE: ProfilingForm = {
   form_id: 1,
+  pipeline_snapshot_id: MOCK_PIPELINE_SNAPSHOT_ID.PREFERENCE,
   name: '취향 테스트 v1',
   profiling_type: 'PREFERENCE',
   questions: [
@@ -159,6 +164,7 @@ export const mockProfilingFormPREFERENCE: ProfilingForm = {
 /** 건강 테스트(HEALTH) 활성 폼 목 데이터 */
 export const mockProfilingFormHEALTH: ProfilingForm = {
   form_id: 2,
+  pipeline_snapshot_id: MOCK_PIPELINE_SNAPSHOT_ID.HEALTH,
   name: '웰니스 케어 진단 v1',
   profiling_type: 'HEALTH',
   questions: [

--- a/src/mocks/data/profilingResults.ts
+++ b/src/mocks/data/profilingResults.ts
@@ -1,11 +1,16 @@
 /**
  * GET /api/v1/profilings/results/:result_id 목 데이터
+ *
+ * ProfilingResultDetail — 제출 시 선택한 product_type(DIFFUSER | PERFUME)에 따라
+ * 실서버는 결과가 달라질 수 있음. 목에서는 공통 샘플 1건 사용.
  */
 import type { ProfilingResultDetail } from '@/app/find-my-scent/_types'
 
 export const mockProfilingResultDetail: ProfilingResultDetail = {
   id: 42,
+  /** PREFERENCE | HEALTH | AI 등 */
   input_data_type: 'PREFERENCE',
+  /** 제출 시 선택한 product_type과 맞추려면 MSW에서 submit 직후 별도 저장 로직 필요 */
   product_type: 'DIFFUSER',
   input_data_summary:
     '차분한 무드와 가을 숲을 선호하는 당신에게 포근한 우디 향을 추천합니다.',
@@ -21,4 +26,13 @@ export const mockProfilingResultDetail: ProfilingResultDetail = {
   },
   recommended_products: [{ purchase_url: 'https://www.coupang.com/' }],
   created_at: '2026-02-28T14:30:00Z',
+}
+
+/** 향수(PERFUME) 제출 시 결과 페이지 UI 확인용 보조 목 (선택) */
+export const mockProfilingResultDetailPerfume: ProfilingResultDetail = {
+  ...mockProfilingResultDetail,
+  id: 43,
+  product_type: 'PERFUME',
+  input_data_summary:
+    '우아한 플로럴과 시트러스를 선호하는 당신에게 맞춤 향수 블렌드를 추천합니다.',
 }

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -13,6 +13,7 @@ import {
   mockProfilingFormPREFERENCE,
   mockProfilingFormHEALTH,
 } from './data/profilingForms'
+import { MOCK_PIPELINE_SNAPSHOT_ID } from './data/profilingConstants'
 import { mockProfilingResultDetail } from './data/profilingResults'
 import { adminCategoryHandlers } from './handlers/adminCategoryHandlers'
 import {
@@ -189,11 +190,18 @@ export const profilingSubmitHandler = http.post(
   '/api/v1/profilings/submit',
   async ({ request }) => {
     const body = (await request.json()) as {
+      pipeline_snapshot_id?: number
       profiling_type?: string
       product_type?: string
       responses?: unknown[]
     }
-    if (!body?.profiling_type || !body?.responses) {
+    if (
+      body?.pipeline_snapshot_id == null ||
+      typeof body.pipeline_snapshot_id !== 'number' ||
+      !body?.profiling_type ||
+      !body?.product_type ||
+      !Array.isArray(body?.responses)
+    ) {
       return HttpResponse.json(
         {
           success: false,
@@ -201,6 +209,50 @@ export const profilingSubmitHandler = http.post(
             code: 'BAD_REQUEST',
             message: '필수 항목이 누락되었습니다.',
             details: null,
+          },
+        },
+        { status: 400 }
+      )
+    }
+    if (!PRODUCT_TYPES.includes(body.product_type as ProductType)) {
+      return HttpResponse.json(
+        {
+          success: false,
+          error: {
+            code: 'BAD_REQUEST',
+            message: `product_type은 ${PRODUCT_TYPES.join(' 또는 ')}이어야 합니다.`,
+            details: { field: 'product_type', reason: 'invalid' },
+          },
+        },
+        { status: 400 }
+      )
+    }
+    if (!PROFILING_TYPES.includes(body.profiling_type as ProfilingType)) {
+      return HttpResponse.json(
+        {
+          success: false,
+          error: {
+            code: 'BAD_REQUEST',
+            message: `profiling_type은 ${PROFILING_TYPES.join(' 또는 ')}여야 합니다.`,
+            details: { field: 'profiling_type', reason: 'invalid' },
+          },
+        },
+        { status: 400 }
+      )
+    }
+    const expectedSnapshot =
+      body.profiling_type === 'HEALTH'
+        ? MOCK_PIPELINE_SNAPSHOT_ID.HEALTH
+        : MOCK_PIPELINE_SNAPSHOT_ID.PREFERENCE
+    if (body.pipeline_snapshot_id !== expectedSnapshot) {
+      return HttpResponse.json(
+        {
+          success: false,
+          error: {
+            code: 'BAD_REQUEST',
+            message:
+              'pipeline_snapshot_id가 활성 폼과 일치하지 않습니다. 최신 폼을 다시 불러오세요.',
+            details: { field: 'pipeline_snapshot_id', reason: 'invalid' },
           },
         },
         { status: 400 }


### PR DESCRIPTION
## ✨ PR 개요
- 취향/건강 테스트 시작 전 **향수(PERFUME) / 디퓨저(DIFFUSER)** 중 추천 유형을 선택하고, 제출 시 **`product_type`** 과 활성 폼의 **`pipeline_snapshot_id`** 를 함께 보내도록 연동했습니다.


## 📌 관련 이슈
Closes #159 

## 🧩 작업 내용 (주요 변경사항)
### UI
- `ProductTypeSelectModal`: 유형 선택(가로 2버튼), 우측 상단 닫기(X) → `onClose` (기본: `router.back()`)
- `ProfilingTestPage`: 폼 로딩 후 모달 → 선택 시 `QuizView` 진입
- `QuizView` / `ProfilingQuizClient`: `pipelineSnapshotId`, `productType` props로 제출 payload 구성

### API·타입
- `ProfilingForm` / `ProfilingSubmitRequest`: `pipeline_snapshot_id`, `product_type` 반영
- `useProfilingForm`: 활성 폼 조회 응답에서 `pipeline_snapshot_id` 보관
- `profilingClient.buildSubmitPayload`: `pipelineSnapshotId`, `profilingType`, `productType` 포함

### 목·로컬 API
- `profilingConstants.ts`: 목용 `MOCK_PIPELINE_SNAPSHOT_ID` (PREFERENCE / HEALTH)
- `profilingForms.ts`: 폼 데이터와 스냅샷 ID 정합
- MSW `handlers` · `app/api/v1/profilings/submit/route.ts`: `product_type` 검증, `pipeline_snapshot_id`와 `profiling_type` 일치 검증
- `profilingResults` 등 목 데이터 보강 (필요 시)

## 동작 요약
1. `GET /api/v1/profilings/forms/active` → 질문 + `pipeline_snapshot_id`
2. 모달에서 유형 선택 → 퀴즈 진행
3. `POST /api/v1/profilings/submit` 에 `pipeline_snapshot_id`, `profiling_type`, `product_type`, `responses` 전송


## 💬 리뷰 포인트
<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

https://github.com/user-attachments/assets/570c8b6e-d171-48f4-92c9-bb6a50abfd1b



## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트

- [ ] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [ ] 불필요한 console.log 제거
- [ ] 로컬에서 실행 확인 완료
