### PR TITLE
fix: 이미지 URL/프로필링 API 프록시·비로그인 테스트 UX·MSW 정합 (#162)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,67 @@
 import type { NextConfig } from 'next'
 
+type RemotePattern = NonNullable<
+  NonNullable<NextConfig['images']>['remotePatterns']
+>[number]
+
+/**
+ * next/image 외부 호스트 허용 — 개발/스테이징 API·CDN 도메인
+ * (미설정 시 외부 절대 URL 이미지에서 "hostname is not configured" 런타임 에러)
+ */
+function buildImageRemotePatterns(): RemotePattern[] {
+  const patterns: RemotePattern[] = []
+  const seen = new Set<string>()
+
+  const pushFromUrl = (raw: string | undefined) => {
+    const trimmed = raw?.trim()
+    if (!trimmed) return
+    try {
+      const url = new URL(trimmed)
+      const key = `${url.protocol}//${url.host}`
+      if (seen.has(key)) return
+      seen.add(key)
+      const protocol = (url.protocol === 'https:' ? 'https' : 'http') as
+        | 'http'
+        | 'https'
+      const entry: RemotePattern = {
+        protocol,
+        hostname: url.hostname,
+        pathname: '/**',
+      }
+      if (url.port) entry.port = url.port
+      patterns.push(entry)
+    } catch {
+      /* ignore */
+    }
+  }
+
+  pushFromUrl(process.env.NEXT_PUBLIC_API_URL)
+  pushFromUrl(process.env.NEXT_PUBLIC_API_BASE_URL)
+
+  const extra = process.env.NEXT_PUBLIC_IMAGE_REMOTE_HOSTNAMES?.split(',') ?? []
+  for (const part of extra) {
+    const h = part.trim()
+    if (!h) continue
+    if (h.startsWith('http://') || h.startsWith('https://')) {
+      pushFromUrl(h)
+      continue
+    }
+    patterns.push({ protocol: 'https', hostname: h, pathname: '/**' })
+    patterns.push({ protocol: 'http', hostname: h, pathname: '/**' })
+  }
+
+  for (const hostname of ['localhost', '127.0.0.1']) {
+    patterns.push({ protocol: 'http', hostname, pathname: '/**' })
+    patterns.push({ protocol: 'https', hostname, pathname: '/**' })
+  }
+
+  return patterns
+}
+
 const nextConfig: NextConfig = {
+  images: {
+    remotePatterns: buildImageRemotePatterns(),
+  },
   reactCompiler: true,
   // Next.js 16: Turbopack 기본 사용. SVG를 React 컴포넌트로 import 하기 위해 SVGR 사용
   turbopack: {

--- a/src/app/admin/product/_components/ProductTableServer.tsx
+++ b/src/app/admin/product/_components/ProductTableServer.tsx
@@ -16,6 +16,7 @@ import {
   ACCORD_LABEL_PILL_SM_CLASS,
 } from '@/constants/accordLabelStyles'
 import { ProductDeleteButton } from './ProductDeleteButton'
+import { resolveApiMediaUrl } from '@/lib/resolveApiMediaUrl'
 
 const PAGE_SIZE = 10
 
@@ -37,8 +38,6 @@ export async function ProductTableServer({
     page: searchParams.page ? Number(searchParams.page) : 1,
     size: PAGE_SIZE,
   })
-  console.log('실제 호출', response.data.results)
-
   const items = (response?.data?.results || []) as (
     | AdminElementProduct
     | AdminBlendProduct
@@ -61,13 +60,17 @@ export async function ProductTableServer({
           <AdminTableRow key={item.id} type="product">
             <AdminTableCell slot={1}>
               <div className="flex items-center gap-3">
-                <Image
-                  src={item.thumbnail_image_url || ''}
-                  alt={item.name}
-                  width={40}
-                  height={40}
-                  className="h-20 w-20 rounded-md object-cover"
-                />
+                {resolveApiMediaUrl(item.thumbnail_image_url) ? (
+                  <Image
+                    src={resolveApiMediaUrl(item.thumbnail_image_url)}
+                    alt={item.name}
+                    width={40}
+                    height={40}
+                    className="h-20 w-20 rounded-md object-cover"
+                  />
+                ) : (
+                  <div className="h-20 w-20 rounded-md bg-neutral-100" />
+                )}
                 <span className="text-[16px] font-bold">{item.name}</span>
               </div>
             </AdminTableCell>

--- a/src/app/api/v1/profilings/_lib/upstreamProxy.ts
+++ b/src/app/api/v1/profilings/_lib/upstreamProxy.ts
@@ -1,0 +1,69 @@
+import { cookies } from 'next/headers'
+import { NextResponse } from 'next/server'
+
+/** MSW/목 응답 경로 외 실서버 연동 시 쿠키 access_token 을 Bearer 로 붙여 백엔드로 전달 */
+export async function proxyToProfilingUpstream(
+  upstreamPathWithQuery: string,
+  init: RequestInit = {}
+): Promise<NextResponse> {
+  const baseUrl = process.env.NEXT_PUBLIC_API_URL?.trim()
+  if (!baseUrl) {
+    return NextResponse.json(
+      {
+        success: false as const,
+        error: {
+          code: 'MISSING_API_URL',
+          message: 'NEXT_PUBLIC_API_URL is not configured.',
+          details: null,
+        },
+      },
+      { status: 500 }
+    )
+  }
+
+  const cookieStore = await cookies()
+  const token = cookieStore.get('access_token')?.value
+
+  if (!token) {
+    return NextResponse.json(
+      {
+        success: false as const,
+        error: {
+          code: 'UNAUTHORIZED',
+          message: '로그인이 필요합니다.',
+          details: null,
+        },
+      },
+      { status: 401 }
+    )
+  }
+
+  const url = `${baseUrl}${upstreamPathWithQuery}`
+  const upstream = await fetch(url, {
+    ...init,
+    headers: {
+      Accept: 'application/json',
+      ...(init.body ? { 'Content-Type': 'application/json' } : {}),
+      Authorization: `Bearer ${token}`,
+      ...(init.headers as Record<string, string>),
+    },
+    cache: 'no-store',
+  })
+
+  const text = await upstream.text()
+  let data: unknown = null
+  try {
+    data = text ? JSON.parse(text) : null
+  } catch {
+    data = {
+      success: false,
+      error: {
+        code: 'UPSTREAM_PARSE_ERROR',
+        message: '서버 응답을 해석하지 못했습니다.',
+        details: null,
+      },
+    }
+  }
+
+  return NextResponse.json(data, { status: upstream.status })
+}

--- a/src/app/api/v1/profilings/forms/active/route.ts
+++ b/src/app/api/v1/profilings/forms/active/route.ts
@@ -1,18 +1,24 @@
 /**
- * 활성 프로파일링 폼 조회 (MSW 미가로챔 시 fallback)
- * - MSW 사용 시에는 worker가 이 요청을 가로챔
- * - worker 미등록/미동작 시 요청이 서버로 오면 같은 목데이터로 응답
- * - 실 API 연동 시 NEXT_PUBLIC_API_BASE_URL 설정으로 외부 서버 사용
+ * 활성 프로파일링 폼 조회
+ * - Query: profiling_type (PREFERENCE | HEALTH), product_type (PERFUME | DIFFUSER)
+ * - NEXT_PUBLIC_USE_MOCK_API=true: 목 응답
+ * - 그 외: httpOnly access_token 으로 백엔드 프록시
  */
 import { NextResponse } from 'next/server'
 import {
   mockProfilingFormPREFERENCE,
   mockProfilingFormHEALTH,
 } from '@/mocks/data/profilingForms'
+import { proxyToProfilingUpstream } from '../../_lib/upstreamProxy'
+
+const USE_MOCK = process.env.NEXT_PUBLIC_USE_MOCK_API === 'true'
+
+const PRODUCT_TYPES = ['PERFUME', 'DIFFUSER'] as const
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url)
   const profilingType = searchParams.get('profiling_type')
+  const productType = searchParams.get('product_type')
 
   if (profilingType !== 'PREFERENCE' && profilingType !== 'HEALTH') {
     return NextResponse.json(
@@ -21,17 +27,53 @@ export async function GET(request: Request) {
         error: {
           code: 'INVALID_PARAMETER',
           message: 'profiling_type은 PREFERENCE 또는 HEALTH여야 합니다.',
-          details: { field: 'profiling_type' },
+          details: {
+            field: 'profiling_type',
+            reason: 'invalid_value',
+          },
         },
       },
       { status: 400 }
     )
   }
 
-  const form =
-    profilingType === 'HEALTH'
-      ? mockProfilingFormHEALTH
-      : mockProfilingFormPREFERENCE
+  if (
+    !productType ||
+    !PRODUCT_TYPES.includes(productType as (typeof PRODUCT_TYPES)[number])
+  ) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          code: 'INVALID_PARAMETER',
+          message: 'product_type은 PERFUME 또는 DIFFUSER여야 합니다.',
+          details: {
+            field: 'product_type',
+            reason: 'invalid_value',
+          },
+        },
+      },
+      { status: 400 }
+    )
+  }
 
-  return NextResponse.json({ success: true, data: form })
+  if (USE_MOCK) {
+    const form =
+      profilingType === 'HEALTH'
+        ? mockProfilingFormHEALTH
+        : mockProfilingFormPREFERENCE
+
+    return NextResponse.json({ success: true, data: form })
+  }
+
+  const q = new URLSearchParams({
+    profiling_type: profilingType,
+    product_type: productType,
+  })
+  return proxyToProfilingUpstream(
+    `/api/v1/profilings/forms/active?${q.toString()}`,
+    {
+      method: 'GET',
+    }
+  )
 }

