### PR TITLE
[Feat] 어드민 상품 상세 조회 및 수정 기능 구현 (#169)

### DIFF
--- a/src/app/admin/product/_api/adminFetchProductDetail.ts
+++ b/src/app/admin/product/_api/adminFetchProductDetail.ts
@@ -1,0 +1,15 @@
+import { apiFetch } from '@/lib/api'
+import type {
+  AdminElementDetailResponse,
+  AdminBlendDetailResponse,
+} from '../_types/AdminProductType'
+
+export const fetchAdminElementDetail = (
+  id: number
+): Promise<AdminElementDetailResponse> =>
+  apiFetch.get(`/api/v1/scents/elements/${id}`)
+
+export const fetchAdminBlendDetail = (
+  id: number
+): Promise<AdminBlendDetailResponse> =>
+  apiFetch.get(`/api/v1/scents/blends/${id}`)

--- a/src/app/admin/product/_api/adminPatchProduct.ts
+++ b/src/app/admin/product/_api/adminPatchProduct.ts
@@ -1,0 +1,8 @@
+import { authFetch } from '@/lib/api'
+import type { CreateElementBody, CreateBlendBody } from './adminCreateProduct'
+
+export const patchAdminElement = (id: number, body: CreateElementBody) =>
+  authFetch.patch(`/api/v1/admin/scents/elements/${id}`, body)
+
+export const patchAdminBlend = (id: number, body: CreateBlendBody) =>
+  authFetch.patch(`/api/v1/admin/scents/blends/${id}`, body)

--- a/src/app/admin/product/_components/ProductEditButton.tsx
+++ b/src/app/admin/product/_components/ProductEditButton.tsx
@@ -1,0 +1,106 @@
+'use client'
+
+import { useState, Suspense } from 'react'
+import Button from '@/components/common/Button'
+import PenIcon from '@/assets/icons/pen.svg'
+import Modal from '@/components/common/Modal/Modal'
+import { useModalStore } from '@/store/useModalStore'
+import { fetchAdminProductList } from '../_api/adminFetchProductList'
+import {
+  fetchElementDetailAction,
+  fetchBlendDetailAction,
+  fetchElementCategoriesAction,
+  fetchBlendCategoriesAction,
+} from '../_lib/productActions'
+import { ElementProductForm } from './product-post/ElementProductForm'
+import { BlendProductForm } from './product-post/BlendProductForm'
+import type { ProductTabId } from '../_types/AdminProductType'
+
+interface ProductEditButtonProps {
+  type: ProductTabId
+  id: number
+}
+
+export function ProductEditButton({ type, id }: ProductEditButtonProps) {
+  const { openModal, closeModal, openAlert } = useModalStore()
+  const [isLoading, setIsLoading] = useState(false)
+
+  const handleEdit = async () => {
+    setIsLoading(true)
+    try {
+      if (type === 'ELEMENT') {
+        const [detailRes, categoryRes] = await Promise.all([
+          fetchElementDetailAction(id),
+          fetchElementCategoriesAction(),
+        ])
+        const item = detailRes.data
+
+        openModal(
+          <Suspense fallback={null}>
+            <Modal isOpen onClose={closeModal} size="md" overflowVisible>
+              <Modal.Header>단품 수정</Modal.Header>
+              <ElementProductForm
+                categoryPromise={Promise.resolve(categoryRes)}
+                onClose={closeModal}
+                initialData={{
+                  name: item.name,
+                  description: item.description ?? '',
+                  category_id: item.element_category.id,
+                  image_url: item.image_url,
+                }}
+                productId={id}
+              />
+            </Modal>
+          </Suspense>
+        )
+      } else {
+        const [detailRes, categoryRes, elementRes] = await Promise.all([
+          fetchBlendDetailAction(id),
+          fetchBlendCategoriesAction(),
+          fetchAdminProductList('ELEMENT'),
+        ])
+        const item = detailRes.data
+
+        openModal(
+          <Suspense fallback={null}>
+            <Modal isOpen onClose={closeModal} size="md" overflowVisible>
+              <Modal.Header>조합 수정</Modal.Header>
+              <BlendProductForm
+                elementPromise={Promise.resolve(elementRes)}
+                categoryPromise={Promise.resolve(categoryRes)}
+                onClose={closeModal}
+                initialData={{
+                  name: item.name,
+                  description: item.description ?? '',
+                  blend_category_ids: item.blend_categories.map((c) => c.id),
+                  image_url: item.image_url,
+                }}
+                productId={id}
+              />
+            </Modal>
+          </Suspense>
+        )
+      }
+    } catch {
+      openAlert({
+        type: 'danger',
+        title: '불러오기 실패',
+        content: '상품 정보를 불러오지 못했습니다.',
+      })
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <Button
+      color="none"
+      size="w32h32"
+      rounded="sm"
+      onClick={handleEdit}
+      disabled={isLoading}
+    >
+      <PenIcon width={16} height={16} className="text-gray-secondary" />
+    </Button>
+  )
+}

--- a/src/app/admin/product/_components/ProductTableServer.tsx
+++ b/src/app/admin/product/_components/ProductTableServer.tsx
@@ -16,6 +16,7 @@ import {
   ACCORD_LABEL_PILL_SM_CLASS,
 } from '@/constants/accordLabelStyles'
 import { ProductDeleteButton } from './ProductDeleteButton'
+import { ProductEditButton } from './ProductEditButton'
 import { resolveApiMediaUrl } from '@/lib/resolveApiMediaUrl'
 
 const PAGE_SIZE = 10
@@ -119,7 +120,10 @@ export async function ProductTableServer({
             </AdminTableCell>
 
             <AdminTableCell slot={7}>
-              <ProductDeleteButton type={activeTab} id={item.id} />
+              <div className="flex items-center gap-1">
+                <ProductEditButton type={activeTab} id={item.id} />
+                <ProductDeleteButton type={activeTab} id={item.id} />
+              </div>
             </AdminTableCell>
           </AdminTableRow>
         )

--- a/src/app/admin/product/_components/product-post/BlendProductForm.tsx
+++ b/src/app/admin/product/_components/product-post/BlendProductForm.tsx
@@ -9,7 +9,7 @@ import { useModalStore } from '@/store/useModalStore'
 import type { AdminCategoryListResponse } from '@/app/admin/category/_types/AdminCategoryType'
 import type { AdminElementListResponse } from '../../_types/AdminProductType'
 import type { CreateBlendBody } from '../../_api/adminCreateProduct'
-import { createBlendAction } from '../../_lib/productActions'
+import { createBlendAction, patchBlendAction } from '../../_lib/productActions'
 import { useImageUpload } from '../../_hooks/useImageUpload'
 import { ImageUploadField } from './ImageUploadField'
 import { CategoryMultiSelectWrapper } from './CategoryMultiSelectWrapper'
@@ -23,18 +23,27 @@ interface BlendProductFormProps {
   elementPromise: Promise<AdminElementListResponse | null>
   categoryPromise: Promise<AdminCategoryListResponse | null>
   onClose: () => void
+  initialData?: {
+    name: string
+    description?: string
+    blend_category_ids: number[]
+    image_url: string
+  }
+  productId?: number
 }
 
 export function BlendProductForm({
   elementPromise,
   categoryPromise,
   onClose,
+  initialData,
+  productId,
 }: BlendProductFormProps) {
   const { openAlert } = useModalStore()
   const [data, setData] = useState<CreateBlendBody>({
-    name: '',
-    description: '',
-    blend_category_ids: [],
+    name: initialData?.name ?? '',
+    description: initialData?.description ?? '',
+    blend_category_ids: initialData?.blend_category_ids ?? [],
     element_ids: [],
     image_url: undefined,
   })
@@ -46,7 +55,7 @@ export function BlendProductForm({
     fileInputRef,
     handleImageChange,
     handleRemoveImage,
-  } = useImageUpload()
+  } = useImageUpload(initialData?.image_url)
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target
@@ -100,15 +109,21 @@ export function BlendProductForm({
       return
     }
 
-    const result = await createBlendAction({ ...data, image_url: imageUrl })
+    const body = { ...data, image_url: imageUrl }
+    const result = productId
+      ? await patchBlendAction(productId, body)
+      : await createBlendAction(body)
+
     if (!result.success) {
       openAlert({
         type: 'danger',
-        title: '등록 실패',
+        title: productId ? '수정 실패' : '등록 실패',
         content:
           result.error instanceof Error
             ? result.error.message
-            : '조합 등록 중 오류가 발생했습니다.',
+            : productId
+              ? '조합 수정 중 오류가 발생했습니다.'
+              : '조합 등록 중 오류가 발생했습니다.',
       })
       return
     }
@@ -200,7 +215,7 @@ export function BlendProductForm({
           취소
         </Button>
         <Button color="primary" onClick={handleSubmit} disabled={isPending}>
-          조합 등록
+          {productId ? '조합 수정' : '조합 등록'}
         </Button>
       </Modal.Footer>
     </>

--- a/src/app/admin/product/_components/product-post/ElementProductForm.tsx
+++ b/src/app/admin/product/_components/product-post/ElementProductForm.tsx
@@ -7,7 +7,10 @@ import Input from '@/components/common/Input'
 import { useModalStore } from '@/store/useModalStore'
 import type { AdminCategoryListResponse } from '@/app/admin/category/_types/AdminCategoryType'
 import type { CreateElementBody } from '../../_api/adminCreateProduct'
-import { createElementAction } from '../../_lib/productActions'
+import {
+  createElementAction,
+  patchElementAction,
+} from '../../_lib/productActions'
 import { useImageUpload } from '../../_hooks/useImageUpload'
 import { ImageUploadField } from './ImageUploadField'
 import { CategorySelectWrapper } from './CategorySelectWrapper'
@@ -19,17 +22,26 @@ const REQUIRED_MARK = <span className="ml-0.5 text-red-500">*</span>
 interface ElementProductFormProps {
   categoryPromise: Promise<AdminCategoryListResponse | null>
   onClose: () => void
+  initialData?: {
+    name: string
+    description?: string
+    category_id: number
+    image_url: string
+  }
+  productId?: number
 }
 
 export function ElementProductForm({
   categoryPromise,
   onClose,
+  initialData,
+  productId,
 }: ElementProductFormProps) {
   const { openAlert } = useModalStore()
   const [data, setData] = useState<CreateElementBody>({
-    name: '',
-    description: '',
-    category_id: 0,
+    name: initialData?.name ?? '',
+    description: initialData?.description ?? '',
+    category_id: initialData?.category_id ?? 0,
     image_url: undefined,
   })
 
@@ -40,7 +52,7 @@ export function ElementProductForm({
     fileInputRef,
     handleImageChange,
     handleRemoveImage,
-  } = useImageUpload()
+  } = useImageUpload(initialData?.image_url)
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target
@@ -73,15 +85,21 @@ export function ElementProductForm({
       return
     }
 
-    const result = await createElementAction({ ...data, image_url: imageUrl })
+    const body = { ...data, image_url: imageUrl }
+    const result = productId
+      ? await patchElementAction(productId, body)
+      : await createElementAction(body)
+
     if (!result.success) {
       openAlert({
         type: 'danger',
-        title: '등록 실패',
+        title: productId ? '수정 실패' : '등록 실패',
         content:
           result.error instanceof Error
             ? result.error.message
-            : '단품 등록 중 오류가 발생했습니다.',
+            : productId
+              ? '단품 수정 중 오류가 발생했습니다.'
+              : '단품 등록 중 오류가 발생했습니다.',
       })
       return
     }
@@ -144,7 +162,7 @@ export function ElementProductForm({
           취소
         </Button>
         <Button color="primary" onClick={handleSubmit} disabled={isPending}>
-          단품 등록
+          {productId ? '단품 수정' : '단품 등록'}
         </Button>
       </Modal.Footer>
     </>

--- a/src/app/admin/product/_components/product-post/ImageUploadField.tsx
+++ b/src/app/admin/product/_components/product-post/ImageUploadField.tsx
@@ -32,10 +32,10 @@ export function ImageUploadField({
         disabled={isPending}
         className="hidden"
       />
-      {imagePreview ? (
+      {(imagePreview ?? imageUrl) ? (
         <div className="relative h-36 w-36 overflow-hidden rounded-lg border border-neutral-200">
           <Image
-            src={imagePreview}
+            src={(imagePreview ?? imageUrl)!}
             alt="미리보기"
             fill
             className="object-cover"

--- a/src/app/admin/product/_hooks/useImageUpload.ts
+++ b/src/app/admin/product/_hooks/useImageUpload.ts
@@ -4,10 +4,10 @@ import { useState, useTransition, useEffect, useRef } from 'react'
 import { useModalStore } from '@/store/useModalStore'
 import { getProductPresignedUrlAction } from '@/app/admin/product/_lib/productActions'
 
-export function useImageUpload() {
+export function useImageUpload(initialImageUrl?: string) {
   const { openAlert } = useModalStore()
   const [imagePreview, setImagePreview] = useState<string | null>(null)
-  const [imageUrl, setImageUrl] = useState<string | undefined>(undefined)
+  const [imageUrl, setImageUrl] = useState<string | undefined>(initialImageUrl)
   const [isPending, startTransition] = useTransition()
   const fileInputRef = useRef<HTMLInputElement>(null)
 

--- a/src/app/admin/product/_lib/productActions.ts
+++ b/src/app/admin/product/_lib/productActions.ts
@@ -10,6 +10,11 @@ import {
   type CreateElementBody,
   type CreateBlendBody,
 } from '../_api/adminCreateProduct'
+import { patchAdminElement, patchAdminBlend } from '../_api/adminPatchProduct'
+import {
+  fetchAdminElementDetail,
+  fetchAdminBlendDetail,
+} from '../_api/adminFetchProductDetail'
 import {
   fetchAdminElementCategories,
   fetchAdminBlendCategories,
@@ -85,6 +90,46 @@ export async function createElementAction(body: CreateElementBody) {
 export async function createBlendAction(body: CreateBlendBody) {
   try {
     await createAdminBlend(body)
+    revalidatePath('/admin/product')
+    return { success: true }
+  } catch (error) {
+    return { success: false, error }
+  }
+}
+
+/**
+ * 향 단품 상세 조회 Server Action
+ */
+export async function fetchElementDetailAction(id: number) {
+  return fetchAdminElementDetail(id)
+}
+
+/**
+ * 향 조합 상세 조회 Server Action
+ */
+export async function fetchBlendDetailAction(id: number) {
+  return fetchAdminBlendDetail(id)
+}
+
+/**
+ * 향 단품 수정 Server Action
+ */
+export async function patchElementAction(id: number, body: CreateElementBody) {
+  try {
+    await patchAdminElement(id, body)
+    revalidatePath('/admin/product')
+    return { success: true }
+  } catch (error) {
+    return { success: false, error }
+  }
+}
+
+/**
+ * 향 조합 수정 Server Action
+ */
+export async function patchBlendAction(id: number, body: CreateBlendBody) {
+  try {
+    await patchAdminBlend(id, body)
     revalidatePath('/admin/product')
     return { success: true }
   } catch (error) {

--- a/src/app/admin/product/_types/AdminProductType.ts
+++ b/src/app/admin/product/_types/AdminProductType.ts
@@ -34,6 +34,37 @@ export interface AdminElementListResponse {
   data: AdminPaginatedData<AdminElementProduct>
 }
 
+export interface AdminElementDetail {
+  id: number
+  name: string
+  image_url: string
+  description: string | null
+  element_category: {
+    id: number
+    name: { kr: string; en: string }
+  }
+}
+
+export interface AdminBlendDetail {
+  id: number
+  name: string
+  image_url: string
+  description: string | null
+  blend_categories: { id: number; name: { kr: string; en: string } }[]
+  contained_elements: { name: string; category: { kr: string; en: string } }[]
+  purchase_url: string | null
+}
+
+export interface AdminElementDetailResponse {
+  success: boolean
+  data: AdminElementDetail
+}
+
+export interface AdminBlendDetailResponse {
+  success: boolean
+  data: AdminBlendDetail
+}
+
 export interface AdminBlendListResponse {
   success: boolean
   data: AdminPaginatedData<AdminBlendProduct>

--- a/src/app/api/v1/users/me/route.ts
+++ b/src/app/api/v1/users/me/route.ts
@@ -37,7 +37,7 @@ export async function GET() {
       )
     }
 
-    const response = await fetch(`${baseUrl}/api/v1/auth/me`, {
+    const response = await fetch(`${baseUrl}/api/v1/users/me`, {
       method: 'GET',
       headers: {
         Accept: 'application/json',
@@ -56,7 +56,7 @@ export async function GET() {
           success: false,
           data: null,
           error: {
-            code: data?.error?.code ?? 'ME_FETCH_FAILED',
+            code: data?.error?.code ?? 'USERS_ME_FETCH_FAILED',
             message: data?.error?.message ?? 'Failed to fetch user profile.',
           },
         },
@@ -66,13 +66,13 @@ export async function GET() {
 
     return NextResponse.json(data, { status: response.status })
   } catch (error) {
-    console.error('Me API error:', error)
+    console.error('Users me API error:', error)
     return NextResponse.json(
       {
         success: false,
         data: null,
         error: {
-          code: 'ME_FAILED',
+          code: 'USERS_ME_FAILED',
           message: 'An error occurred while fetching profile.',
         },
       },

--- a/src/components/common/ClientLayoutInitializer.tsx
+++ b/src/components/common/ClientLayoutInitializer.tsx
@@ -4,10 +4,10 @@ import { useEffect } from 'react'
 import { useAuthStore } from '@/store/useAuthStore'
 import type { User } from '@/types'
 
-/** 쿠키 기준 최신 프로필(is_admin 등) 동기화 — same-origin /api/auth/me */
+/** 쿠키 기준 최신 프로필(is_admin 등) 동기화 — same-origin /api/v1/users/me */
 async function syncUserProfileFromApi(): Promise<void> {
   try {
-    const res = await fetch('/api/auth/me', {
+    const res = await fetch('/api/v1/users/me', {
       credentials: 'include',
       headers: { Accept: 'application/json' },
     })

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -123,5 +123,5 @@ export function postLogout(): Promise<ApiResponse<null>> {
  * 현재 로그인된 사용자 정보를 가져옵니다.
  */
 export function getMe(): Promise<ApiResponse<User>> {
-  return appFetch.get<ApiResponse<User>>('/api/auth/me')
+  return appFetch.get<ApiResponse<User>>('/api/v1/users/me')
 }

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -4,7 +4,7 @@ import type { User } from '@/types'
 
 interface AuthState {
   isInitialized: boolean
-  /** 로그인 시 /api/auth/me 동기화 완료 여부(헤더·관리자 메뉴 판단용) */
+  /** 로그인 시 /api/v1/users/me 동기화 완료 여부(헤더·관리자 메뉴 판단용) */
   userProfileLoaded: boolean
   isLoggedIn?: boolean
   user: User | null


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->

 어드민 상품 목록에 수정 버튼을 추가하고, 클릭 시 상세 조회 API를 호출해 기존 값이 채워진 수정 모달을 제공합니다.                                               단품/조합 각각 별도 폼으로 수정 후 PATCH API를 연동합니다.
내정보 조회 path를 api/auth/me 에서 api/v1/users/me 알맞은 경로로 수정하였습니다.

## 📌 관련 이슈

<!-- Closes #이슈번호 -->

Closes #169 

## 🧩 작업 내용 (주요 변경사항)

- 수정 버튼 컴포넌트 추가, 클릭 시 상세 조회 후 모달 오픈
- 단품/조합 상세 조회 API 함수 추가 
- fetchElementDetailAction, fetchBlendDetailAction, patchElementAction, patchBlendAction Server Action 추가 

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

수정 버튼 클릭 시 모달 오픈 전에 API를 미리 호출하는 구조

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

향 단품 , 조합 몇개를 이미지 변경 해보았는데 한번 확인 가능합니다.


## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

Blend 수정 시 기존에 포함된 단품 목록은 이름/카테고리만 확인 가능, 체크박스 초기 선택은 미지원

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료
