### PR TITLE
[Refactor] 어드민 에러 모달 상세 메시지 표시 (#176)

### DIFF
--- a/src/app/admin/_components/AdminStatusToggleCell.tsx
+++ b/src/app/admin/_components/AdminStatusToggleCell.tsx
@@ -9,7 +9,11 @@ interface AdminStatusToggleCellProps {
   id: number | string
   status: string
   slot: number
-  onToggle: (nextStatus: any) => Promise<{ success: boolean }>
+  onToggle: (nextStatus: any) => Promise<{
+    success: boolean
+    message?: string | null
+    reason?: string | null
+  }>
   trueLabel?: string
   falseLabel?: string
 }
@@ -41,8 +45,8 @@ export function AdminStatusToggleCell({
       if (!result.success) {
         openAlert({
           type: 'danger',
-          title: '오류',
-          content: '상태 변경에 실패했습니다.',
+          title: result.message ?? '상태 변경 실패',
+          content: result.reason ?? '상태 변경에 실패했습니다.',
           confirmText: '확인',
         })
       }

--- a/src/app/admin/_lib/actionUtils.ts
+++ b/src/app/admin/_lib/actionUtils.ts
@@ -1,0 +1,11 @@
+import { FetchError } from '@/lib/api'
+
+export function extractError(error: unknown) {
+  if (error instanceof FetchError) {
+    return { message: error.message, reason: error.details?.reason ?? null }
+  }
+  return {
+    message: error instanceof Error ? error.message : null,
+    reason: null,
+  }
+}

--- a/src/app/admin/category/_components/CategoryPostModal.tsx
+++ b/src/app/admin/category/_components/CategoryPostModal.tsx
@@ -60,9 +60,9 @@ export function CategoryPostModal({
       } else {
         openAlert({
           type: 'danger',
-          title: '카테고리 등록 실패',
+          title: result.message ?? '카테고리 등록 실패',
           content:
-            result.message ??
+            result.reason ??
             '카테고리 등록에 실패했습니다. 다시 시도해 주세요.',
           confirmText: '확인',
         })

--- a/src/app/admin/category/_lib/categoryAction.ts
+++ b/src/app/admin/category/_lib/categoryAction.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { revalidatePath } from 'next/cache'
-import { FetchError } from '@/lib/api'
+import { extractError } from '@/app/admin/_lib/actionUtils'
 import { createAdminCategory } from '../_api/adminCreateCategory'
 import { deleteAdminCategory } from '../_api/adminDeleteCategory'
 import type {
@@ -21,10 +21,7 @@ export async function postCategoryAction(
     revalidatePath('/admin/category')
     return { success: true as const }
   } catch (error) {
-    if (error instanceof Error) {
-      return { success: false, message: error.message }
-    }
-    return { success: false as const, message: null, reason: null }
+    return { success: false as const, ...extractError(error) }
   }
 }
 
@@ -38,15 +35,8 @@ export async function deleteCategoryAction(
   try {
     await deleteAdminCategory(rootCategory, categoryId)
     revalidatePath('/admin/category')
-    return { success: true }
+    return { success: true as const }
   } catch (error) {
-    if (error instanceof FetchError) {
-      return {
-        success: false as const,
-        message: error.message,
-        reason: error.details?.reason,
-      }
-    }
-    return { success: false as const, message: null, reason: null }
+    return { success: false as const, ...extractError(error) }
   }
 }

--- a/src/app/admin/product/_components/product-post/BlendProductForm.tsx
+++ b/src/app/admin/product/_components/product-post/BlendProductForm.tsx
@@ -117,13 +117,12 @@ export function BlendProductForm({
     if (!result.success) {
       openAlert({
         type: 'danger',
-        title: productId ? '수정 실패' : '등록 실패',
+        title: result.message ?? (productId ? '수정 실패' : '등록 실패'),
         content:
-          result.error instanceof Error
-            ? result.error.message
-            : productId
-              ? '조합 수정 중 오류가 발생했습니다.'
-              : '조합 등록 중 오류가 발생했습니다.',
+          result.reason ??
+          (productId
+            ? '조합 수정 중 오류가 발생했습니다.'
+            : '조합 등록 중 오류가 발생했습니다.'),
       })
       return
     }

--- a/src/app/admin/product/_components/product-post/ElementProductForm.tsx
+++ b/src/app/admin/product/_components/product-post/ElementProductForm.tsx
@@ -93,13 +93,12 @@ export function ElementProductForm({
     if (!result.success) {
       openAlert({
         type: 'danger',
-        title: productId ? '수정 실패' : '등록 실패',
+        title: result.message ?? (productId ? '수정 실패' : '등록 실패'),
         content:
-          result.error instanceof Error
-            ? result.error.message
-            : productId
-              ? '단품 수정 중 오류가 발생했습니다.'
-              : '단품 등록 중 오류가 발생했습니다.',
+          result.reason ??
+          (productId
+            ? '단품 수정 중 오류가 발생했습니다.'
+            : '단품 등록 중 오류가 발생했습니다.'),
       })
       return
     }

--- a/src/app/admin/product/_lib/productActions.ts
+++ b/src/app/admin/product/_lib/productActions.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { revalidatePath } from 'next/cache'
-import { FetchError } from '@/lib/api'
+import { extractError } from '@/app/admin/_lib/actionUtils'
 import { deleteAdminProduct } from '../_api/adminDeleteProduct'
 import {
   createAdminElement,
@@ -45,14 +45,7 @@ export async function deleteProductAction(type: ProductTabId, id: number) {
     revalidatePath('/admin/product')
     return { success: true as const }
   } catch (error) {
-    if (error instanceof FetchError) {
-      return {
-        success: false as const,
-        message: error.message,
-        reason: error.details?.reason,
-      }
-    }
-    return { success: false as const, message: null, reason: null }
+    return { success: false as const, ...extractError(error) }
   }
 }
 
@@ -67,7 +60,7 @@ export async function getProductPresignedUrlAction(
     const data = await getAdminProductPresignedUrl(file_name, file_size)
     return { success: true as const, data: data.data }
   } catch (error) {
-    return { success: false as const, error }
+    return { success: false as const, ...extractError(error) }
   }
 }
 
@@ -78,9 +71,9 @@ export async function createElementAction(body: CreateElementBody) {
   try {
     await createAdminElement(body)
     revalidatePath('/admin/product')
-    return { success: true }
+    return { success: true as const }
   } catch (error) {
-    return { success: false, error }
+    return { success: false as const, ...extractError(error) }
   }
 }
 
@@ -91,9 +84,9 @@ export async function createBlendAction(body: CreateBlendBody) {
   try {
     await createAdminBlend(body)
     revalidatePath('/admin/product')
-    return { success: true }
+    return { success: true as const }
   } catch (error) {
-    return { success: false, error }
+    return { success: false as const, ...extractError(error) }
   }
 }
 
@@ -118,9 +111,9 @@ export async function patchElementAction(id: number, body: CreateElementBody) {
   try {
     await patchAdminElement(id, body)
     revalidatePath('/admin/product')
-    return { success: true }
+    return { success: true as const }
   } catch (error) {
-    return { success: false, error }
+    return { success: false as const, ...extractError(error) }
   }
 }
 
@@ -131,8 +124,8 @@ export async function patchBlendAction(id: number, body: CreateBlendBody) {
   try {
     await patchAdminBlend(id, body)
     revalidatePath('/admin/product')
-    return { success: true }
+    return { success: true as const }
   } catch (error) {
-    return { success: false, error }
+    return { success: false as const, ...extractError(error) }
   }
 }

--- a/src/app/admin/recommend/_actions/recommendActions.ts
+++ b/src/app/admin/recommend/_actions/recommendActions.ts
@@ -1,7 +1,6 @@
 'use server'
 
 import { revalidatePath } from 'next/cache'
-import { FetchError } from '@/lib/api'
 import { deleteAdminRecommend } from '../_api/adminDeleteRecommend'
 import {
   patchAdminBlendMapPublish,
@@ -19,16 +18,7 @@ import {
   ProductPoolCreateBody,
   ProductPoolsListResponse,
 } from '../_types'
-
-function extractError(error: unknown) {
-  if (error instanceof FetchError) {
-    return { message: error.message, reason: error.details?.reason ?? null }
-  }
-  return {
-    message: error instanceof Error ? error.message : null,
-    reason: null,
-  }
-}
+import { extractError } from '@/app/admin/_lib/actionUtils'
 
 /**
  * 채택된 제품 후보군 목록 조회 Server Action

--- a/src/app/admin/recommend/_page/RecommendPostModal.tsx
+++ b/src/app/admin/recommend/_page/RecommendPostModal.tsx
@@ -87,8 +87,8 @@ export const RecommendPostModal = ({ activeTab }: RecommendPostModalProps) => {
       if (!result.success) {
         openAlert({
           type: 'danger',
-          title: '등록 실패',
-          content: result.message ?? '향조합 추천맵 등록에 실패했습니다.',
+          title: result.message ?? '등록 실패',
+          content: result.reason ?? '향조합 추천맵 등록에 실패했습니다.',
           confirmText: '확인',
         })
         return
@@ -104,8 +104,8 @@ export const RecommendPostModal = ({ activeTab }: RecommendPostModalProps) => {
       if (!result.success) {
         openAlert({
           type: 'danger',
-          title: '등록 실패',
-          content: result.message ?? '제품 후보군 등록에 실패했습니다.',
+          title: result.message ?? '등록 실패',
+          content: result.reason ?? '제품 후보군 등록에 실패했습니다.',
           confirmText: '확인',
         })
         return
@@ -115,8 +115,8 @@ export const RecommendPostModal = ({ activeTab }: RecommendPostModalProps) => {
       if (!result.success) {
         openAlert({
           type: 'danger',
-          title: '등록 실패',
-          content: result.message ?? '제품 추천맵 등록에 실패했습니다.',
+          title: result.message ?? '등록 실패',
+          content: result.reason ?? '제품 추천맵 등록에 실패했습니다.',
           confirmText: '확인',
         })
         return

--- a/src/app/admin/test/_actions/testActions.ts
+++ b/src/app/admin/test/_actions/testActions.ts
@@ -1,22 +1,21 @@
 'use server'
 
 import { revalidatePath } from 'next/cache'
-// import { deleteAdminTest } from '../_api/adminDeleteTest' // TODO: DELETE API 미개발, 추후 활성화
+import { deleteAdminTest } from '../_api/adminDeleteTest'
 import { patchAdminTestPublish } from '../_api/adminPatchTest'
 import { createAdminTest, CreateTestPayload } from '../_api/adminCreateTest'
 import { fetchAdminTestDetail } from '../_api/adminFetchTestDetail'
+import { extractError } from '@/app/admin/_lib/actionUtils'
 
-// TODO: DELETE API 미개발, 추후 활성화
-// export async function deleteTestAction(form_id: number) {
-//   try {
-//     await deleteAdminTest(form_id)
-//     revalidatePath('/admin/test')
-//     return { success: true }
-//   } catch (error) {
-//     const message = error instanceof Error ? error.message : null
-//     return { success: false, message }
-//   }
-// }
+export async function deleteTestAction(form_id: number) {
+  try {
+    await deleteAdminTest(form_id)
+    revalidatePath('/admin/test')
+    return { success: true as const }
+  } catch (error) {
+    return { success: false as const, ...extractError(error) }
+  }
+}
 
 /**
  * 테스트 발행 상태 토글 Server Action
@@ -28,10 +27,9 @@ export async function toggleTestPublishAction(
   try {
     await patchAdminTestPublish(form_id, status)
     revalidatePath('/admin/test')
-    return { success: true }
+    return { success: true as const }
   } catch (error) {
-    const message = error instanceof Error ? error.message : null
-    return { success: false, message }
+    return { success: false as const, ...extractError(error) }
   }
 }
 
@@ -41,10 +39,9 @@ export async function toggleTestPublishAction(
 export async function getTestDetailAction(form_id: number) {
   try {
     const result = await fetchAdminTestDetail(form_id)
-    return { success: true, data: result.data }
+    return { success: true as const, data: result.data }
   } catch (error) {
-    const message = error instanceof Error ? error.message : null
-    return { success: false, message, data: null }
+    return { success: false as const, ...extractError(error), data: null }
   }
 }
 
@@ -55,9 +52,8 @@ export async function createTestAction(payload: CreateTestPayload) {
   try {
     await createAdminTest(payload)
     revalidatePath('/admin/test')
-    return { success: true }
+    return { success: true as const }
   } catch (error) {
-    const message = error instanceof Error ? error.message : null
-    return { success: false, message }
+    return { success: false as const, ...extractError(error) }
   }
 }

--- a/src/app/admin/test/create/_hooks/useTestCreate.tsx
+++ b/src/app/admin/test/create/_hooks/useTestCreate.tsx
@@ -226,8 +226,8 @@ export const useTestCreate = () => {
       } else {
         openAlert({
           type: 'danger',
-          title: '테스트 생성 실패',
-          content: result.message ?? '테스트 생성에 실패했습니다.',
+          title: result.message ?? '테스트 생성 실패',
+          content: result.reason ?? '테스트 생성에 실패했습니다.',
           confirmText: '확인',
         })
       }


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->

API 실패 에러 발생 시 openAlert 모달에 내용이 하드코딩되어 실제 에러 원인을 알 수 없는 문제 개선.
## 📌 관련 이슈

<!-- Closes #이슈번호 -->

Closes #176 

## 🧩 작업 내용 (주요 변경사항)

-  FetchError / 일반 Error 를 통일된 형식({message, reason })으로 변환하는 extractError 유틸 함수 추가
- 로컬 에러   처리 코드를 제거하고 공통 유틸로 교체

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->


모든 catch 블록의 반환 타입이 { success: false as const, message, reason } 으로 통일하였습니다.

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료
