### PR TITLE
[Feat] 제품 추천맵 생성 API 연동 (#157)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,67 +1,6 @@
 import type { NextConfig } from 'next'
 
-type RemotePattern = NonNullable<
-  NonNullable<NextConfig['images']>['remotePatterns']
->[number]
-
-/**
- * next/image 외부 호스트 허용 — 개발/스테이징 API·CDN 도메인
- * (미설정 시 외부 절대 URL 이미지에서 "hostname is not configured" 런타임 에러)
- */
-function buildImageRemotePatterns(): RemotePattern[] {
-  const patterns: RemotePattern[] = []
-  const seen = new Set<string>()
-
-  const pushFromUrl = (raw: string | undefined) => {
-    const trimmed = raw?.trim()
-    if (!trimmed) return
-    try {
-      const url = new URL(trimmed)
-      const key = `${url.protocol}//${url.host}`
-      if (seen.has(key)) return
-      seen.add(key)
-      const protocol = (url.protocol === 'https:' ? 'https' : 'http') as
-        | 'http'
-        | 'https'
-      const entry: RemotePattern = {
-        protocol,
-        hostname: url.hostname,
-        pathname: '/**',
-      }
-      if (url.port) entry.port = url.port
-      patterns.push(entry)
-    } catch {
-      /* ignore */
-    }
-  }
-
-  pushFromUrl(process.env.NEXT_PUBLIC_API_URL)
-  pushFromUrl(process.env.NEXT_PUBLIC_API_BASE_URL)
-
-  const extra = process.env.NEXT_PUBLIC_IMAGE_REMOTE_HOSTNAMES?.split(',') ?? []
-  for (const part of extra) {
-    const h = part.trim()
-    if (!h) continue
-    if (h.startsWith('http://') || h.startsWith('https://')) {
-      pushFromUrl(h)
-      continue
-    }
-    patterns.push({ protocol: 'https', hostname: h, pathname: '/**' })
-    patterns.push({ protocol: 'http', hostname: h, pathname: '/**' })
-  }
-
-  for (const hostname of ['localhost', '127.0.0.1']) {
-    patterns.push({ protocol: 'http', hostname, pathname: '/**' })
-    patterns.push({ protocol: 'https', hostname, pathname: '/**' })
-  }
-
-  return patterns
-}
-
 const nextConfig: NextConfig = {
-  images: {
-    remotePatterns: buildImageRemotePatterns(),
-  },
   reactCompiler: true,
   // Next.js 16: Turbopack 기본 사용. SVG를 React 컴포넌트로 import 하기 위해 SVGR 사용
   turbopack: {

--- a/src/app/admin/recommend/_actions/recommendActions.ts
+++ b/src/app/admin/recommend/_actions/recommendActions.ts
@@ -5,12 +5,28 @@ import { deleteAdminRecommend } from '../_api/adminDeleteRecommend'
 import {
   patchAdminBlendMapPublish,
   patchAdminProductPoolAdopt,
+  patchAdminProductMapPublish,
 } from '../_api/adminPatchRecommend'
 import {
   createAdminBlendMap,
   createAdminProductPool,
+  createAdminProductMap,
 } from '../_api/adminCreateRecommend'
-import { RecommendTabId, ProductPoolCreateBody } from '../_types'
+import { RECOMMEND_API } from '../_api'
+import {
+  RecommendTabId,
+  ProductPoolCreateBody,
+  ProductPoolsListResponse,
+} from '../_types'
+
+/**
+ * 채택된 제품 후보군 목록 조회 Server Action
+ * — 클라이언트에서 authFetch를 직접 호출하면 토큰이 주입되지 않으므로
+ *   서버 컨텍스트에서 실행되는 Server Action으로 감쌈
+ */
+export async function fetchAdoptedPoolsAction(): Promise<ProductPoolsListResponse> {
+  return RECOMMEND_API.productPools({ size: 5, adoption_status: 'ADOPTED' })
+}
 
 /**
  * 추천 관련 데이터 삭제 Server Action
@@ -43,8 +59,12 @@ export async function toggleRecommendStatusAction(
       await patchAdminBlendMapPublish(id, status as 'PUBLISHED' | 'UNPUBLISHED')
     } else if (tabId === 'product-pools') {
       await patchAdminProductPoolAdopt(id, status as 'ADOPTED' | 'UNADOPTED')
+    } else if (tabId === 'product-maps') {
+      await patchAdminProductMapPublish(
+        id,
+        status as 'PUBLISHED' | 'UNPUBLISHED'
+      )
     }
-    // TODO: product-maps PATCH 연동 시 추가
 
     revalidatePath('/admin/recommend')
     return { success: true }
@@ -62,6 +82,23 @@ export async function toggleRecommendStatusAction(
 export async function createProductPoolAction(body: ProductPoolCreateBody) {
   try {
     await createAdminProductPool(body)
+
+    revalidatePath('/admin/recommend')
+    return { success: true }
+  } catch (error) {
+    return {
+      success: false,
+      message: error instanceof Error ? error.message : null,
+    }
+  }
+}
+
+/**
+ * 제품 추천맵 생성 Server Action
+ */
+export async function createProductMapAction(product_pool_id: number) {
+  try {
+    await createAdminProductMap(product_pool_id)
 
     revalidatePath('/admin/recommend')
     return { success: true }

--- a/src/app/admin/recommend/_api/adminCreateRecommend.ts
+++ b/src/app/admin/recommend/_api/adminCreateRecommend.ts
@@ -12,3 +12,9 @@ export const createAdminBlendMap = (input_type: string) =>
  */
 export const createAdminProductPool = (body: ProductPoolCreateBody) =>
   authFetch.post('/api/v1/admin/matches/product-pools', body)
+
+/**
+ * 제품 추천맵 생성 POST API
+ */
+export const createAdminProductMap = (product_pool_id: number) =>
+  authFetch.post('/api/v1/admin/matches/product-maps', { product_pool_id })

--- a/src/app/admin/recommend/_api/adminPatchRecommend.ts
+++ b/src/app/admin/recommend/_api/adminPatchRecommend.ts
@@ -21,3 +21,14 @@ export const patchAdminProductPoolAdopt = (
   authFetch.patch(`/api/v1/admin/matches/product-pools/${id}/adopt`, {
     adoption_status,
   })
+
+/**
+ * 제품 추천맵 발행 설정 PATCH API
+ */
+export const patchAdminProductMapPublish = (
+  id: number,
+  publish_status: 'PUBLISHED' | 'UNPUBLISHED'
+) =>
+  authFetch.patch(`/api/v1/admin/matches/product-maps/${id}/publish`, {
+    publish_status,
+  })

--- a/src/app/admin/recommend/_page/ProductMapsForm.tsx
+++ b/src/app/admin/recommend/_page/ProductMapsForm.tsx
@@ -1,8 +1,8 @@
-import React, { use } from 'react'
-import { AdminSelect } from '@/app/admin/_components'
+import React, { use, useEffect } from 'react'
 import { ProductMapsFormProps } from '@/app/admin/recommend/_types'
 import { PRODUCT_TYPE_LABELS } from '@/app/admin/_constants/labels'
 import { formatDate } from '@/app/admin/_utils'
+import { cn } from '@/lib/cn'
 
 export const ProductMapsForm = ({
   value,
@@ -12,30 +12,53 @@ export const ProductMapsForm = ({
   const res = use(poolsPromise)
   const pools = res.data.results
 
-  const options = pools.map((p: any) => ({
-    label: `${p.id} - ${PRODUCT_TYPE_LABELS[p.product_type]} [${p.product_count}개]`,
-    secondaryLabel: formatDate(p.updated_at),
-    value: String(p.id),
-  }))
+  useEffect(() => {
+    if (pools.length > 0 && value === 0) {
+      onChange(pools[0].id)
+    }
+  }, [pools])
 
   return (
     <div className="flex flex-col gap-4 py-6">
       <div className="flex flex-col gap-2">
         <label className="text-lg font-bold">대상 후보군 선택</label>
         {pools.length > 0 ? (
-          <AdminSelect
-            value={String(value)}
-            onChange={(val: string) => onChange(Number(val))}
-            width="w-full"
-            options={options}
-          />
+          <div className="flex flex-col gap-1.5">
+            {pools.map((p: any) => (
+              <button
+                key={p.id}
+                type="button"
+                onClick={() => onChange(p.id)}
+                className={cn(
+                  'border-gray-light flex cursor-pointer items-center gap-3 rounded-lg border p-3 transition-colors',
+                  value === p.id ? 'bg-gray-white' : 'text-gray-primary'
+                )}
+              >
+                <span
+                  className={cn(
+                    'h-3.5 w-3.5 rounded-full border-2',
+                    value === p.id
+                      ? 'border-black-primary bg-black-primary'
+                      : 'border-gray-light'
+                  )}
+                />
+                <span>
+                  #{p.id} · {PRODUCT_TYPE_LABELS[p.product_type]} ·{' '}
+                  {p.product_count}개
+                </span>
+                <span className="text-gray-secondary ml-auto text-xs">
+                  {formatDate(p.updated_at)}
+                </span>
+              </button>
+            ))}
+          </div>
         ) : (
-          <div className="bg-gray-light/30 rounded-xl py-8 text-center text-gray-400">
+          <div className="bg-gray-white text-gray-secondary rounded-lg py-8 text-center">
             채택 완료된 후보군이 없습니다. 제품 후보군 탭에서 채택을 먼저 진행해
             주세요.
           </div>
         )}
-        <p className="text-sm text-gray-500">
+        <p className="text-gray-secondary text-sm">
           채택 완료된 후보군을 선택하면, 해당 후보군 내의 제품들로 추천 맵을
           생성합니다.
         </p>

--- a/src/app/admin/recommend/_page/RecommendPostModal.tsx
+++ b/src/app/admin/recommend/_page/RecommendPostModal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState, Suspense, useMemo } from 'react'
+import React, { useState, useEffect, Suspense } from 'react'
 import Modal from '@/components/common/Modal/Modal'
 import Button from '@/components/common/Button'
 import {
@@ -8,7 +8,6 @@ import {
   RECOMMEND_TABS,
   ProductPoolCreateBody,
 } from '@/app/admin/recommend/_types'
-import { RECOMMEND_API } from '@/app/admin/recommend/_api'
 import { BlendMapsForm } from './BlendMapsForm'
 import { ProductPoolsForm } from './ProductPoolsForm'
 import { ProductMapsForm } from './ProductMapsForm'
@@ -16,6 +15,8 @@ import { useModalStore } from '@/store/useModalStore'
 import {
   createBlendMapAction,
   createProductPoolAction,
+  createProductMapAction,
+  fetchAdoptedPoolsAction,
 } from '../_actions/recommendActions'
 
 interface RecommendPostModalProps {
@@ -53,15 +54,18 @@ export const RecommendPostModal = ({ activeTab }: RecommendPostModalProps) => {
     },
 
     // 3. 제품 추천맵
-    product_pool_id: 1,
+    product_pool_id: 0,
   })
 
-  const poolsPromise = useMemo(() => {
-    if (activeTab !== 'product-maps') return null
-    return RECOMMEND_API.productPools({
-      size: 20,
-      adoption_status: 'ADOPTED',
-    })
+  const [poolsPromise, setPoolsPromise] = useState<ReturnType<
+    typeof fetchAdoptedPoolsAction
+  > | null>(null)
+
+  useEffect(() => {
+    if (activeTab === 'product-maps') {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setPoolsPromise(fetchAdoptedPoolsAction())
+    }
   }, [activeTab])
 
   // 일반 필드 업데이트
@@ -106,8 +110,18 @@ export const RecommendPostModal = ({ activeTab }: RecommendPostModalProps) => {
         })
         return
       }
+    } else if (activeTab === 'product-maps') {
+      const result = await createProductMapAction(formData.product_pool_id)
+      if (!result.success) {
+        openAlert({
+          type: 'danger',
+          title: '등록 실패',
+          content: result.message ?? '제품 추천맵 등록에 실패했습니다.',
+          confirmText: '확인',
+        })
+        return
+      }
     }
-    // TODO: product-maps 등록 연동 시 추가
 
     closeModal()
   }


### PR DESCRIPTION
제품 추천맵 생성 POST API 함수 추가 , 제품 추천맵 발행 상태 변경 PATCH API 함수 추가, 채택된 후보군 목록 조회 `fetchAdoptedPoolsAction` Server Action 추가

#157

## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->

제품 추천맵(product-maps) 생성 모달을 실제 API와 연동합니다.
채택된 후보군 목록을 Server Action으로 조회하고, 선택한 후보군 ID로 추천맵을 생성합니다.

## 📌 관련 이슈

<!-- Closes #이슈번호 -->

Closes #157 

## 🧩 작업 내용 (주요 변경사항)

- 제품 추천맵 생성 POST API 추가
- 제품 추천맵 발행 상태 변경 PATCH API 추가
- `createProductMapAction`, `fetchAdoptedPoolsAction` Server Action 추가
- next.config.ts 파일 rollback

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

삭제 로직 생기면 추가하겠습니다

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료