--- a/src/app/api/v1/profilings/results/[resultId]/route.ts
+++ b/src/app/api/v1/profilings/results/[resultId]/route.ts
@@ -1,12 +1,16 @@
 /**
- * 결과 상세 조회 (MSW 미가로챔 시 fallback)
- * GET /api/v1/profilings/results/:resultId
+ * 결과 상세 조회
+ * - NEXT_PUBLIC_USE_MOCK_API=true: 목 응답
+ * - 그 외: 백엔드 프록시
  */
 import { NextResponse } from 'next/server'
 import { mockProfilingResultDetail } from '@/mocks/data/profilingResults'
+import { proxyToProfilingUpstream } from '../../_lib/upstreamProxy'
+
+const USE_MOCK = process.env.NEXT_PUBLIC_USE_MOCK_API === 'true'
 
 export async function GET(
-  _request: Request,
+  request: Request,
   { params }: { params: Promise<{ resultId: string }> }
 ) {
   const { resultId } = await params
@@ -25,8 +29,14 @@ export async function GET(
     )
   }
 
-  return NextResponse.json({
-    success: true,
-    data: { ...mockProfilingResultDetail, id },
+  if (USE_MOCK) {
+    return NextResponse.json({
+      success: true,
+      data: { ...mockProfilingResultDetail, id },
+    })
+  }
+
+  return proxyToProfilingUpstream(`/api/v1/profilings/results/${id}`, {
+    method: 'GET',
   })
 }

--- a/src/app/api/v1/profilings/submit/route.ts
+++ b/src/app/api/v1/profilings/submit/route.ts
@@ -1,10 +1,14 @@
 /**
- * 테스트 제출 (MSW 미가로챔 시 fallback)
- * POST /api/v1/profilings/submit
+ * 테스트 제출
+ * - NEXT_PUBLIC_USE_MOCK_API=true: 기존 목 검증·응답
+ * - 그 외: 백엔드 프록시
  */
 import { NextResponse } from 'next/server'
 import { MOCK_PIPELINE_SNAPSHOT_ID } from '@/mocks/data/profilingConstants'
 import { mockProfilingResultDetail } from '@/mocks/data/profilingResults'
+import { proxyToProfilingUpstream } from '../_lib/upstreamProxy'
+
+const USE_MOCK = process.env.NEXT_PUBLIC_USE_MOCK_API === 'true'
 
 const PRODUCT_TYPES = ['DIFFUSER', 'PERFUME'] as const
 const PROFILING_TYPES = ['PREFERENCE', 'HEALTH'] as const
@@ -30,6 +34,13 @@ export async function POST(request: Request) {
       },
       { status: 400 }
     )
