### PR TITLE
[Feat] 어드민 서버 액션에 로딩 UX 추가 및 응답 완료 후 revalidate 보장 (#181)

### DIFF
--- a/src/app/admin/product/_components/product-post/BlendProductForm.tsx
+++ b/src/app/admin/product/_components/product-post/BlendProductForm.tsx
@@ -6,6 +6,7 @@ import Modal from '@/components/common/Modal/Modal'
 import Button from '@/components/common/Button'
 import Input from '@/components/common/Input'
 import { useModalStore } from '@/store/useModalStore'
+import { LoadingSpinner } from '@/components/common/LoadingSpinner'
 import type { AdminCategoryListResponse } from '@/app/admin/category/_types/AdminCategoryType'
 import type { AdminElementListResponse } from '../../_types/AdminProductType'
 import type { CreateBlendBody } from '../../_api/adminCreateProduct'
@@ -40,6 +41,7 @@ export function BlendProductForm({
   productId,
 }: BlendProductFormProps) {
   const { openAlert } = useModalStore()
+  const [isSubmitting, setIsSubmitting] = useState(false)
   const [data, setData] = useState<CreateBlendBody>({
     name: initialData?.name ?? '',
     description: initialData?.description ?? '',
@@ -109,24 +111,29 @@ export function BlendProductForm({
       return
     }
 
-    const body = { ...data, image_url: imageUrl }
-    const result = productId
-      ? await patchBlendAction(productId, body)
-      : await createBlendAction(body)
+    setIsSubmitting(true)
+    try {
+      const body = { ...data, image_url: imageUrl }
+      const result = productId
+        ? await patchBlendAction(productId, body)
+        : await createBlendAction(body)
 
-    if (!result.success) {
-      openAlert({
-        type: 'danger',
-        title: result.message ?? (productId ? '수정 실패' : '등록 실패'),
-        content:
-          result.reason ??
-          (productId
-            ? '조합 수정 중 오류가 발생했습니다.'
-            : '조합 등록 중 오류가 발생했습니다.'),
-      })
-      return
+      if (!result.success) {
+        openAlert({
+          type: 'danger',
+          title: result.message ?? (productId ? '수정 실패' : '등록 실패'),
+          content:
+            result.reason ??
+            (productId
+              ? '조합 수정 중 오류가 발생했습니다.'
+              : '조합 등록 중 오류가 발생했습니다.'),
+        })
+        return
+      }
+      onClose()
+    } finally {
+      setIsSubmitting(false)
     }
-    onClose()
   }
 
   return (
@@ -209,12 +216,23 @@ export function BlendProductForm({
         <Button
           color="none"
           className="border-gray-light border"
+          disabled={isSubmitting}
           onClick={onClose}
         >
           취소
         </Button>
-        <Button color="primary" onClick={handleSubmit} disabled={isPending}>
-          {productId ? '조합 수정' : '조합 등록'}
+        <Button
+          color="primary"
+          onClick={handleSubmit}
+          disabled={isPending || isSubmitting}
+        >
+          {isSubmitting ? (
+            <LoadingSpinner size="sm" className="mx-auto" />
+          ) : productId ? (
+            '조합 수정'
+          ) : (
+            '조합 등록'
+          )}
         </Button>
       </Modal.Footer>
     </>

--- a/src/app/admin/product/_components/product-post/ElementProductForm.tsx
+++ b/src/app/admin/product/_components/product-post/ElementProductForm.tsx
@@ -5,6 +5,7 @@ import Modal from '@/components/common/Modal/Modal'
 import Button from '@/components/common/Button'
 import Input from '@/components/common/Input'
 import { useModalStore } from '@/store/useModalStore'
+import { LoadingSpinner } from '@/components/common/LoadingSpinner'
 import type { AdminCategoryListResponse } from '@/app/admin/category/_types/AdminCategoryType'
 import type { CreateElementBody } from '../../_api/adminCreateProduct'
 import {
@@ -38,6 +39,7 @@ export function ElementProductForm({
   productId,
 }: ElementProductFormProps) {
   const { openAlert } = useModalStore()
+  const [isSubmitting, setIsSubmitting] = useState(false)
   const [data, setData] = useState<CreateElementBody>({
     name: initialData?.name ?? '',
     description: initialData?.description ?? '',
@@ -85,24 +87,29 @@ export function ElementProductForm({
       return
     }
 
-    const body = { ...data, image_url: imageUrl }
-    const result = productId
-      ? await patchElementAction(productId, body)
-      : await createElementAction(body)
+    setIsSubmitting(true)
+    try {
+      const body = { ...data, image_url: imageUrl }
+      const result = productId
+        ? await patchElementAction(productId, body)
+        : await createElementAction(body)
 
-    if (!result.success) {
-      openAlert({
-        type: 'danger',
-        title: result.message ?? (productId ? '수정 실패' : '등록 실패'),
-        content:
-          result.reason ??
-          (productId
-            ? '단품 수정 중 오류가 발생했습니다.'
-            : '단품 등록 중 오류가 발생했습니다.'),
-      })
-      return
+      if (!result.success) {
+        openAlert({
+          type: 'danger',
+          title: result.message ?? (productId ? '수정 실패' : '등록 실패'),
+          content:
+            result.reason ??
+            (productId
+              ? '단품 수정 중 오류가 발생했습니다.'
+              : '단품 등록 중 오류가 발생했습니다.'),
+        })
+        return
+      }
+      onClose()
+    } finally {
+      setIsSubmitting(false)
     }
-    onClose()
   }
 
   return (
@@ -156,12 +163,23 @@ export function ElementProductForm({
         <Button
           color="none"
           className="border-gray-light border"
+          disabled={isSubmitting}
           onClick={onClose}
         >
           취소
         </Button>
-        <Button color="primary" onClick={handleSubmit} disabled={isPending}>
-          {productId ? '단품 수정' : '단품 등록'}
+        <Button
+          color="primary"
+          onClick={handleSubmit}
+          disabled={isPending || isSubmitting}
+        >
+          {isSubmitting ? (
+            <LoadingSpinner size="sm" className="mx-auto" />
+          ) : productId ? (
+            '단품 수정'
+          ) : (
+            '단품 등록'
+          )}
         </Button>
       </Modal.Footer>
     </>

--- a/src/app/admin/recommend/_page/RecommendPostModal.tsx
+++ b/src/app/admin/recommend/_page/RecommendPostModal.tsx
@@ -18,6 +18,7 @@ import {
   createProductMapAction,
   fetchAdoptedPoolsAction,
 } from '../_actions/recommendActions'
+import { LoadingSpinner } from '@/components/common/LoadingSpinner'
 
 interface RecommendPostModalProps {
   activeTab: RecommendTabId
@@ -32,6 +33,7 @@ const ProductMapsFormFallback = () => (
 
 export const RecommendPostModal = ({ activeTab }: RecommendPostModalProps) => {
   const { closeModal, openAlert } = useModalStore()
+  const [isSubmitting, setIsSubmitting] = useState(false)
 
   const activeTabLabel =
     RECOMMEND_TABS.find((t) => t.id === activeTab)?.label || ''
@@ -63,7 +65,6 @@ export const RecommendPostModal = ({ activeTab }: RecommendPostModalProps) => {
 
   useEffect(() => {
     if (activeTab === 'product-maps') {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       setPoolsPromise(fetchAdoptedPoolsAction())
     }
   }, [activeTab])
@@ -82,48 +83,52 @@ export const RecommendPostModal = ({ activeTab }: RecommendPostModalProps) => {
   }
 
   const handleRegister = async () => {
-    if (activeTab === 'blend-maps') {
-      const result = await createBlendMapAction(formData.inputType)
-      if (!result.success) {
-        openAlert({
-          type: 'danger',
-          title: result.message ?? '등록 실패',
-          content: result.reason ?? '향조합 추천맵 등록에 실패했습니다.',
-          confirmText: '확인',
+    setIsSubmitting(true)
+    try {
+      if (activeTab === 'blend-maps') {
+        const result = await createBlendMapAction(formData.inputType)
+        if (!result.success) {
+          openAlert({
+            type: 'danger',
+            title: result.message ?? '등록 실패',
+            content: result.reason ?? '향조합 추천맵 등록에 실패했습니다.',
+            confirmText: '확인',
+          })
+          return
+        }
+      } else if (activeTab === 'product-pools') {
+        const result = await createProductPoolAction({
+          crawl_source: formData.crawl_source,
+          crawl_count: formData.crawl_count,
+          crawl_sort: formData.crawl_sort,
+          product_type: formData.product_type,
+          crawl_config: formData.crawl_config,
         })
-        return
+        if (!result.success) {
+          openAlert({
+            type: 'danger',
+            title: result.message ?? '등록 실패',
+            content: result.reason ?? '제품 후보군 등록에 실패했습니다.',
+            confirmText: '확인',
+          })
+          return
+        }
+      } else if (activeTab === 'product-maps') {
+        const result = await createProductMapAction(formData.product_pool_id)
+        if (!result.success) {
+          openAlert({
+            type: 'danger',
+            title: result.message ?? '등록 실패',
+            content: result.reason ?? '제품 추천맵 등록에 실패했습니다.',
+            confirmText: '확인',
+          })
+          return
+        }
       }
-    } else if (activeTab === 'product-pools') {
-      const result = await createProductPoolAction({
-        crawl_source: formData.crawl_source,
-        crawl_count: formData.crawl_count,
-        crawl_sort: formData.crawl_sort,
-        product_type: formData.product_type,
-        crawl_config: formData.crawl_config,
-      })
-      if (!result.success) {
-        openAlert({
-          type: 'danger',
-          title: result.message ?? '등록 실패',
-          content: result.reason ?? '제품 후보군 등록에 실패했습니다.',
-          confirmText: '확인',
-        })
-        return
-      }
-    } else if (activeTab === 'product-maps') {
-      const result = await createProductMapAction(formData.product_pool_id)
-      if (!result.success) {
-        openAlert({
-          type: 'danger',
-          title: result.message ?? '등록 실패',
-          content: result.reason ?? '제품 추천맵 등록에 실패했습니다.',
-          confirmText: '확인',
-        })
-        return
-      }
+      closeModal()
+    } finally {
+      setIsSubmitting(false)
     }
-
-    closeModal()
   }
 
   const renderContent = () => {
@@ -161,19 +166,33 @@ export const RecommendPostModal = ({ activeTab }: RecommendPostModalProps) => {
   }
 
   return (
-    <Modal isOpen onClose={closeModal} size="md" overflowVisible>
+    <Modal
+      isOpen
+      onClose={isSubmitting ? () => {} : closeModal}
+      size="md"
+      overflowVisible
+    >
       <Modal.Header>{activeTabLabel} 등록</Modal.Header>
       <Modal.Content>{renderContent()}</Modal.Content>
       <Modal.Footer className="flex justify-end gap-2 text-[16px]">
         <Button
           color="none"
           className="border-gray-light border"
+          disabled={isSubmitting}
           onClick={closeModal}
         >
           취소
         </Button>
-        <Button color="primary" onClick={handleRegister}>
-          등록
+        <Button
+          color="primary"
+          disabled={isSubmitting}
+          onClick={handleRegister}
+        >
+          {isSubmitting ? (
+            <LoadingSpinner size="sm" className="mx-auto" />
+          ) : (
+            '등록'
+          )}
         </Button>
       </Modal.Footer>
     </Modal>

--- a/src/app/admin/test/create/_hooks/useTestCreate.tsx
+++ b/src/app/admin/test/create/_hooks/useTestCreate.tsx
@@ -12,6 +12,7 @@ export const useTestCreate = () => {
   const router = useRouter()
   const { openAlert, openModal, closeModal } = useModalStore()
   const [uiCategory, setUiCategory] = useState<string>('PREFERENCE')
+  const [isSubmitting, setIsSubmitting] = useState(false)
 
   const generateUniqueId = (prefix: string) =>
     `${prefix}-${Math.random().toString(36).substring(2, 9)}`
@@ -219,6 +220,7 @@ export const useTestCreate = () => {
       })),
     }
 
+    setIsSubmitting(true)
     try {
       const result = await createTestAction(payload)
       if (result.success) {
@@ -238,6 +240,8 @@ export const useTestCreate = () => {
         content: '테스트 생성 중 오류가 발생했습니다.',
         confirmText: '확인',
       })
+    } finally {
+      setIsSubmitting(false)
     }
   }
 
@@ -249,6 +253,7 @@ export const useTestCreate = () => {
     state: {
       uiCategory,
       formData,
+      isSubmitting,
     },
     actions: {
       updateField,

--- a/src/app/admin/test/create/page.tsx
+++ b/src/app/admin/test/create/page.tsx
@@ -8,6 +8,7 @@ import {
   AdminTabGroup,
 } from '@/app/admin/_components'
 import Button from '@/components/common/Button'
+import { LoadingSpinner } from '@/components/common/LoadingSpinner'
 import { useTestCreate } from '@/app/admin/test/create/_hooks'
 import { QuestionForm } from '@/app/admin/test/create/_components'
 import { Question } from '@/app/admin/test/create/_types'
@@ -37,8 +38,17 @@ export default function TestCreatePage() {
             >
               미리보기
             </Button>
-            <Button color="primary" rounded="sm" onClick={actions.handleSave}>
-              저장
+            <Button
+              color="primary"
+              rounded="sm"
+              disabled={state.isSubmitting}
+              onClick={actions.handleSave}
+            >
+              {state.isSubmitting ? (
+                <LoadingSpinner size="sm" className="mx-auto" />
+              ) : (
+                '저장'
+              )}
             </Button>
           </div>
         }

--- a/src/components/common/Modal/AlertModal.tsx
+++ b/src/components/common/Modal/AlertModal.tsx
@@ -1,10 +1,11 @@
 'use client'
 
-import React from 'react'
+import React, { useState } from 'react'
 import Modal from './Modal'
 import Button from '../Button'
 import AlertDangerIcon from '@/assets/icons/alertDanger.svg'
 import AlertSuccessIcon from '@/assets/icons/alertSuccess.svg'
+import { LoadingSpinner } from '@/components/common/LoadingSpinner'
 
 export interface AlertConfig {
   type: 'success' | 'danger'
@@ -14,7 +15,7 @@ export interface AlertConfig {
   showButtons?: boolean
   confirmText?: string
   cancelText?: string
-  onConfirm?: () => void
+  onConfirm?: () => void | Promise<void>
   onCancel?: () => void
 }
 
@@ -35,12 +36,23 @@ export function AlertModal({
   onConfirm,
   onCancel,
 }: AlertModalProps) {
-  const handleConfirm = () => {
-    if (onConfirm) onConfirm()
-    else onClose()
+  const [isConfirming, setIsConfirming] = useState(false)
+
+  const handleConfirm = async () => {
+    if (onConfirm) {
+      setIsConfirming(true)
+      try {
+        await onConfirm()
+      } finally {
+        setIsConfirming(false)
+      }
+    } else {
+      onClose()
+    }
   }
 
   const handleCancel = () => {
+    if (isConfirming) return
     if (onCancel) onCancel()
     else onClose()
   }
@@ -93,9 +105,14 @@ export function AlertModal({
               color={isDanger ? 'danger' : 'success'}
               size="none"
               className="flex-1 rounded-[14px] border border-transparent py-3 font-semibold"
+              disabled={isConfirming}
               onClick={handleConfirm}
             >
-              {confirmText}
+              {isConfirming ? (
+                <LoadingSpinner size="sm" className="mx-auto" />
+              ) : (
+                confirmText
+              )}
             </Button>
           </div>
         )}


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->

isSubmitting 상태 추가 + AlertModal에 onConfirm에 promise 함수 받을 수 있도록 추가

## 📌 관련 이슈

<!-- Closes #이슈번호 -->

Closes #181

## 🧩 작업 내용 (주요 변경사항)

- AlertModal.tsx ->  onConfirm 타입을 () => void | Promise<void>로 확장하여 비동기 로직도 추가될 수 있도록 수정 후 isConfirming 상태 추가 후 처리 중인 상황에서 버튼은 disabled 후 로딩 스피너 추가 -> 삭제 버튼 로직 적용
- 상품 + 추천 등록 모달에 submitting 로직 추가
- 테스트 생성 페이지에 submitting 로직 추가

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

배포 환경에서도 테스트 필요

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료
