### PR TITLE
[Feat] 테스트 / 추천관리 삭제 버튼 활성화 (#175)

### DIFF
--- a/src/app/admin/category/_api/adminFetchCategory.ts
+++ b/src/app/admin/category/_api/adminFetchCategory.ts
@@ -9,7 +9,7 @@ export const fetchAdminElementCategories =
     return authFetch.get<AdminCategoryListResponse>(
       '/api/v1/scents/categories/element',
       {
-        cache: 'force-cache',
+        cache: 'no-store',
       }
     )
   }
@@ -22,7 +22,7 @@ export const fetchAdminBlendCategories =
     return authFetch.get<AdminCategoryListResponse>(
       '/api/v1/scents/categories/blend',
       {
-        cache: 'force-cache',
+        cache: 'no-store',
       }
     )
   }

--- a/src/app/admin/category/_components/CategoryDeleteButton.tsx
+++ b/src/app/admin/category/_components/CategoryDeleteButton.tsx
@@ -43,7 +43,15 @@ export function CategoryDeleteButton({
   }
 
   return (
-    <Button color="none" size="w32h32" rounded="sm" onClick={handleDelete}>
+    <Button
+      color="none"
+      size="w32h32"
+      rounded="sm"
+      onClick={(e) => {
+        e.stopPropagation()
+        handleDelete()
+      }}
+    >
       <TrashIcon
         width={16}
         height={16}

--- a/src/app/admin/product/_components/ProductDeleteButton.tsx
+++ b/src/app/admin/product/_components/ProductDeleteButton.tsx
@@ -40,7 +40,15 @@ export function ProductDeleteButton({ type, id }: ProductDeleteButtonProps) {
   }
 
   return (
-    <Button color="none" size="w32h32" rounded="sm" onClick={handleDelete}>
+    <Button
+      color="none"
+      size="w32h32"
+      rounded="sm"
+      onClick={(e) => {
+        e.stopPropagation()
+        handleDelete()
+      }}
+    >
       <TrashIcon
         width={16}
         height={16}

--- a/src/app/admin/product/_components/ProductEditButton.tsx
+++ b/src/app/admin/product/_components/ProductEditButton.tsx
@@ -97,7 +97,10 @@ export function ProductEditButton({ type, id }: ProductEditButtonProps) {
       color="none"
       size="w32h32"
       rounded="sm"
-      onClick={handleEdit}
+      onClick={(e) => {
+        e.stopPropagation()
+        handleEdit()
+      }}
       disabled={isLoading}
     >
       <PenIcon width={16} height={16} className="text-gray-secondary" />

--- a/src/app/admin/recommend/_components/RecommendDeleteButton.tsx
+++ b/src/app/admin/recommend/_components/RecommendDeleteButton.tsx
@@ -41,7 +41,15 @@ export function RecommendDeleteButton({
   }
 
   return (
-    <Button color="none" size="w32h32" rounded="sm" onClick={handleDelete}>
+    <Button
+      color="none"
+      size="w32h32"
+      rounded="sm"
+      onClick={(e) => {
+        e.stopPropagation()
+        handleDelete()
+      }}
+    >
       <TrashIcon
         width={16}
         height={16}

--- a/src/app/admin/recommend/_components/RecommendDeleteButton.tsx
+++ b/src/app/admin/recommend/_components/RecommendDeleteButton.tsx
@@ -16,7 +16,7 @@ export function RecommendDeleteButton({
   tabId,
   id,
 }: RecommendDeleteButtonProps) {
-  const { openAlert, closeModal } = useModalStore()
+  const { openAlert, closeAll } = useModalStore()
 
   const handleDelete = async () => {
     openAlert({
@@ -25,16 +25,16 @@ export function RecommendDeleteButton({
       content: `선택한 ${tabId === 'product-pools' ? '후보군' : '추천맵'}을 삭제하시겠습니까?`,
       confirmText: '삭제',
       onConfirm: async () => {
-        try {
-          const result = await deleteRecommendAction(tabId, id)
-          if (result.success) {
-            closeModal()
-          } else {
-            alert('삭제에 실패했습니다.')
-          }
-        } catch (error) {
-          console.error('Delete error:', error)
-          alert('삭제 중 오류가 발생했습니다.')
+        const result = await deleteRecommendAction(tabId, id)
+        if (result.success) {
+          closeAll()
+        } else {
+          openAlert({
+            type: 'danger',
+            title: result.message ?? '삭제 실패',
+            content: result.reason ?? '삭제에 실패했습니다.',
+            confirmText: '확인',
+          })
         }
       },
     })

--- a/src/app/admin/recommend/_page/BlendMapsTab.tsx
+++ b/src/app/admin/recommend/_page/BlendMapsTab.tsx
@@ -5,7 +5,7 @@ import {
   AdminFirstCell,
   AdminTypeCell,
 } from '@/app/admin/_components'
-// import { RecommendDeleteButton } from '../_components/RecommendDeleteButton' // TODO: DELETE API 미개발, 추후 활성화
+import { RecommendDeleteButton } from '../_components/RecommendDeleteButton'
 import { RecommendStatusCell } from '../_components/RecommendStatusCell'
 import {
   BlendMapsItemResponse,
@@ -33,7 +33,7 @@ export const BlendMapsTab = ({
           <AdminDateCell slot={5} date={row.created_at} />
           <AdminDateCell slot={6} date={row.updated_at} />
           <AdminTableCell slot={7}>
-            {/* <RecommendDeleteButton tabId="blend-maps" id={row.id} /> TODO: DELETE API 미개발, 추후 활성화 */}
+            <RecommendDeleteButton tabId="blend-maps" id={row.id} />
           </AdminTableCell>
         </AdminTableRow>
       ))}

--- a/src/app/admin/recommend/_page/ProductPoolsTab.tsx
+++ b/src/app/admin/recommend/_page/ProductPoolsTab.tsx
@@ -7,7 +7,7 @@ import {
   AdminFirstCell,
   AdminTypeCell,
 } from '@/app/admin/_components'
-// import { RecommendDeleteButton } from '../_components/RecommendDeleteButton' // TODO: DELETE API 미개발, 추후 활성화
+import { RecommendDeleteButton } from '../_components/RecommendDeleteButton'
 import { RecommendStatusCell } from '../_components/RecommendStatusCell'
 import {
   ProductPoolsItemResponse,
@@ -37,7 +37,7 @@ export const ProductPoolsTab = ({
           <AdminDateCell slot={5} date={row.created_at} />
           <AdminDateCell slot={6} date={row.updated_at} />
           <AdminTableCell slot={7}>
-            {/* <RecommendDeleteButton tabId="product-pools" id={row.id} /> TODO: DELETE API 미개발, 추후 활성화 */}
+            <RecommendDeleteButton tabId="product-pools" id={row.id} />
           </AdminTableCell>
         </AdminTableRow>
       ))}

--- a/src/app/admin/test/_components/TestDeleteButton.tsx
+++ b/src/app/admin/test/_components/TestDeleteButton.tsx
@@ -3,7 +3,7 @@
 import React from 'react'
 import Button from '@/components/common/Button'
 import TrashIcon from '@/assets/icons/trash.svg'
-// import { deleteTestAction } from '../_actions/testActions'
+import { deleteTestAction } from '../_actions/testActions'
 import { useModalStore } from '@/store/useModalStore'
 
 interface TestDeleteButtonProps {
@@ -11,7 +11,7 @@ interface TestDeleteButtonProps {
 }
 
 export function TestDeleteButton({ testId }: TestDeleteButtonProps) {
-  const { openAlert } = useModalStore()
+  const { openAlert, closeAll } = useModalStore()
 
   const handleDelete = async () => {
     openAlert({
@@ -19,28 +19,19 @@ export function TestDeleteButton({ testId }: TestDeleteButtonProps) {
       title: '테스트 삭제',
       content: '해당 테스트를 삭제하시겠습니까?',
       confirmText: '삭제',
-      // onConfirm: async () => {
-      //   try {
-      //     const result = await deleteTestAction(testId)
-      //     if (result.success) {
-      //       closeModal()
-      //     } else {
-      //       openAlert({
-      //         type: 'danger',
-      //         title: '삭제 실패',
-      //         content: result.message ?? '삭제에 실패했습니다.',
-      //         confirmText: '확인',
-      //       })
-      //     }
-      //   } catch {
-      //     openAlert({
-      //       type: 'danger',
-      //       title: '삭제 실패',
-      //       content: '삭제 중 오류가 발생했습니다.',
-      //       confirmText: '확인',
-      //     })
-      //   }
-      // },
+      onConfirm: async () => {
+        const result = await deleteTestAction(testId)
+        if (result.success) {
+          closeAll()
+        } else {
+          openAlert({
+            type: 'danger',
+            title: result.message ?? '삭제 실패',
+            content: result.reason ?? '테스트 삭제에 실패했습니다.',
+            confirmText: '확인',
+          })
+        }
+      },
     })
   }
 

--- a/src/app/admin/test/_components/TestDeleteButton.tsx
+++ b/src/app/admin/test/_components/TestDeleteButton.tsx
@@ -36,7 +36,15 @@ export function TestDeleteButton({ testId }: TestDeleteButtonProps) {
   }
 
   return (
-    <Button color="none" size="w32h32" rounded="sm" onClick={handleDelete}>
+    <Button
+      color="none"
+      size="w32h32"
+      rounded="sm"
+      onClick={(e) => {
+        e.stopPropagation()
+        handleDelete()
+      }}
+    >
       <TrashIcon
         width={16}
         height={16}


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->


DELETE API 미개발로 주석 처리되어 있던 삭제 버튼 및 Server Action 활성화.

테스트 관리: TestDeleteButton, deleteTestAction
추천 관리: BlendMapsTab, ProductPoolsTab의 RecommendDeleteButton

버튼 조작 시 상위 엘리먼트로 이벤트 전파 중단 처리

## 📌 관련 이슈

<!-- Closes #이슈번호 -->

Closes #175 

## 🧩 작업 내용 (주요 변경사항)

- 주석 처리 된 삭제 버튼을 주석 해제 
- 삭제 버튼 클릭 시 상위 요소 상세 조회가 되는 문제 수정

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료
