### PR TITLE
fix: 권한 분기와 프로파일링 접근 제어 개선(#171)

### DIFF
--- a/src/app/find-my-scent/_components/ProfilingTestPage.tsx
+++ b/src/app/find-my-scent/_components/ProfilingTestPage.tsx
@@ -13,6 +13,7 @@ import { QuizView } from './QuizView'
 import { useProfilingForm } from '../_hooks/useProfilingForm'
 import { useErrorPopup } from '../_hooks/useErrorPopup'
 import { isLoginRequiredFetchError } from '@/lib/api'
+import { useAuthStore } from '@/store/useAuthStore'
 
 const styles = {
   emptyText: 'text-neutral-500',
@@ -22,6 +23,7 @@ const styles = {
 
 export function ProfilingTestPage({ testType }: { testType: TestType }) {
   const router = useRouter()
+  const { isLoggedIn, isInitialized } = useAuthStore()
   const [productType, setProductType] = useState<ProductTypeChoice | null>(null)
   const { questions, pipelineSnapshotId, isLoading, error, refetch } =
     useProfilingForm(testType, productType)
@@ -41,6 +43,27 @@ export function ProfilingTestPage({ testType }: { testType: TestType }) {
           onSelect={setProductType}
           onClose={() => router.back()}
         />
+      </>
+    )
+  }
+
+  if (isInitialized && isLoggedIn === false) {
+    return (
+      <>
+        <PageCenter>
+          <div className="flex flex-col items-center gap-2 text-center">
+            <p className="text-neutral-500">로그인 후 이용할 수 있어요.</p>
+            <button
+              type="button"
+              onClick={() => router.push('/login')}
+              className={styles.retryBtn}
+              aria-label="로그인하기"
+            >
+              로그인하기
+            </button>
+          </div>
+        </PageCenter>
+        <LoginRequiredTestModal isOpen onClose={() => router.push('/login')} />
       </>
     )
   }

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -18,12 +18,23 @@ export const useAuthStore = create<AuthState>((set) => ({
   userProfileLoaded: false,
   isLoggedIn: undefined,
   user: null,
-  login: (user) => set({ isLoggedIn: true, user, userProfileLoaded: true }),
+  login: (user) =>
+    set({
+      isInitialized: true,
+      isLoggedIn: true,
+      user,
+      userProfileLoaded: true,
+    }),
   logout: async () => {
     // httpOnly 쿠키 삭제는 Server Action에서만 가능
     await logoutAction()
     localStorage.removeItem('user')
-    set({ isLoggedIn: false, user: null, userProfileLoaded: true })
+    set({
+      isInitialized: true,
+      isLoggedIn: false,
+      user: null,
+      userProfileLoaded: true,
+    })
   },
   initialize: () => {
     if (typeof window !== 'undefined') {
@@ -37,7 +48,7 @@ export const useAuthStore = create<AuthState>((set) => ({
       } catch {
         localStorage.removeItem('user')
       }
-      set({ isLoggedIn: !!user, user })
+      set({ isInitialized: true, isLoggedIn: !!user, user })
     }
   },
 }))


### PR DESCRIPTION
## ✨ PR 개요
- 비로그인 상태에서 테스트 진입 시 접근을 선차단하고, 로그인 유도 모달이 즉시 표시되도록 개선했습니다.
- 인증 스토어 초기화 플래그(`isInitialized`)를 실제 초기화 플로우와 일치하도록 보강했습니다.


## 📌 관련 이슈
Closes #171 

## 🧩 작업 내용 (주요 변경사항)
## 변경 사항

- `ProfilingTestPage`
  - 비로그인 상태(`isInitialized && isLoggedIn === false`)에서 테스트 화면 대신 로그인 유도 UI/모달을 즉시 표시하도록 분기 추가

- `useAuthStore`
  - `initialize`, `login`, `logout`에서 `isInitialized` 값이 일관되게 갱신되도록 수정

## 기대 효과

- API 응답 타이밍/에러 타입에 의존하지 않고 비로그인 접근을 안정적으로 차단
- 테스트 페이지 진입 시 로그인 유도 모달이 누락되는 케이스 방지

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료
