### PR TITLE
[Fix] 이미지 업로드 및 삭제 모달 버그 수정 (#165)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,14 @@
 import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'oz-project-scentmatch.s3.ap-northeast-2.amazonaws.com',
+      },
+    ],
+  },
   reactCompiler: true,
   // Next.js 16: Turbopack 기본 사용. SVG를 React 컴포넌트로 import 하기 위해 SVGR 사용
   turbopack: {

--- a/src/app/admin/category/_components/CategoryDeleteButton.tsx
+++ b/src/app/admin/category/_components/CategoryDeleteButton.tsx
@@ -15,7 +15,7 @@ export function CategoryDeleteButton({
   rootCategory,
   categoryId,
 }: CategoryDeleteButtonProps) {
-  const { openAlert, closeModal } = useModalStore()
+  const { openAlert, closeAll } = useModalStore()
 
   const handleDelete = async () => {
     openAlert({
@@ -24,26 +24,18 @@ export function CategoryDeleteButton({
       content: '해당 카테고리를 정말 삭제하시겠습니까?',
       confirmText: '삭제',
       onConfirm: async () => {
-        try {
-          const result = await deleteCategoryAction(rootCategory, categoryId)
-          if (result.success) {
-            closeModal()
-          } else {
-            openAlert({
-              type: 'danger',
-              title: '카테고리 삭제 실패',
-              content:
-                result.message ??
-                '카테고리 삭제에 실패했습니다. 다시 시도해 주세요.',
-              confirmText: '확인',
-            })
-          }
-        } catch {
+        const result = await deleteCategoryAction(rootCategory, categoryId)
+        if (result.success) {
+          closeAll()
+        } else {
           openAlert({
             type: 'danger',
-            title: '카테고리 삭제 실패',
-            content: '네트워크 오류가 발생했습니다. 다시 시도해 주세요.',
+            title: result.message ?? '카테고리 삭제 실패',
+            content: result.reason ?? '카테고리 삭제에 실패했습니다.',
             confirmText: '확인',
+            onConfirm: () => {
+              closeAll()
+            },
           })
         }
       },

--- a/src/app/admin/category/_lib/categoryAction.ts
+++ b/src/app/admin/category/_lib/categoryAction.ts
@@ -1,6 +1,7 @@
 'use server'
 
 import { revalidatePath } from 'next/cache'
+import { FetchError } from '@/lib/api'
 import { createAdminCategory } from '../_api/adminCreateCategory'
 import { deleteAdminCategory } from '../_api/adminDeleteCategory'
 import type {
@@ -18,10 +19,12 @@ export async function postCategoryAction(
   try {
     await createAdminCategory(rootCategory, payload)
     revalidatePath('/admin/category')
-    return { success: true }
+    return { success: true as const }
   } catch (error) {
-    const message = error instanceof Error ? error.message : null
-    return { success: false, message }
+    if (error instanceof Error) {
+      return { success: false, message: error.message }
+    }
+    return { success: false as const, message: null, reason: null }
   }
 }
 
@@ -37,7 +40,13 @@ export async function deleteCategoryAction(
     revalidatePath('/admin/category')
     return { success: true }
   } catch (error) {
-    const message = error instanceof Error ? error.message : null
-    return { success: false, message }
+    if (error instanceof FetchError) {
+      return {
+        success: false as const,
+        message: error.message,
+        reason: error.details?.reason,
+      }
+    }
+    return { success: false as const, message: null, reason: null }
   }
 }

--- a/src/app/admin/product/_components/ProductDeleteButton.tsx
+++ b/src/app/admin/product/_components/ProductDeleteButton.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import React from 'react'
 import Button from '@/components/common/Button'
 import TrashIcon from '@/assets/icons/trash.svg'
 import { deleteProductAction } from '../_lib/productActions'
@@ -13,7 +12,7 @@ interface ProductDeleteButtonProps {
 }
 
 export function ProductDeleteButton({ type, id }: ProductDeleteButtonProps) {
-  const { openAlert, closeModal } = useModalStore()
+  const { openAlert, closeAll } = useModalStore()
 
   const handleDelete = async () => {
     openAlert({
@@ -22,15 +21,19 @@ export function ProductDeleteButton({ type, id }: ProductDeleteButtonProps) {
       content: `해당 상품을 정말 삭제하시겠습니까?`,
       confirmText: '삭제',
       onConfirm: async () => {
-        try {
-          const result = await deleteProductAction(type, id)
-          if (result.success) {
-            closeModal()
-          } else {
-            alert('삭제에 실패했습니다.')
-          }
-        } catch {
-          alert('삭제 중 오류가 발생했습니다.')
+        const result = await deleteProductAction(type, id)
+        if (result.success) {
+          closeAll()
+        } else {
+          openAlert({
+            type: 'danger',
+            title: result.message ?? '삭제 실패',
+            content: result.reason ?? '상품 삭제에 실패했습니다.',
+            confirmText: '확인',
+            onConfirm: () => {
+              closeAll()
+            },
+          })
         }
       },
     })

--- a/src/app/admin/product/_components/product-post/ImageUploadField.tsx
+++ b/src/app/admin/product/_components/product-post/ImageUploadField.tsx
@@ -33,11 +33,12 @@ export function ImageUploadField({
         className="hidden"
       />
       {imagePreview ? (
-        <div className="relative w-full overflow-hidden rounded-lg border border-neutral-200">
+        <div className="relative h-36 w-36 overflow-hidden rounded-lg border border-neutral-200">
           <Image
             src={imagePreview}
             alt="미리보기"
-            className="h-36 w-full object-cover"
+            fill
+            className="object-cover"
           />
           {isPending && (
             <div className="absolute inset-0 flex items-center justify-center bg-black/40">
@@ -65,10 +66,10 @@ export function ImageUploadField({
           type="button"
           onClick={() => fileInputRef.current?.click()}
           disabled={isPending}
-          className="flex h-28 w-full flex-col items-center justify-center gap-1.5 rounded-lg border-2 border-dashed border-neutral-300 bg-neutral-50 text-neutral-400 transition hover:border-violet-400 hover:bg-violet-50 hover:text-violet-500 disabled:cursor-not-allowed disabled:opacity-50"
+          className="border-gray-light bg-gray-white text-gray-secondary flex h-36 w-36 cursor-pointer flex-col items-center justify-center gap-1.5 rounded-lg border-2 border-dashed hover:border-violet-400 hover:bg-violet-50 hover:text-violet-500 disabled:cursor-not-allowed disabled:opacity-50"
         >
-          <span className="text-xs font-medium">클릭하여 이미지 선택</span>
-          <span className="text-xs opacity-60">JPG · PNG · WEBP</span>
+          <span>클릭하여 이미지 선택</span>
+          <span>JPG · PNG</span>
         </button>
       )}
     </div>

--- a/src/app/admin/product/_hooks/useImageUpload.ts
+++ b/src/app/admin/product/_hooks/useImageUpload.ts
@@ -21,6 +21,17 @@ export function useImageUpload() {
     const file = e.target.files?.[0]
     if (!file) return
 
+    const allowed = ['image/jpeg', 'image/jpg', 'image/png']
+    if (!allowed.includes(file.type)) {
+      openAlert({
+        type: 'danger',
+        title: '지원하지 않는 파일 형식',
+        content: 'JPG, PNG 파일만 업로드할 수 있습니다.',
+      })
+      e.target.value = ''
+      return
+    }
+
     if (imagePreview) URL.revokeObjectURL(imagePreview)
     setImagePreview(URL.createObjectURL(file))
     setImageUrl(undefined)

--- a/src/app/admin/product/_lib/productActions.ts
+++ b/src/app/admin/product/_lib/productActions.ts
@@ -1,6 +1,7 @@
 'use server'
 
 import { revalidatePath } from 'next/cache'
+import { FetchError } from '@/lib/api'
 import { deleteAdminProduct } from '../_api/adminDeleteProduct'
 import {
   createAdminElement,
@@ -37,9 +38,16 @@ export async function deleteProductAction(type: ProductTabId, id: number) {
   try {
     await deleteAdminProduct(type, id)
     revalidatePath('/admin/product')
-    return { success: true }
+    return { success: true as const }
   } catch (error) {
-    return { success: false, error }
+    if (error instanceof FetchError) {
+      return {
+        success: false as const,
+        message: error.message,
+        reason: error.details?.reason,
+      }
+    }
+    return { success: false as const, message: null, reason: null }
   }
 }
 


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->

이미지 업로드 관련 next/image 오류  3건과 삭제 실패 시 브라우저 alert로 노출되던 문제, 에러 정보 미표시 문제를 수정

## 📌 관련 이슈

<!-- Closes #이슈번호 -->

Closes #165 

## 🧩 작업 내용 (주요 변경사항)

- blob URL 미리보기를 `fill` prop으로 변경, 부모에 `h-36` 고정
- next/Image 외부 URL remotePatterns 추가하여 S3 Url로 Image 출력 가능하도록 수정
- file.type` 검증으로 JPG·PNG 외 파일 업로드 차단
- `FetchError`의 `message`·`details.reason` 반환하도록 수정, 삭제 실패 모달에 서버 에러 메시지 표시

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

1. 삭제가 실패하였습니다. 라는 에러 메시지만으로 로직이 문제다 >> 사실 카테고리와 상품이 서로 의존을 하고 있는 관계라 한개가 삭제되면 남은 데이터가 참조하지 못하는 참조 무결성의 문제 였고 그 에러 메시지를 모달에 디테일한 정보를 출력하여 정확한 상황을 인지 가능
2. 이미지 next/Image 사용을 위해 width,height 값 + 외부 Url (S3 url) 허용하여 버그 해결

