### PR TITLE
[Fix] 추천관리/테스트관리 배포 환경 GET 에러 수정 (#173)

### DIFF
--- a/src/app/admin/recommend/_actions/recommendActions.ts
+++ b/src/app/admin/recommend/_actions/recommendActions.ts
@@ -1,6 +1,7 @@
 'use server'
 
 import { revalidatePath } from 'next/cache'
+import { FetchError } from '@/lib/api'
 import { deleteAdminRecommend } from '../_api/adminDeleteRecommend'
 import {
   patchAdminBlendMapPublish,
@@ -19,13 +20,33 @@ import {
   ProductPoolsListResponse,
 } from '../_types'
 
+function extractError(error: unknown) {
+  if (error instanceof FetchError) {
+    return { message: error.message, reason: error.details?.reason ?? null }
+  }
+  return {
+    message: error instanceof Error ? error.message : null,
+    reason: null,
+  }
+}
+
 /**
  * 채택된 제품 후보군 목록 조회 Server Action
  * — 클라이언트에서 authFetch를 직접 호출하면 토큰이 주입되지 않으므로
  *   서버 컨텍스트에서 실행되는 Server Action으로 감쌈
  */
 export async function fetchAdoptedPoolsAction(): Promise<ProductPoolsListResponse> {
-  return RECOMMEND_API.productPools({ size: 5, adoption_status: 'ADOPTED' })
+  try {
+    return await RECOMMEND_API.productPools({
+      size: 5,
+      adoption_status: 'ADOPTED',
+    })
+  } catch {
+    return {
+      success: false,
+      data: { results: [], page: 1, size: 5, count: 0, total_pages: 0 },
+    } as ProductPoolsListResponse
+  }
 }
 
 /**
@@ -37,12 +58,9 @@ export async function deleteRecommendAction(tabId: RecommendTabId, id: number) {
 
     revalidatePath('/admin/recommend')
 
-    return { success: true }
+    return { success: true as const }
   } catch (error) {
-    return {
-      success: false,
-      message: error instanceof Error ? error.message : null,
-    }
+    return { success: false as const, ...extractError(error) }
   }
 }
 
@@ -67,12 +85,9 @@ export async function toggleRecommendStatusAction(
     }
 
     revalidatePath('/admin/recommend')
-    return { success: true }
+    return { success: true as const }
   } catch (error) {
-    return {
-      success: false,
-      message: error instanceof Error ? error.message : null,
-    }
+    return { success: false as const, ...extractError(error) }
   }
 }
 
@@ -84,12 +99,9 @@ export async function createProductPoolAction(body: ProductPoolCreateBody) {
     await createAdminProductPool(body)
 
     revalidatePath('/admin/recommend')
-    return { success: true }
+    return { success: true as const }
   } catch (error) {
-    return {
-      success: false,
-      message: error instanceof Error ? error.message : null,
-    }
+    return { success: false as const, ...extractError(error) }
   }
 }
 
@@ -101,12 +113,9 @@ export async function createProductMapAction(product_pool_id: number) {
     await createAdminProductMap(product_pool_id)
 
     revalidatePath('/admin/recommend')
-    return { success: true }
+    return { success: true as const }
   } catch (error) {
-    return {
-      success: false,
-      message: error instanceof Error ? error.message : null,
-    }
+    return { success: false as const, ...extractError(error) }
   }
 }
 
@@ -118,11 +127,8 @@ export async function createBlendMapAction(input_type: string) {
     await createAdminBlendMap(input_type)
 
     revalidatePath('/admin/recommend')
-    return { success: true }
+    return { success: true as const }
   } catch (error) {
-    return {
-      success: false,
-      message: error instanceof Error ? error.message : null,
-    }
+    return { success: false as const, ...extractError(error) }
   }
 }

--- a/src/app/admin/recommend/_api/adminFetchRecommend.ts
+++ b/src/app/admin/recommend/_api/adminFetchRecommend.ts
@@ -49,8 +49,7 @@ export const fetchAdminRecommendList = <T extends RecommendTabId>(
 ): Promise<RecommendResponseMap[T]> =>
   authFetch.get<RecommendResponseMap[T]>(`/api/v1/admin/matches/${tabId}`, {
     params: options,
-    cache: 'force-cache',
-    next: { tags: [`${tabId}`] },
+    cache: 'no-store',
   })
 
 // 탭별 API 함수 모음

--- a/src/app/admin/recommend/_components/RecommendTableServer.tsx
+++ b/src/app/admin/recommend/_components/RecommendTableServer.tsx
@@ -2,7 +2,12 @@ import React from 'react'
 import { RECOMMEND_API } from '../_api'
 import { RecommendTabId } from '../_types'
 import { BlendMapsTab, ProductPoolsTab, ProductMapsTab } from '../_page'
-import { AdminTableEmpty, AdminPagination } from '@/app/admin/_components'
+import {
+  AdminTableEmpty,
+  AdminTableError,
+  AdminPagination,
+  AdminPageGuard,
+} from '@/app/admin/_components'
 
 const MAP_COMPONENTS: Record<RecommendTabId, React.ComponentType<any>> = {
   'blend-maps': BlendMapsTab,
@@ -36,14 +41,22 @@ export async function RecommendTableServer({
     input_type: searchParams.input_type,
   }
 
-  const response = await RECOMMEND_API.get(activeTab, options as any)
+  let recommendData: any[] = []
+  let totalPages = 1
 
-  const recommendData = response?.success ? response.data.results : []
-  const totalPages = response?.data?.total_pages ?? 1
+  try {
+    const response = await RECOMMEND_API.get(activeTab, options as any)
+    recommendData = response?.data?.results || []
+    totalPages = response?.data?.total_pages ?? 1
+  } catch {
+    if (currentPage > 1) return <AdminPageGuard currentPage={currentPage} />
+    return <AdminTableError />
+  }
 
   const ActiveTabContent = MAP_COMPONENTS[activeTab]
 
-  if (!recommendData.length && currentPage === 1) {
+  if (!recommendData.length) {
+    if (currentPage > 1) return <AdminPageGuard currentPage={currentPage} />
     return <AdminTableEmpty />
   }
 

--- a/src/app/admin/recommend/_page/ProductMapsForm.tsx
+++ b/src/app/admin/recommend/_page/ProductMapsForm.tsx
@@ -10,7 +10,7 @@ export const ProductMapsForm = ({
   poolsPromise,
 }: ProductMapsFormProps) => {
   const res = use(poolsPromise)
-  const pools = res.data.results
+  const pools = res?.data?.results ?? []
 
   useEffect(() => {
     if (pools.length > 0 && value === 0) {

--- a/src/app/admin/recommend/_page/RecommendAdminContent.tsx
+++ b/src/app/admin/recommend/_page/RecommendAdminContent.tsx
@@ -65,7 +65,7 @@ export default function RecommendAdminContent({
       <AdminTable headers={RECOMMEND_TAB_HEADERS[activeTab]}>
         <ErrorBoundary fallback={<AdminTableError />}>
           <Suspense
-            key={`${activeTab}-${JSON.stringify(searchParams)}`}
+            key={`${activeTab}-${searchParams.toString()}`}
             fallback={<AdminTableLoading />}
           >
             {children}

--- a/src/app/admin/recommend/page.tsx
+++ b/src/app/admin/recommend/page.tsx
@@ -5,6 +5,8 @@ import { RecommendTableServer } from './_components/RecommendTableServer'
 import { RecommendTabId } from './_types'
 import { notFound } from 'next/navigation'
 
+export const dynamic = 'force-dynamic'
+
 export const metadata: Metadata = {
   title: '어드민 추천 관리',
 }

--- a/src/app/admin/test/_api/adminFetchTest.ts
+++ b/src/app/admin/test/_api/adminFetchTest.ts
@@ -14,5 +14,6 @@ export async function fetchAdminTests(
 ): Promise<TestListResponse> {
   return authFetch.get<TestListResponse>('/api/v1/admin/profilings/forms', {
     params: options,
+    cache: 'no-store',
   })
 }

--- a/src/app/admin/test/_components/TestTableServer.tsx
+++ b/src/app/admin/test/_components/TestTableServer.tsx
@@ -5,12 +5,14 @@ import {
   AdminDateCell,
   AdminTypeCell,
   AdminTableEmpty,
+  AdminTableError,
   AdminPagination,
+  AdminPageGuard,
 } from '@/app/admin/_components'
 import { fetchAdminTests } from '../_api/adminFetchTest'
 import { TestStatusCell } from './TestStatusCell'
 import { TestTableRow } from './TestTableRow'
-// import { TestDeleteButton } from './TestDeleteButton' // TODO: DELETE API 미개발, 추후 활성화
+import { TestDeleteButton } from './TestDeleteButton'
 
 interface TestTableServerProps {
   searchParams: {
@@ -26,18 +28,26 @@ export async function TestTableServer({ searchParams }: TestTableServerProps) {
   const currentPage = Math.max(1, Number(searchParams.page) || 1)
   const pageSize = 10
 
-  const response = await fetchAdminTests({
-    page: currentPage,
-    size: pageSize,
-    profiling_type: searchParams.profiling_type,
-    publish_status: searchParams.publish_status,
-    search: searchParams.q,
-  })
+  let tests: any[] = []
+  let totalPages = 1
 
-  const tests = response?.data?.results || []
-  const totalPages = response?.data?.total_pages ?? 1
+  try {
+    const response = await fetchAdminTests({
+      page: currentPage,
+      size: pageSize,
+      profiling_type: searchParams.profiling_type,
+      publish_status: searchParams.publish_status,
+      search: searchParams.q,
+    })
+    tests = response?.data?.results || []
+    totalPages = response?.data?.total_pages ?? 1
+  } catch {
+    if (currentPage > 1) return <AdminPageGuard currentPage={currentPage} />
+    return <AdminTableError />
+  }
 
-  if (!tests.length && currentPage === 1) {
+  if (!tests.length) {
+    if (currentPage > 1) return <AdminPageGuard currentPage={currentPage} />
     return <AdminTableEmpty />
   }
 
@@ -56,7 +66,7 @@ export async function TestTableServer({ searchParams }: TestTableServerProps) {
           <AdminDateCell slot={6} date={test.updated_at} />
 
           <AdminTableCell slot={7}>
-            {/* <TestDeleteButton testId={test.id} /> TODO: DELETE API 미개발, 추후 활성화 */}
+            <TestDeleteButton testId={test.id} />
           </AdminTableCell>
         </TestTableRow>
       ))}


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->

배포 환경에서 추천관리/테스트관리 목록 조회 시 발생하던 Application error (reading '0') 에러 수정

## 📌 관련 이슈

<!-- Closes #이슈번호 -->

Closes #173 

## 🧩 작업 내용 (주요 변경사항)

- authFetch 기반 API에 cache: 'no-store' 적용 (추천관리, 테스트관리)
- recommend/page.tsx에 누락된 dynamic = 'force-dynamic' 추가
- RecommendTableServer / TestTableServer try-catch 추가
- fetchAdoptedPoolsAction try-catch 추가
- RecommendAdminContent Suspense key JSON.stringify(URLSearchParams) → .toString() 수정
- ProductMapsForm res.data.results null safety 적용
## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

- authFetch를 사용하는 서버 사이드 API는 cache: 'no-store' 없으면 Next.js Data Cache가 인증 응답을 해버려 빈 응답 생성
 
## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

배포 환경에서만 발생하는 문제 > PR 후 테스트 확인

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료