+  }
+
+  if (!USE_MOCK) {
+    return proxyToProfilingUpstream('/api/v1/profilings/submit', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    })
   }
 
   if (

--- a/src/app/find-my-scent/_api/profilingClient.ts
+++ b/src/app/find-my-scent/_api/profilingClient.ts
@@ -1,11 +1,16 @@
 /**
  * 향기 성향 테스트 API
- * - GET forms/active, POST submit, GET results/:id
- * - 목데이터(MSW): NEXT_PUBLIC_USE_MOCK_API=true 시 같은 origin 요청 → MSW가 가로챔
+ *
+ * 활성 폼 조회 GET `/api/v1/profilings/forms/active`
+ * - Query: `profiling_type` (PREFERENCE | HEALTH), `product_type` (PERFUME | DIFFUSER)
+ * - Header: `Authorization: Bearer <token>` — 실서버는 Next Route 프록시가 쿠키의 access_token 으로 부착,
+ *   MSW 모드(`NEXT_PUBLIC_USE_MOCK_API`)에서는 브라우저가 `Bearer mock-dev-token` 전달
+ * - 브라우저: 같은 오리진 + `credentials: 'include'` / RSC: 내부 URL + `Cookie` 헤더
  */
-import { apiFetch } from '@/lib/api'
+import { handleResponse } from '@/lib/api/client'
 import type {
   AnswersState,
+  ProductTypeChoice,
   ProfilingFormResponse,
   ProfilingQuestion,
   ProfilingResultDetail,
@@ -37,18 +42,80 @@ export function toQuizQuestions(
   return data.questions.map(toQuizQuestion)
 }
 
+async function profilingFetchJson<T>(
+  path: string,
+  init: RequestInit = {}
+): Promise<T> {
+  const isBrowser = typeof window !== 'undefined'
+
+  const hasBody =
+    init.body != null && init.method !== 'GET' && init.method !== undefined
+
+  const headers: Record<string, string> = {
+    Accept: 'application/json',
+    ...(hasBody ? { 'Content-Type': 'application/json' } : {}),
+  }
+  if (
+    init.headers &&
+    typeof init.headers === 'object' &&
+    !Array.isArray(init.headers)
+  ) {
+    const h = init.headers as Record<string, string>
+    for (const [k, v] of Object.entries(h)) {
+      if (v != null) headers[k] = v
+    }
+  }
+
+  let url: string
+  const fetchInit: RequestInit = {
+    ...init,
+    headers,
+    ...(isBrowser
+      ? { credentials: 'include' as RequestCredentials }
+      : { cache: 'no-store' }),
+  }
+
+  if (isBrowser && process.env.NEXT_PUBLIC_USE_MOCK_API === 'true') {
+    // MSW/브라우저 직접 호출 시 스펙상 Bearer 필요 — Route 프록시 경로는 쿠키 사용
+    headers.Authorization = 'Bearer mock-dev-token'
+  }
+
+  if (isBrowser) {
+    url = path.startsWith('/') ? path : `/${path}`
+  } else {
+    const { headers: nextHeaders } = await import('next/headers')
+    const h = await nextHeaders()
+    const host = h.get('host') ?? 'localhost:3000'
+    const proto = h.get('x-forwarded-proto') ?? 'http'
+    const rel = path.startsWith('/') ? path : `/${path}`
+    url = `${proto}://${host}${rel}`
+    const cookie = h.get('cookie')
+    if (cookie) {
+      headers.cookie = cookie
+    }
+  }
+
+  const response = await fetch(url, fetchInit)
+  const finalRes = await handleResponse(response)
+  return finalRes.json() as Promise<T>
+}
+
 /**
  * 향기 성향 테스트 항목 조회
- * GET /api/v1/profilings/forms/active?profiling_type={PREFERENCE|HEALTH}
+ * GET /api/v1/profilings/forms/active?profiling_type=&product_type=
+ * 헤더: 실서버는 Route 프록시가 Bearer 부착 / MSW는 클라이언트에서 mock Bearer
  */
 export async function fetchProfilingFormActive(
-  profilingType: ProfilingType
+  profilingType: ProfilingType,
+  productType: ProductTypeChoice
 ): Promise<ProfilingFormResponse> {
-  return apiFetch.get<ProfilingFormResponse>(
-    '/api/v1/profilings/forms/active',
-    {
-      params: { profiling_type: profilingType },
-    }
+  const q = new URLSearchParams({
+    profiling_type: profilingType,
+    product_type: productType,
+  })
+  return profilingFetchJson<ProfilingFormResponse>(
+    `/api/v1/profilings/forms/active?${q.toString()}`,
+    { method: 'GET' }
   )
 }
 
@@ -61,7 +128,7 @@ export function buildSubmitPayload(
   answers: AnswersState,
   pipelineSnapshotId: number,
   profilingType: ProfilingType,
-  productType: 'DIFFUSER' | 'PERFUME'
+  productType: ProductTypeChoice
 ): ProfilingSubmitRequest {
   const responses = questions.map((q) => {
     const selectedIds = answers[q.id] ?? []
@@ -85,21 +152,26 @@ export function buildSubmitPayload(
 export async function submitProfiling(
   body: ProfilingSubmitRequest
 ): Promise<ProfilingSubmitResponse> {
-  return apiFetch.post<ProfilingSubmitResponse>(
+  return profilingFetchJson<ProfilingSubmitResponse>(
     '/api/v1/profilings/submit',
-    body
+    {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }
   )
 }
 
 /**
- * 결과 상세 조회
- * GET /api/v1/profilings/results/{result_id}
+ * 결과 상세 조회 GET `/api/v1/profilings/results/{result_id}`
+ * - 200 / 401 / 404 — 실패 시 `error.details` 는 null 또는 `{ field, reason }`
+ * - MSW·프록시 경로는 활성 폼 조회와 동일 (Bearer: 목은 mock-dev-token / 실서버는 쿠키 프록시)
  */
 export async function fetchProfilingResult(
   resultId: number
 ): Promise<ProfilingResultDetailResponse> {
-  return apiFetch.get<ProfilingResultDetailResponse>(
-    `/api/v1/profilings/results/${resultId}`
+  return profilingFetchJson<ProfilingResultDetailResponse>(
+    `/api/v1/profilings/results/${resultId}`,
+    { method: 'GET' }
   )
 }
 

--- a/src/app/find-my-scent/_components/LoginRequiredTestModal.tsx
+++ b/src/app/find-my-scent/_components/LoginRequiredTestModal.tsx
@@ -1,0 +1,127 @@
+'use client'
+
+/**
+ * 비회원 테스트 진입 시 — 공통 ErrorFeedback/Alert 수정 없이 사용.
+ * body 로 포털 + min-h-dvh flex 로 뷰포트 정중앙 정렬 (modal-root / absolute 한계 회피).
+ */
+import { createPortal } from 'react-dom'
+import { useEffect, useRef, useSyncExternalStore } from 'react'
+import { useRouter } from 'next/navigation'
+import Modal from '@/components/common/Modal/Modal'
+import Button from '@/components/common/Button'
+import AlertDangerIcon from '@/assets/icons/alertDanger.svg'
+
+const REDIRECT_MS = 3000
+const MODAL_Z = 100
+
+function useIsClient() {
+  return useSyncExternalStore(
+    () => () => {},
+    () => true,
+    () => false
+  )
+}
+
+type LoginRequiredTestModalProps = {
+  isOpen: boolean
+  onClose: () => void
+}
+
+export function LoginRequiredTestModal({
+  isOpen,
+  onClose,
+}: LoginRequiredTestModalProps) {
+  const router = useRouter()
+  const mounted = useIsClient()
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const onCloseRef = useRef(onClose)
+
+  useEffect(() => {
+    onCloseRef.current = onClose
+  }, [onClose])
+
+  const goLogin = () => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+    onCloseRef.current()
+    router.push('/login')
+  }
+
+  useEffect(() => {
+    if (!isOpen) return
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null
+      onCloseRef.current()
+      router.push('/login')
+    }, REDIRECT_MS)
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current)
+        timerRef.current = null
+      }
+    }
+  }, [isOpen, router])
+
+  if (!isOpen || !mounted) return null
+
+  return createPortal(
+    <div
+      className="fixed inset-0 overflow-y-auto bg-black/40 [scrollbar-gutter:stable]"
+      style={{ zIndex: MODAL_Z }}
+    >
+      <div
+        className="flex min-h-[100dvh] w-full items-center justify-center p-4"
+        onClick={(e) => {
+          if (e.target === e.currentTarget) goLogin()
+        }}
+        role="presentation"
+      >
+        {/*
+          Modal(size md)은 max-w-[448px]라 부모가 더 넓으면 블록 기본 정렬로 왼쪽에 붙음 → flex justify-center 로 수평 중앙.
+          100vw는 스크롤바 포함 너비라 시각적으로 한쪽으로 치우쳐 보일 수 있어 사용하지 않음.
+        */}
+        <div
+          className="box-border flex w-full max-w-[672px] shrink-0 justify-center"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="login-required-test-title"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <Modal isOpen onClose={goLogin} size="md" showCloseButton>
+            <div className="bg-danger absolute h-[6px] w-full" />
+
+            <div className="flex flex-col items-center px-6 pt-12 pb-8">
+              <div className="text-danger bg-danger/10 mb-6 flex h-18 w-18 items-center justify-center rounded-full">
+                <AlertDangerIcon width={40} height={40} />
+              </div>
+
+              <h2
+                id="login-required-test-title"
+                className="mb-2 text-center text-xl font-bold text-black"
+              >
+                회원만 접근 가능합니다
+              </h2>
+              <div className="mb-8 text-center text-sm leading-relaxed whitespace-pre-wrap text-gray-500">
+                로그인먼저 해주세요.
+              </div>
+
+              <div className="flex w-full gap-3">
+                <Button
+                  color="danger"
+                  size="none"
+                  className="flex-1 rounded-[14px] border border-transparent py-3 font-semibold"
+                  onClick={goLogin}
+                >
+                  로그인하기
+                </Button>
+              </div>
+            </div>
+          </Modal>
+        </div>
+      </div>
+    </div>,
+    document.body
+  )
+}

--- a/src/app/find-my-scent/_components/ProductTypeSelectModal.tsx
+++ b/src/app/find-my-scent/_components/ProductTypeSelectModal.tsx
@@ -3,8 +3,9 @@
 /** 테스트 진입 전: 향수(퍼퓸) vs 디퓨저 추천 유형 선택 */
 import Image from 'next/image'
 import { ModalOverlay, ModalPortal } from '@/components/common/Modal'
+import type { ProductTypeChoice } from '../_types'
 
-export type ProductTypeChoice = 'DIFFUSER' | 'PERFUME'
+export type { ProductTypeChoice }
 
 type ProductTypeSelectModalProps = {
   isOpen: boolean

--- a/src/app/find-my-scent/_components/ProfilingQuizClient.tsx
+++ b/src/app/find-my-scent/_components/ProfilingQuizClient.tsx
@@ -1,8 +1,7 @@
 'use client'
 
 /** 서버에서 받은 질문으로 퀴즈만 렌더 (로딩/에러는 서버·loading/error에서 처리) */
-import type { QuizQuestion, TestType } from '../_types'
-import type { ProductTypeChoice } from './ProductTypeSelectModal'
+import type { ProductTypeChoice, QuizQuestion, TestType } from '../_types'
 import { QuizView } from './QuizView'
 
 type ProfilingQuizClientProps = {

--- a/src/app/find-my-scent/_components/ProfilingTestPage.tsx
+++ b/src/app/find-my-scent/_components/ProfilingTestPage.tsx
@@ -1,17 +1,18 @@
 'use client'
 
-/** 취향/건강 테스트 공통 페이지 — 진입 전 제품 유형(향수/디퓨저) 선택 후 퀴즈 */
+/** 취향/건강 테스트 공통 페이지 — 진입 전 제품 유형(향수/디퓨저) 선택 후 활성 폼 조회·퀴즈 */
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { PageCenter } from '@/components/common/PageCenter'
 import { LoadingSpinner } from '@/components/common/LoadingSpinner'
 import { ErrorFeedbackModal } from '@/components/common/ErrorFeedback'
+import { LoginRequiredTestModal } from './LoginRequiredTestModal'
 import { ProductTypeSelectModal } from './ProductTypeSelectModal'
-import type { ProductTypeChoice } from './ProductTypeSelectModal'
+import type { ProductTypeChoice, TestType } from '../_types'
 import { QuizView } from './QuizView'
 import { useProfilingForm } from '../_hooks/useProfilingForm'
 import { useErrorPopup } from '../_hooks/useErrorPopup'
-import type { TestType } from '../_types'
+import { isLoginRequiredFetchError } from '@/lib/api'
 
 const styles = {
   emptyText: 'text-neutral-500',
@@ -21,33 +22,62 @@ const styles = {
 
 export function ProfilingTestPage({ testType }: { testType: TestType }) {
   const router = useRouter()
-  const { questions, pipelineSnapshotId, isLoading, error, refetch } =
-    useProfilingForm(testType)
   const [productType, setProductType] = useState<ProductTypeChoice | null>(null)
+  const { questions, pipelineSnapshotId, isLoading, error, refetch } =
+    useProfilingForm(testType, productType)
   const { isOpen: showErrorPopup, close: closeErrorPopup } =
     useErrorPopup(error)
 
+  if (productType === null) {
+    return (
+      <>
+        <PageCenter>
+          <p className="text-center text-sm text-neutral-500">
+            추천 받을 제품 유형을 선택해 주세요.
+          </p>
+        </PageCenter>
+        <ProductTypeSelectModal
+          isOpen
+          onSelect={setProductType}
+          onClose={() => router.back()}
+        />
+      </>
+    )
+  }
+
   if (error) {
+    const needLogin = isLoginRequiredFetchError(error)
     return (
       <>
         <PageCenter>
           <div className="flex flex-col items-center gap-2 text-center">
-            <p className="text-neutral-500">질문을 불러오지 못했어요.</p>
+            <p className="text-neutral-500">
+              {needLogin
+                ? '로그인 후 이용할 수 있어요.'
+                : '질문을 불러오지 못했어요.'}
+            </p>
             <button
               type="button"
-              onClick={refetch}
+              onClick={() => (needLogin ? router.push('/login') : refetch())}
               className={styles.retryBtn}
-              aria-label="테스트 다시 하기"
+              aria-label={needLogin ? '로그인하기' : '테스트 다시 하기'}
             >
-              테스트 다시 하기
+              {needLogin ? '로그인하기' : '테스트 다시 하기'}
             </button>
           </div>
         </PageCenter>
-        <ErrorFeedbackModal
-          message={error.message}
-          isOpen={showErrorPopup}
-          onClose={closeErrorPopup}
-        />
+        {needLogin ? (
+          <LoginRequiredTestModal
+            isOpen={showErrorPopup}
+            onClose={closeErrorPopup}
+          />
+        ) : (
+          <ErrorFeedbackModal
+            message={error.message}
+            isOpen={showErrorPopup}
+            onClose={closeErrorPopup}
+          />
+        )}
       </>
     )
   }
@@ -69,20 +99,11 @@ export function ProfilingTestPage({ testType }: { testType: TestType }) {
   }
 
   return (
-    <>
-      <ProductTypeSelectModal
-        isOpen={productType === null}
-        onSelect={setProductType}
-        onClose={() => router.back()}
-      />
-      {productType != null && (
-        <QuizView
-          testType={testType}
-          questions={questions}
-          pipelineSnapshotId={pipelineSnapshotId}
-          productType={productType}
-        />
-      )}
-    </>
+    <QuizView
+      testType={testType}
+      questions={questions}
+      pipelineSnapshotId={pipelineSnapshotId}
+      productType={productType}
+    />
   )
 }

--- a/src/app/find-my-scent/_hooks/useProfilingForm.ts
+++ b/src/app/find-my-scent/_hooks/useProfilingForm.ts
@@ -7,18 +7,30 @@ import {
   fetchProfilingFormActive,
   toQuizQuestions,
 } from '../_api/profilingClient'
-import type { ProfilingType, QuizQuestion } from '../_types'
+import type { ProductTypeChoice, ProfilingType, QuizQuestion } from '../_types'
 
-export function useProfilingForm(profilingType: ProfilingType) {
+export function useProfilingForm(
+  profilingType: ProfilingType,
+  productType: ProductTypeChoice | null
+) {
   const [questions, setQuestions] = useState<QuizQuestion[]>([])
   const [pipelineSnapshotId, setPipelineSnapshotId] = useState<number | null>(
     null
   )
-  const [isLoading, setIsLoading] = useState(true)
+  const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<Error | null>(null)
   const loadRef = useRef<() => void | Promise<void>>(() => {})
 
   useEffect(() => {
+    if (productType == null) {
+      setQuestions([])
+      setPipelineSnapshotId(null)
+      setError(null)
+      setIsLoading(false)
+      loadRef.current = async () => {}
+      return
+    }
+
     let cancelled = false
     loadRef.current = async () => {
       setError(null)
@@ -26,7 +38,7 @@ export function useProfilingForm(profilingType: ProfilingType) {
       setPipelineSnapshotId(null)
       setIsLoading(true)
       try {
-        const res = await fetchProfilingFormActive(profilingType)
+        const res = await fetchProfilingFormActive(profilingType, productType)
         if (cancelled) return
         setQuestions(toQuizQuestions(res.data))
         setPipelineSnapshotId(res.data.pipeline_snapshot_id)
@@ -43,7 +55,7 @@ export function useProfilingForm(profilingType: ProfilingType) {
     return () => {
       cancelled = true
     }
-  }, [profilingType])
+  }, [profilingType, productType])
 
   return {
     questions,

--- a/src/app/find-my-scent/_types/index.ts
+++ b/src/app/find-my-scent/_types/index.ts
@@ -33,7 +33,17 @@ export type ProfilingForm = {
   questions: ProfilingQuestion[]
 }
 
-/** API 응답 - 활성 폼 조회 */
+/**
+ * GET /api/v1/profilings/forms/active 실패 시 error 스키마
+ * (성공 시에는 handleResponse 이후 data만 사용)
+ */
+export type ProfilingFormsActiveError = {
+  code: string
+  message: string
+  details: { field: string; reason: string } | null
+}
+
+/** API 응답 - 활성 폼 조회 (성공 본문) */
 export type ProfilingFormResponse = {
   success: boolean
   data: ProfilingForm
@@ -54,11 +64,14 @@ export type QuizQuestion = {
   }[]
 }
 
+/** 활성 폼 조회·제출 시 제품 유형 (API: PERFUME | DIFFUSER) */
+export type ProductTypeChoice = 'DIFFUSER' | 'PERFUME'
+
 /** POST /api/v1/profilings/submit 요청 */
 export type ProfilingSubmitRequest = {
   pipeline_snapshot_id: number
   profiling_type: ProfilingType
-  product_type: 'DIFFUSER' | 'PERFUME'
+  product_type: ProductTypeChoice
   responses: { question_key: string; answer_option_keys: string[] }[]
 }
 
@@ -69,7 +82,7 @@ export type ProfilingSubmitResponse = {
   error?: { code: string; message: string; details?: Record<string, unknown> }
 }
 
-/** GET /api/v1/profilings/results/{result_id} 응답 - recommended_blend 등 */
+/** GET /api/v1/profilings/results/{result_id} — recommended_blend */
 export type ProfilingResultBlend = {
   name: string
   image_url: string
@@ -90,10 +103,17 @@ export type ProfilingResultDetail = {
   created_at: string
 }
 
+/** 결과 상세 조회 실패 시 error (details 는 null 또는 { field, reason }) */
+export type ProfilingResultDetailError = {
+  code: string
+  message: string
+  details: { field: string; reason: string } | null
+}
+
 export type ProfilingResultDetailResponse = {
   success: boolean
   data?: ProfilingResultDetail
-  error?: { code: string; message: string; details?: Record<string, unknown> }
+  error?: ProfilingResultDetailError
 }
 
 /** ProfilingType과 동일 (UI용 alias) */

--- a/src/app/products/_api/productDetailMappers.ts
+++ b/src/app/products/_api/productDetailMappers.ts
@@ -6,20 +6,20 @@ import type { ProductDetailModalProduct } from '@/components/products/ProductDet
 import {
   blendCategoryKrToNoteLabel,
   scentCategoryKrToId,
+  type BlendDetailResponse,
+  type ElementDetailResponse,
 } from './productsClient'
-import type {
-  BlendDetailResponse,
-  ElementDetailResponse,
-} from './productsClient'
+import { resolveApiMediaUrl } from '@/lib/resolveApiMediaUrl'
 
 export function mapElementDetailToModalProduct(
   res: ElementDetailResponse
 ): ProductDetailModalProduct {
   const data = res.data
-  const imageUrl =
+  const raw =
     typeof data.image_url === 'string'
       ? data.image_url
       : (data.image_url?.[0] ?? '')
+  const imageUrl = resolveApiMediaUrl(raw)
   const kr = data.element_category?.name?.kr ?? ''
   const scentFamilyId = scentCategoryKrToId[kr] ?? 'woody'
   return {
@@ -44,7 +44,7 @@ export function mapBlendDetailToModalProduct(
     .filter(Boolean)
   return {
     name: data.name,
-    imageUrl: data.image_url,
+    imageUrl: resolveApiMediaUrl(data.image_url),
     scentFamilyIds,
     noteLabels,
     oneLineDescription: data.description ?? '',

--- a/src/app/products/_api/productsClient.ts
+++ b/src/app/products/_api/productsClient.ts
@@ -1,7 +1,7 @@
 /**
  * 향(단품/조합) API — 명세 최종본 기준
  * - 목데이터(MSW): NEXT_PUBLIC_USE_MOCK_API=true 시 같은 origin 요청 → MSW가 가로챔
- * - 실제 API: NEXT_PUBLIC_API_BASE_URL 사용
+ * - 실제 API: NEXT_PUBLIC_API_URL 사용 (lib/api client와 동일)
  */
 import { apiFetch } from '@/lib/api'
 

--- a/src/app/products/combo/ComboPageClient.tsx
+++ b/src/app/products/combo/ComboPageClient.tsx
@@ -12,6 +12,7 @@ import {
 } from '../_api/productsClient'
 import { mapBlendDetailToModalProduct } from '../_api/productDetailMappers'
 import { useProductDetailModal, type CombinationItem } from '../_hooks'
+import { resolveApiMediaUrl } from '@/lib/resolveApiMediaUrl'
 
 type ComboPageClientProps = {
   initialItems: CombinationItem[]
@@ -78,7 +79,7 @@ export function ComboPageClient({ initialItems }: ComboPageClientProps) {
               <ProductCard
                 variant="combo"
                 name={item.name}
-                imageUrl={item.thumbnail_image_url}
+                imageUrl={resolveApiMediaUrl(item.thumbnail_image_url)}
                 scentFamilyId="woody"
                 scentFamilyIds={[]}
                 scentNotes={scentNotes}

--- a/src/app/products/single/SinglePageClient.tsx
+++ b/src/app/products/single/SinglePageClient.tsx
@@ -9,6 +9,7 @@ import { ProductDetailModal } from '@/components/products/ProductDetailModal'
 import { fetchElementDetail, scentCategoryKrToId } from '../_api/productsClient'
 import { mapElementDetailToModalProduct } from '../_api/productDetailMappers'
 import { useProductDetailModal, type SingleItem } from '../_hooks'
+import { resolveApiMediaUrl } from '@/lib/resolveApiMediaUrl'
 
 type SinglePageClientProps = {
   initialItems: SingleItem[]
@@ -63,7 +64,7 @@ export function SinglePageClient({ initialItems }: SinglePageClientProps) {
               <ProductCard
                 variant="single"
                 name={item.name}
-                imageUrl={item.thumbnail_image_url}
+                imageUrl={resolveApiMediaUrl(item.thumbnail_image_url)}
                 scentFamilyId={scentFamilyId}
                 onClick={() => openDetail(item.id)}
                 priority={index === 0}

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -13,7 +13,6 @@ import OpenIcon from '@/assets/icons/open.svg'
 import { useModalStore } from '@/store/useModalStore'
 import Modal from './Modal'
 import { useAuthStore } from '@/store/useAuthStore'
-import { useState, useEffect } from 'react'
 
 const styles = {
   header:
@@ -30,7 +29,7 @@ const styles = {
   chevronWrap: 'ml-0.5 shrink-0',
 } as const
 export function Header() {
-  const { isLoggedIn, user, logout: logoutFromStore } = useAuthStore()
+  const { isLoggedIn, logout: logoutFromStore } = useAuthStore()
   const router = useRouter()
 
   const { openModal, closeModal, closeAll } = useModalStore()
@@ -65,9 +64,12 @@ export function Header() {
     try {
       await logoutFromStore()
       router.push('/login')
-    } catch (error: any) {
-      console.error('Logout Error:', error)
-      alert(error.message || '로그아웃 처리 중 오류가 발생했습니다.')
+    } catch (error: unknown) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : '로그아웃 처리 중 오류가 발생했습니다.'
+      alert(message)
     }
   }
 
@@ -77,34 +79,6 @@ export function Header() {
   }
 
   const renderRightMenu = () => {
-    // 개발 환경에서는 로그인 상태와 관계없이 로그인 링크와 프로필 메뉴를 모두 보여줌
-    if (process.env.NODE_ENV === 'development') {
-      return (
-        <>
-          <Link href="/login" className={styles.rightLink}>
-            로그인
-          </Link>
-          <Dropdown
-            trigger={
-              <Image
-                src="/profile.svg"
-                alt="프로필 메뉴"
-                width={36}
-                height={36}
-                className="size-9"
-                aria-hidden
-              />
-            }
-            items={headerNavLinks.profile}
-            variant="profile"
-            menuMinWidth="min-w-[200px]"
-            aria-label="프로필 메뉴"
-            onProfileAction={handleProfileMenu}
-          />
-        </>
-      )
-    }
-
     if (isLoggedIn) {
       return (
         <Dropdown
@@ -146,6 +120,8 @@ export function Header() {
                 width={189}
                 height={29}
                 className="h-7 w-auto"
+                priority
+                loading="eager"
               />
             </Link>
 

--- a/src/components/products/ProductCard.tsx
+++ b/src/components/products/ProductCard.tsx
@@ -32,6 +32,7 @@ export function ProductCard({
   onClick,
   priority = false,
 }: ProductCardProps) {
+  const hasImage = Boolean(imageUrl?.trim())
   const accordIds: string[] =
     variant === 'combo' && scentFamilyIds?.length
       ? scentFamilyIds
@@ -47,14 +48,18 @@ export function ProductCard({
       <article className="rounded-2xl bg-white shadow-md">
         <div className="aspect-square w-full overflow-hidden rounded-t-2xl">
           <Lens className="h-full w-full">
-            <Image
-              src={imageUrl}
-              alt={name}
-              fill
-              sizes="(max-width: 768px) 100vw, 33vw"
-              className="block rounded-[20px_20px_0_0] object-contain p-1"
-              priority={priority}
-            />
+            {hasImage ? (
+              <Image
+                src={imageUrl}
+                alt={name}
+                fill
+                sizes="(max-width: 768px) 100vw, 33vw"
+                className="block rounded-[20px_20px_0_0] object-contain p-1"
+                priority={priority}
+              />
+            ) : (
+              <div className="h-full w-full rounded-[20px_20px_0_0] bg-neutral-100" />
+            )}
           </Lens>
         </div>
         <div className="p-3">

--- a/src/components/products/ProductDetailModal.tsx
+++ b/src/components/products/ProductDetailModal.tsx
@@ -136,7 +136,7 @@ export function ProductDetailModal({
               <span>로딩 중...</span>
             </div>
           )}
-          {!isLoading && product && (
+          {!isLoading && product?.imageUrl?.trim() && (
             <Image
               src={product.imageUrl}
               alt={product.name}

--- a/src/lib/api/fetchError.ts
+++ b/src/lib/api/fetchError.ts
@@ -26,5 +26,14 @@ export class FetchError extends Error {
   }
 }
 
+/** 비로그인·세션 없음 등 로그인 유도가 필요한 API 오류인지 */
+export function isLoginRequiredFetchError(err: unknown): err is FetchError {
+  if (!(err instanceof FetchError)) return false
+  if (err.status === 401 || err.status === 403) return true
+  return /로그인|login|unauthorized|unauthenticated|인증|authentication|세션|session/i.test(
+    err.message
+  )
+}
+
 // re-export for convenience
 export type { ApiErrorResponse }

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -1,7 +1,7 @@
 // 단일 진입점 (외부에서 import 시 여기서만 가져오세요)
 export { apiFetch, authFetch, handleResponse } from './client'
 export { createFetch } from './createFetch'
-export { FetchError } from './fetchError'
+export { FetchError, isLoginRequiredFetchError } from './fetchError'
 export type {
   FetchOptions,
   FetchArgs,

--- a/src/lib/resolveApiMediaUrl.ts
+++ b/src/lib/resolveApiMediaUrl.ts
@@ -1,0 +1,28 @@
+/**
+ * API가 주는 이미지 URL을 Next/Image 및 브라우저에서 올바르게 요청되도록 정규화합니다.
+ * - 절대 URL(http/https, //)은 그대로 둡니다.
+ * - 상대 경로(/uploads/...)는 NEXT_PUBLIC_API_URL 기준으로 절대 URL로 만듭니다.
+ *   (그렇지 않으면 localhost:3000/uploads/... 로 가서 404가 납니다.)
+ */
+export function resolveApiMediaUrl(url: string | null | undefined): string {
+  if (url == null || !String(url).trim()) return ''
+  const u = String(url).trim()
+  if (
+    u.startsWith('http://') ||
+    u.startsWith('https://') ||
+    u.startsWith('//') ||
+    u.startsWith('data:') ||
+    u.startsWith('blob:')
+  ) {
+    return u
+  }
+  const base =
+    process.env.NEXT_PUBLIC_API_URL?.trim().replace(/\/$/, '') ||
+    'http://localhost:3000'
+  const path = u.startsWith('/') ? u : `/${u}`
+  try {
+    return new URL(path, `${base}/`).href
+  } catch {
+    return u
+  }
+}

--- a/src/mocks/constants.ts
+++ b/src/mocks/constants.ts
@@ -2,7 +2,7 @@
  * MSW 핸들러 검증용 상수 (문자열 비교 대신 일원화하여 유지보수 용이)
  */
 
-/** GET /api/v1/profilings/forms/active — profiling_type */
+/** GET /api/v1/profilings/forms/active — profiling_type, product_type */
 export const PROFILING_TYPES = ['PREFERENCE', 'HEALTH'] as const
 export type ProfilingType = (typeof PROFILING_TYPES)[number]
 

--- a/src/mocks/data/profilingForms.ts
+++ b/src/mocks/data/profilingForms.ts
@@ -1,7 +1,7 @@
 /**
  * 향기 성향 테스트 항목 조회 목 데이터
  *
- * GET /api/v1/profilings/forms/active?profiling_type=PREFERENCE|HEALTH
+ * GET /api/v1/profilings/forms/active?profiling_type=&product_type= (PERFUME|DIFFUSER)
  * Response data: ProfilingForm
  * - pipeline_snapshot_id: 제출(POST /profilings/submit) 시 동일 값을 pipeline_snapshot_id로 전달
  */
@@ -18,34 +18,19 @@ export const mockProfilingFormPREFERENCE: ProfilingForm = {
     {
       id: 1,
       question_key: 'mood',
-      question_text: '평소 선호하는 분위기는 무엇인가요?',
-      selection_type: 'SINGLE',
+      question_text: '선호하는 무드를 선택해주세요',
+      selection_type: 'MULTI',
       is_required: true,
       options: [
         {
           id: 1,
           answer_option_key: 'calm',
-          answer_option_text: '차분하고 편안한',
+          answer_option_text: '차분',
         },
         {
           id: 2,
           answer_option_key: 'energetic',
-          answer_option_text: '활기차고 경쾌한',
-        },
-        {
-          id: 3,
-          answer_option_key: 'elegant',
-          answer_option_text: '우아하고 세련된',
-        },
-        {
-          id: 4,
-          answer_option_key: 'mysterious',
-          answer_option_text: '신비롭고 깊은',
-        },
-        {
-          id: 5,
-          answer_option_key: 'fresh',
-          answer_option_text: '자연스럽고 청량한',
+          answer_option_text: '활기',
         },
       ],
     },

--- a/src/mocks/data/profilingResults.ts
+++ b/src/mocks/data/profilingResults.ts
@@ -1,30 +1,28 @@
 /**
- * GET /api/v1/profilings/results/:result_id 목 데이터
+ * GET /api/v1/profilings/results/{result_id} 목 데이터
  *
- * ProfilingResultDetail — 제출 시 선택한 product_type(DIFFUSER | PERFUME)에 따라
- * 실서버는 결과가 달라질 수 있음. 목에서는 공통 샘플 1건 사용.
+ * API 성공 스키마와 동일. 제출(product_type 등)에 따라 실서버는 필드가 달라질 수 있음.
  */
 import type { ProfilingResultDetail } from '@/app/find-my-scent/_types'
 
+/** 명세 Success Response Example 기준 기본 샘플 */
 export const mockProfilingResultDetail: ProfilingResultDetail = {
   id: 42,
-  /** PREFERENCE | HEALTH | AI 등 */
   input_data_type: 'PREFERENCE',
-  /** 제출 시 선택한 product_type과 맞추려면 MSW에서 submit 직후 별도 저장 로직 필요 */
   product_type: 'DIFFUSER',
-  input_data_summary:
-    '차분한 무드와 가을 숲을 선호하는 당신에게 포근한 우디 향을 추천합니다.',
+  input_data_summary: '차분한 무드와 가을 숲을 선호하는 당신에게...',
   recommended_blend: {
     name: '포근한 숲',
-    image_url: '/img/17.svg',
-    description:
-      '따뜻한 우디 향. 깊고 신비로운 오리엔탈 조합 향기가 당신만의 개성을 표현합니다.',
+    image_url: '/images/blend_5.jpg',
+    description: '따뜻한 우디 향',
     contained_elements: [
       { name: '시더우드', category: { kr: '우디', en: 'Woody' } },
       { name: '라벤더', category: { kr: '아로마틱', en: 'Aromatic' } },
     ],
   },
-  recommended_products: [{ purchase_url: 'https://www.coupang.com/' }],
+  recommended_products: [
+    { purchase_url: 'https://shop.example.com/product/1' },
+  ],
   created_at: '2026-02-28T14:30:00Z',
 }
 

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -141,14 +141,31 @@ export const blendDetailHandler = http.get(
 
 /**
  * 향기 성향 테스트 항목 조회 GET /api/v1/profilings/forms/active
- * Query: profiling_type (required) PREFERENCE | HEALTH
- * - 200: success, 400: 잘못된 파라미터, 404: 활성화된 테스트 없음(목에서는 미사용)
+ * - Query: profiling_type (PREFERENCE | HEALTH), product_type (PERFUME | DIFFUSER)
+ * - Header: Authorization Bearer (MSW 직접 호출 시 profilingClient 가 mock-dev-token 부착)
+ * - 실패 스키마: { success: false, error: { code, message, details } }, details 는 null 또는 { field, reason }
  */
 export const profilingFormActiveHandler = http.get(
   '/api/v1/profilings/forms/active',
   ({ request }) => {
+    const auth = request.headers.get('Authorization')
+    if (!auth || !/^Bearer\s+\S+/.test(auth)) {
+      return HttpResponse.json(
+        {
+          success: false,
+          error: {
+            code: 'UNAUTHORIZED',
+            message: 'Authorization Bearer 토큰이 필요합니다.',
+            details: null,
+          },
+        },
+        { status: 401 }
+      )
+    }
+
     const url = new URL(request.url)
     const profilingType = url.searchParams.get('profiling_type')
+    const productType = url.searchParams.get('product_type')
 
     if (!profilingType) {
       return HttpResponse.json(
@@ -172,6 +189,34 @@ export const profilingFormActiveHandler = http.get(
             code: 'INVALID_PARAMETER',
             message: `profiling_type은 ${PROFILING_TYPES.join(' 또는 ')}여야 합니다.`,
             details: { field: 'profiling_type', reason: 'invalid_value' },
+          },
+        },
+        { status: 400 }
+      )
+    }
+
+    if (!productType) {
+      return HttpResponse.json(
+        {
+          success: false,
+          error: {
+            code: 'INVALID_PARAMETER',
+            message: 'product_type은 필수입니다.',
+            details: { field: 'product_type', reason: 'required' },
+          },
+        },
+        { status: 400 }
+      )
+    }
+
+    if (!PRODUCT_TYPES.includes(productType as ProductType)) {
+      return HttpResponse.json(
+        {
+          success: false,
+          error: {
+            code: 'INVALID_PARAMETER',
+            message: `product_type은 ${PRODUCT_TYPES.join(' 또는 ')}이어야 합니다.`,
+            details: { field: 'product_type', reason: 'invalid_value' },
           },
         },
         { status: 400 }
@@ -273,12 +318,31 @@ export const profilingSubmitHandler = http.post(
 
 /**
  * 결과 상세 조회 GET /api/v1/profilings/results/:resultId
+ * - 200: 성공 스키마
+ * - 401: Authorization Bearer 없음/무효 (profilingFetchJson 이 MSW 모드에서 mock 토큰 부착)
+ * - 404: result_id 가 양의 정수가 아니거나 리소스 없음
  */
 export const profilingResultDetailHandler = http.get(
   '/api/v1/profilings/results/:resultId',
-  ({ params }) => {
-    const resultId = params.resultId
-    if (!resultId) {
+  ({ request, params }) => {
+    const auth = request.headers.get('Authorization')
+    if (!auth || !/^Bearer\s+\S+/.test(auth)) {
+      return HttpResponse.json(
+        {
+          success: false,
+          error: {
+            code: 'UNAUTHORIZED',
+            message: 'Authorization Bearer 토큰이 필요합니다.',
+            details: null,
+          },
+        },
+        { status: 401 }
+      )
+    }
+
+    const rawId = params.resultId
+    const id = Number(rawId)
+    if (!rawId || !Number.isInteger(id) || id < 1) {
       return HttpResponse.json(
         {
           success: false,
@@ -291,11 +355,12 @@ export const profilingResultDetailHandler = http.get(
         { status: 404 }
       )
     }
+
     return HttpResponse.json({
       success: true,
       data: {
         ...mockProfilingResultDetail,
-        id: Number(resultId) || mockProfilingResultDetail.id,
+        id,
       },
     })
   }


### PR DESCRIPTION
## ✨ PR 개요
- #162 — 개발 API 연결 시 랜딩/목록에서 깨지던 부분과 향기 성향 테스트·이미지 로딩을 정리했습니다.

## 📌 관련 이슈
Closes #162 

## 🧩 작업 내용 (주요 변경사항)
- **이미지**: `next.config` 원격 패턴, `resolveApiMediaUrl`로 상대 경로 보정, 빈 `src` 방지(카드/모달/어드민 테이블 등)
- **프로필링 API**: 활성 폼 조회에 `product_type` 쿼리 반영, Next Route + `upstreamProxy`로 쿠키 기반 Bearer 프록시 (로그인 후에도 동일 오리진으로 호출)
- **MSW/목**: `forms/active`, `submit`, `results` 및 목 데이터를 최신 스키마에 맞춤
- **비회원**: 테스트 진입 시 전용 모달 + 로그인 유도 (ESLint 대응: ref/effect 패턴 정리)
- **기타**: 헤더 미사용 import·로그아웃 `catch` 정리 등

## 💬 리뷰 포인트
<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항
<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트
- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료
