### PR TITLE
[Feat] 어드민 테스트 수정 기능 추가 및 훅 공통화 (#183)

### DIFF
--- a/src/app/admin/_components/AdminTabGroup.tsx
+++ b/src/app/admin/_components/AdminTabGroup.tsx
@@ -11,6 +11,7 @@ interface AdminTabGroupProps {
   className?: string
   /** 탭들을 부모 너비에 맞춰 균등하게 배분할지 여부임 */
   fullWidth?: boolean
+  disabled?: boolean
 }
 
 /**
@@ -22,6 +23,7 @@ export const AdminTabGroup = ({
   onChange,
   className,
   fullWidth = false,
+  disabled = false,
 }: AdminTabGroupProps) => {
   return (
     <div className={cn('flex gap-4 pb-4', fullWidth && 'w-full', className)}>
@@ -30,10 +32,11 @@ export const AdminTabGroup = ({
         return (
           <Button
             key={tab.id}
-            onClick={() => onChange(tab.id)}
+            onClick={() => !disabled && onChange(tab.id)}
             className={cn(
-              'cursor-pointer rounded-xl text-sm font-semibold transition-all',
+              'rounded-xl text-sm font-semibold transition-all',
               fullWidth && 'flex-1',
+              disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer',
               isActive
                 ? 'bg-black-primary text-white'
                 : 'bg-gray-light text-black-primary border-none shadow-none hover:bg-neutral-200'

--- a/src/app/admin/test/_actions/testActions.ts
+++ b/src/app/admin/test/_actions/testActions.ts
@@ -2,8 +2,9 @@
 
 import { revalidatePath } from 'next/cache'
 import { deleteAdminTest } from '../_api/adminDeleteTest'
-import { patchAdminTestPublish } from '../_api/adminPatchTest'
+import { toggleAdminTestPublish } from '../_api/adminPatchTest'
 import { createAdminTest, CreateTestPayload } from '../_api/adminCreateTest'
+import { updateAdminTest, UpdateTestPayload } from '../_api/adminUpdateTest'
 import { fetchAdminTestDetail } from '../_api/adminFetchTestDetail'
 import { extractError } from '@/app/admin/_lib/actionUtils'
 
@@ -25,7 +26,7 @@ export async function toggleTestPublishAction(
   status: 'PUBLISHED' | 'UNPUBLISHED'
 ) {
   try {
-    await patchAdminTestPublish(form_id, status)
+    await toggleAdminTestPublish(form_id, status)
     revalidatePath('/admin/test')
     return { success: true as const }
   } catch (error) {
@@ -42,6 +43,22 @@ export async function getTestDetailAction(form_id: number) {
     return { success: true as const, data: result.data }
   } catch (error) {
     return { success: false as const, ...extractError(error), data: null }
+  }
+}
+
+/**
+ * 테스트 수정 Server Action
+ */
+export async function updateTestAction(
+  form_id: number,
+  payload: UpdateTestPayload
+) {
+  try {
+    await updateAdminTest(form_id, payload)
+    revalidatePath('/admin/test')
+    return { success: true as const }
+  } catch (error) {
+    return { success: false as const, ...extractError(error) }
   }
 }
 

--- a/src/app/admin/test/_api/adminPatchTest.ts
+++ b/src/app/admin/test/_api/adminPatchTest.ts
@@ -3,7 +3,7 @@ import { authFetch } from '@/lib/api'
 /**
  * 어드민 테스트 발행 상태 변경 API
  */
-export const patchAdminTestPublish = (
+export const toggleAdminTestPublish = (
   form_id: number,
   publish_status: 'PUBLISHED' | 'UNPUBLISHED'
 ): Promise<{

--- a/src/app/admin/test/_api/adminUpdateTest.ts
+++ b/src/app/admin/test/_api/adminUpdateTest.ts
@@ -1,0 +1,28 @@
+import { authFetch } from '@/lib/api'
+
+export interface UpdateTestPayload {
+  name: string
+  description?: string
+  questions: {
+    question_key: string
+    question_text: string
+    selection_type: string
+    is_required: boolean
+    sort_order: number
+    options: {
+      answer_option_key: string
+      answer_option_text: string
+      sort_order: number
+    }[]
+  }[]
+}
+
+/**
+ * 어드민 테스트 수정 API
+ */
+export const updateAdminTest = (
+  form_id: number,
+  payload: UpdateTestPayload
+): Promise<{ success: boolean }> => {
+  return authFetch.put(`/api/v1/admin/profilings/forms/${form_id}`, payload)
+}

--- a/src/app/admin/test/_api/index.ts
+++ b/src/app/admin/test/_api/index.ts
@@ -1,4 +1,5 @@
 export * from './adminFetchTest'
 export * from './adminCreateTest'
+export * from './adminUpdateTest'
 export * from './adminPatchTest'
 export * from './adminFetchTestDetail'

--- a/src/app/admin/test/_components/TestEditButton.tsx
+++ b/src/app/admin/test/_components/TestEditButton.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import Button from '@/components/common/Button'
+import PenIcon from '@/assets/icons/pen.svg'
+
+interface TestEditButtonProps {
+  testId: number
+}
+
+export function TestEditButton({ testId }: TestEditButtonProps) {
+  const router = useRouter()
+
+  return (
+    <Button
+      color="none"
+      size="w32h32"
+      rounded="sm"
+      onClick={(e) => {
+        e.stopPropagation()
+        router.push(`/admin/test/edit/${testId}`)
+      }}
+    >
+      <PenIcon width={16} height={16} className="text-gray-secondary" />
+    </Button>
+  )
+}

--- a/src/app/admin/test/_components/TestTableServer.tsx
+++ b/src/app/admin/test/_components/TestTableServer.tsx
@@ -13,6 +13,7 @@ import { fetchAdminTests } from '../_api/adminFetchTest'
 import { TestStatusCell } from './TestStatusCell'
 import { TestTableRow } from './TestTableRow'
 import { TestDeleteButton } from './TestDeleteButton'
+import { TestEditButton } from './TestEditButton'
 
 interface TestTableServerProps {
   searchParams: {
@@ -66,7 +67,10 @@ export async function TestTableServer({ searchParams }: TestTableServerProps) {
           <AdminDateCell slot={6} date={test.updated_at} />
 
           <AdminTableCell slot={7}>
-            <TestDeleteButton testId={test.id} />
+            <div className="flex items-center gap-1">
+              <TestEditButton testId={test.id} />
+              <TestDeleteButton testId={test.id} />
+            </div>
           </AdminTableCell>
         </TestTableRow>
       ))}

--- a/src/app/admin/test/_hooks/useTestForm.tsx
+++ b/src/app/admin/test/_hooks/useTestForm.tsx
@@ -1,0 +1,260 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { TestFormData, Question, Option } from '../create/_types'
+import { DEFAULT_TEMPLATES } from '../create/_constants/presets'
+import { useModalStore } from '@/store/useModalStore'
+import { TestPreviewModal } from '../create/_components/TestPreviewModal'
+
+type ActionResult =
+  | { success: true }
+  | { success: false; message?: string | null; reason?: string | null }
+
+interface UseTestFormOptions {
+  initialData: TestFormData
+  onSave: (formData: TestFormData) => Promise<ActionResult>
+  resetQuestionsOnCategoryChange?: boolean
+}
+
+export const useTestForm = ({
+  initialData,
+  onSave,
+  resetQuestionsOnCategoryChange = false,
+}: UseTestFormOptions) => {
+  const router = useRouter()
+  const { openAlert, openModal, closeModal } = useModalStore()
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [uiCategory, setUiCategory] = useState<string>(
+    initialData.profiling_type
+  )
+  const [formData, setFormData] = useState<TestFormData>(initialData)
+
+  const generateUniqueId = (prefix: string) =>
+    `${prefix}-${Math.random().toString(36).substring(2, 9)}`
+
+  const updateField = <K extends keyof TestFormData>(
+    key: K,
+    value: TestFormData[K]
+  ) => {
+    setFormData((prev) => ({ ...prev, [key]: value }))
+  }
+
+  const updateCategory = (categoryName: string) => {
+    setUiCategory(categoryName)
+    if (resetQuestionsOnCategoryChange) {
+      setFormData((prev) => ({
+        ...prev,
+        profiling_type: categoryName,
+        questions: (DEFAULT_TEMPLATES[categoryName] || []).map((q, idx) => ({
+          ...q,
+          key: generateUniqueId(q.question_key),
+          sort_order: idx + 1,
+          options: q.options.map((o) => ({
+            ...o,
+            key: generateUniqueId(o.answer_option_key),
+          })),
+        })),
+      }))
+    }
+  }
+
+  // --- Question Actions ---
+  const addQuestion = () => {
+    const newQuestion: Question = {
+      key: generateUniqueId('mood'),
+      question_key: 'mood',
+      question_text: '',
+      selection_type: 'SINGLE',
+      is_required: true,
+      sort_order: formData.questions.length + 1,
+      options: [],
+    }
+    setFormData((prev) => ({
+      ...prev,
+      questions: [...prev.questions, newQuestion],
+    }))
+  }
+
+  const removeQuestion = (qKey: string) => {
+    setFormData((prev) => {
+      const filtered = prev.questions.filter((q) => q.key !== qKey)
+      const reordered = filtered.map((q, idx) => ({
+        ...q,
+        sort_order: idx + 1,
+      }))
+      return { ...prev, questions: reordered }
+    })
+  }
+
+  const updateQuestion = (qKey: string, updates: Partial<Question>) => {
+    setFormData((prev) => ({
+      ...prev,
+      questions: prev.questions.map((q) =>
+        q.key === qKey ? { ...q, ...updates } : q
+      ),
+    }))
+  }
+
+  const reorderQuestions = (questions: Question[]) => {
+    const reordered = questions.map((q, idx) => ({ ...q, sort_order: idx + 1 }))
+    setFormData((prev) => ({ ...prev, questions: reordered }))
+  }
+
+  // --- Option Actions ---
+  const modifyQuestionOptions = (
+    qKey: string,
+    transformer: (options: Option[]) => Option[]
+  ) => {
+    setFormData((prev) => ({
+      ...prev,
+      questions: prev.questions.map((q) =>
+        q.key === qKey ? { ...q, options: transformer(q.options) } : q
+      ),
+    }))
+  }
+
+  const addOption = (qKey: string) => {
+    modifyQuestionOptions(qKey, (options) => {
+      const newOption: Option = {
+        key: generateUniqueId('opt'),
+        answer_option_key: generateUniqueId('opt'),
+        answer_option_text: '',
+        sort_order: options.length + 1,
+      }
+      return [...options, newOption]
+    })
+  }
+
+  const removeOption = (qKey: string, optKey: string) => {
+    modifyQuestionOptions(qKey, (options) => {
+      const filtered = options.filter((o) => o.key !== optKey)
+      return filtered.map((o, idx) => ({ ...o, sort_order: idx + 1 }))
+    })
+  }
+
+  const updateOption = (
+    qKey: string,
+    optKey: string,
+    updates: Partial<Option>
+  ) => {
+    modifyQuestionOptions(qKey, (options) =>
+      options.map((o) => (o.key === optKey ? { ...o, ...updates } : o))
+    )
+  }
+
+  const reorderOptions = (qKey: string, options: Option[]) => {
+    const reordered = options.map((o, idx) => ({ ...o, sort_order: idx + 1 }))
+    updateQuestion(qKey, { options: reordered })
+  }
+
+  const validate = (): string | null => {
+    if (!formData.name.trim()) {
+      return '테스트 이름을 입력해주세요.'
+    }
+
+    if (formData.questions.length === 0) {
+      return '테스트 질문을 1개 이상 추가해주세요.'
+    }
+
+    const questionKeys = formData.questions.map((q) => q.question_key)
+    if (new Set(questionKeys).size !== questionKeys.length) {
+      return '중복된 유형의 질문이 있습니다. 각 질문 유형은 한 번만 사용할 수 있습니다.'
+    }
+
+    for (let i = 0; i < formData.questions.length; i++) {
+      const q = formData.questions[i]
+
+      if (!q.question_text.trim()) {
+        return `${i + 1}번 질문의 내용을 입력해주세요.`
+      }
+
+      if (q.question_text.length > 50) {
+        return `${i + 1}번 질문의 내용이 제한 글자수를 초과했습니다. \n(최대 50자)`
+      }
+
+      if (q.options.length === 0) {
+        return `${i + 1}번 질문의 답변 선택지를 1개 이상 추가해주세요.`
+      }
+
+      for (let j = 0; j < q.options.length; j++) {
+        if (!q.options[j].answer_option_text.trim()) {
+          return `${i + 1}번 질문의 ${j + 1}번 선택지 내용을 입력해주세요.`
+        }
+
+        if (q.options[j].answer_option_text.length > 50) {
+          return `${i + 1}번 질문의 ${j + 1}번 선택지 내용이 제한 글자수를 초과했습니다. \n (최대 50자)`
+        }
+      }
+    }
+
+    return null
+  }
+
+  const handleSave = async () => {
+    const validationError = validate()
+    if (validationError) {
+      openAlert({
+        type: 'danger',
+        title: '입력 오류',
+        content: validationError,
+        confirmText: '확인',
+      })
+      return
+    }
+
+    setIsSubmitting(true)
+    try {
+      const result = await onSave(formData)
+      if (result.success) {
+        router.push('/admin/test')
+      } else {
+        openAlert({
+          type: 'danger',
+          title: result.message ?? '저장 실패',
+          content: result.reason ?? '저장에 실패했습니다.',
+          confirmText: '확인',
+        })
+      }
+    } catch {
+      openAlert({
+        type: 'danger',
+        title: '저장 실패',
+        content: '저장 중 오류가 발생했습니다.',
+        confirmText: '확인',
+      })
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const handlePreview = () => {
+    openModal(<TestPreviewModal formData={formData} onClose={closeModal} />)
+  }
+
+  return {
+    state: {
+      uiCategory,
+      formData,
+      isSubmitting,
+    },
+    actions: {
+      updateField,
+      updateCategory,
+      handleSave,
+      handlePreview,
+      question: {
+        add: addQuestion,
+        remove: removeQuestion,
+        update: updateQuestion,
+        reorder: reorderQuestions,
+      },
+      option: {
+        add: addOption,
+        remove: removeOption,
+        update: updateOption,
+        reorder: reorderOptions,
+      },
+    },
+  }
+}

--- a/src/app/admin/test/create/_hooks/useTestCreate.tsx
+++ b/src/app/admin/test/create/_hooks/useTestCreate.tsx
@@ -1,277 +1,50 @@
 'use client'
 
 import { useState } from 'react'
-import { useRouter } from 'next/navigation'
-import { TestFormData, Question, Option } from '../_types'
+import { TestFormData } from '../_types'
 import { DEFAULT_TEMPLATES } from '../_constants/presets'
 import { createTestAction } from '../../_actions/testActions'
-import { useModalStore } from '@/store/useModalStore'
-import { TestPreviewModal } from '../_components/TestPreviewModal'
+import { useTestForm } from '../../_hooks/useTestForm'
+
+const generateId = (prefix: string) =>
+  `${prefix}-${Math.random().toString(36).substring(2, 9)}`
 
 export const useTestCreate = () => {
-  const router = useRouter()
-  const { openAlert, openModal, closeModal } = useModalStore()
-  const [uiCategory, setUiCategory] = useState<string>('PREFERENCE')
-  const [isSubmitting, setIsSubmitting] = useState(false)
-
-  const generateUniqueId = (prefix: string) =>
-    `${prefix}-${Math.random().toString(36).substring(2, 9)}`
-
-  const [formData, setFormData] = useState<TestFormData>(() => ({
+  const [initialData] = useState<TestFormData>(() => ({
     name: '',
     description: '',
     profiling_type: 'PREFERENCE',
     questions: (DEFAULT_TEMPLATES['PREFERENCE'] || []).map((q, idx) => ({
       ...q,
-      key: generateUniqueId(q.question_key),
+      key: generateId(q.question_key),
       sort_order: idx + 1,
       options: q.options.map((o) => ({
         ...o,
-        key: generateUniqueId(o.answer_option_key),
+        key: generateId(o.answer_option_key),
       })),
     })),
   }))
 
-  const updateField = <K extends keyof TestFormData>(
-    key: K,
-    value: TestFormData[K]
-  ) => {
-    setFormData((prev) => ({ ...prev, [key]: value }))
-  }
-
-  const updateCategory = (categoryName: string) => {
-    setUiCategory(categoryName)
-
-    setFormData((prev) => ({
-      ...prev,
-      profiling_type: categoryName,
-      questions: (DEFAULT_TEMPLATES[categoryName] || []).map((q, idx) => ({
-        ...q,
-        key: generateUniqueId(q.question_key),
-        sort_order: idx + 1,
-        options: q.options.map((o) => ({
-          ...o,
-          key: generateUniqueId(o.answer_option_key),
+  return useTestForm({
+    initialData,
+    onSave: (formData) =>
+      createTestAction({
+        name: formData.name,
+        description: formData.description,
+        profiling_type: formData.profiling_type,
+        questions: formData.questions.map((q) => ({
+          question_key: q.question_key,
+          question_text: q.question_text,
+          selection_type: q.selection_type,
+          is_required: q.is_required,
+          sort_order: q.sort_order,
+          options: q.options.map((o) => ({
+            answer_option_key: o.answer_option_key,
+            answer_option_text: o.answer_option_text,
+            sort_order: o.sort_order,
+          })),
         })),
-      })),
-    }))
-  }
-
-  // --- Question Actions ---
-  const addQuestion = () => {
-    const newQuestion: Question = {
-      key: generateUniqueId('mood'),
-      question_key: 'mood',
-      question_text: '',
-      selection_type: 'SINGLE',
-      is_required: true,
-      sort_order: formData.questions.length + 1,
-      options: [],
-    }
-    setFormData((prev) => ({
-      ...prev,
-      questions: [...prev.questions, newQuestion],
-    }))
-  }
-
-  const removeQuestion = (qKey: string) => {
-    setFormData((prev) => {
-      const filtered = prev.questions.filter((q) => q.key !== qKey)
-      // 삭제 후 순서(sort_order) 재정렬
-      const reordered = filtered.map((q, idx) => ({
-        ...q,
-        sort_order: idx + 1,
-      }))
-      return { ...prev, questions: reordered }
-    })
-  }
-
-  const updateQuestion = (qKey: string, updates: Partial<Question>) => {
-    setFormData((prev) => ({
-      ...prev,
-      questions: prev.questions.map((q) =>
-        q.key === qKey ? { ...q, ...updates } : q
-      ),
-    }))
-  }
-
-  const reorderQuestions = (questions: Question[]) => {
-    const reordered = questions.map((q, idx) => ({ ...q, sort_order: idx + 1 }))
-    setFormData((prev) => ({ ...prev, questions: reordered }))
-  }
-
-  // --- Option Actions ---
-  const modifyQuestionOptions = (
-    qKey: string,
-    transformer: (options: Option[]) => Option[]
-  ) => {
-    setFormData((prev) => ({
-      ...prev,
-      questions: prev.questions.map((q) =>
-        q.key === qKey ? { ...q, options: transformer(q.options) } : q
-      ),
-    }))
-  }
-
-  const addOption = (qKey: string) => {
-    modifyQuestionOptions(qKey, (options) => {
-      const newOption: Option = {
-        key: generateUniqueId('opt'),
-        answer_option_key: generateUniqueId('opt'),
-        answer_option_text: '',
-        sort_order: options.length + 1,
-      }
-      return [...options, newOption]
-    })
-  }
-
-  const removeOption = (qKey: string, optKey: string) => {
-    modifyQuestionOptions(qKey, (options) => {
-      const filtered = options.filter((o) => o.key !== optKey)
-      return filtered.map((o, idx) => ({ ...o, sort_order: idx + 1 }))
-    })
-  }
-
-  const updateOption = (
-    qKey: string,
-    optKey: string,
-    updates: Partial<Option>
-  ) => {
-    modifyQuestionOptions(qKey, (options) =>
-      options.map((o) => (o.key === optKey ? { ...o, ...updates } : o))
-    )
-  }
-
-  const reorderOptions = (qKey: string, options: Option[]) => {
-    const reordered = options.map((o, idx) => ({ ...o, sort_order: idx + 1 }))
-    updateQuestion(qKey, { options: reordered })
-  }
-
-  const validate = (): string | null => {
-    if (!formData.name.trim()) {
-      return '테스트 이름을 입력해주세요.'
-    }
-
-    if (formData.questions.length === 0) {
-      return '테스트 질문을 1개 이상 추가해주세요.'
-    }
-
-    const questionKeys = formData.questions.map((q) => q.question_key)
-    if (new Set(questionKeys).size !== questionKeys.length) {
-      return '중복된 유형의 질문이 있습니다. 각 질문 유형은 한 번만 사용할 수 있습니다.'
-    }
-
-    for (let i = 0; i < formData.questions.length; i++) {
-      const q = formData.questions[i]
-
-      if (!q.question_text.trim()) {
-        return `${i + 1}번 질문의 내용을 입력해주세요.`
-      }
-
-      if (q.question_text.length > 50) {
-        return `${i + 1}번 질문의 내용이 제한 글자수를 초과했습니다. \n(최대 50자)`
-      }
-
-      if (q.options.length === 0) {
-        return `${i + 1}번 질문의 답변 선택지를 1개 이상 추가해주세요.`
-      }
-
-      for (let j = 0; j < q.options.length; j++) {
-        if (!q.options[j].answer_option_text.trim()) {
-          return `${i + 1}번 질문의 ${j + 1}번 선택지 내용을 입력해주세요.`
-        }
-
-        if (q.options[j].answer_option_text.length > 50) {
-          return `${i + 1}번 질문의 ${j + 1}번 선택지 내용이 제한 글자수를 초과했습니다. \n (최대 50자)`
-        }
-      }
-    }
-
-    return null
-  }
-
-  const handleSave = async () => {
-    const validationError = validate()
-    if (validationError) {
-      openAlert({
-        type: 'danger',
-        title: '입력 오류',
-        content: validationError,
-        confirmText: '확인',
-      })
-      return
-    }
-
-    const payload = {
-      name: formData.name,
-      description: formData.description,
-      profiling_type: formData.profiling_type,
-      questions: formData.questions.map((q) => ({
-        question_key: q.question_key,
-        question_text: q.question_text,
-        selection_type: q.selection_type,
-        is_required: q.is_required,
-        sort_order: q.sort_order,
-        options: q.options.map((o) => ({
-          answer_option_key: o.answer_option_key,
-          answer_option_text: o.answer_option_text,
-          sort_order: o.sort_order,
-        })),
-      })),
-    }
-
-    setIsSubmitting(true)
-    try {
-      const result = await createTestAction(payload)
-      if (result.success) {
-        router.push('/admin/test')
-      } else {
-        openAlert({
-          type: 'danger',
-          title: result.message ?? '테스트 생성 실패',
-          content: result.reason ?? '테스트 생성에 실패했습니다.',
-          confirmText: '확인',
-        })
-      }
-    } catch {
-      openAlert({
-        type: 'danger',
-        title: '테스트 생성 실패',
-        content: '테스트 생성 중 오류가 발생했습니다.',
-        confirmText: '확인',
-      })
-    } finally {
-      setIsSubmitting(false)
-    }
-  }
-
-  const handlePreview = () => {
-    openModal(<TestPreviewModal formData={formData} onClose={closeModal} />)
-  }
-
-  return {
-    state: {
-      uiCategory,
-      formData,
-      isSubmitting,
-    },
-    actions: {
-      updateField,
-      updateCategory,
-      handleSave,
-      handlePreview,
-      question: {
-        add: addQuestion,
-        remove: removeQuestion,
-        update: updateQuestion,
-        reorder: reorderQuestions,
-      },
-      option: {
-        add: addOption,
-        remove: removeOption,
-        update: updateOption,
-        reorder: reorderOptions,
-      },
-    },
-  }
+      }),
+    resetQuestionsOnCategoryChange: true,
+  })
 }

--- a/src/app/admin/test/create/layout.tsx
+++ b/src/app/admin/test/create/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: '어드민 테스트 생성',
+}
+
+export default function TestCreateLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return children
+}

--- a/src/app/admin/test/edit/[id]/_hooks/useTestEdit.tsx
+++ b/src/app/admin/test/edit/[id]/_hooks/useTestEdit.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { TestFormData } from '@/app/admin/test/create/_types'
+import { updateTestAction } from '@/app/admin/test/_actions/testActions'
+import { useTestForm } from '@/app/admin/test/_hooks/useTestForm'
+
+export const useTestEdit = (testId: number, initialData: TestFormData) => {
+  return useTestForm({
+    initialData,
+    onSave: (formData) =>
+      updateTestAction(testId, {
+        name: formData.name,
+        description: formData.description,
+        questions: formData.questions.map((q) => ({
+          question_key: q.question_key,
+          question_text: q.question_text,
+          selection_type: q.selection_type,
+          is_required: q.is_required,
+          sort_order: q.sort_order,
+          options: q.options.map((o) => ({
+            answer_option_key: o.answer_option_key,
+            answer_option_text: o.answer_option_text,
+            sort_order: o.sort_order,
+          })),
+        })),
+      }),
+  })
+}

--- a/src/app/admin/test/edit/[id]/_page/TestEditContent.tsx
+++ b/src/app/admin/test/edit/[id]/_page/TestEditContent.tsx
@@ -99,6 +99,7 @@ export default function TestEditContent({
                 activeTab={state.uiCategory}
                 onChange={(id) => actions.updateCategory(id)}
                 fullWidth
+                disabled
               />
             </div>
 

--- a/src/app/admin/test/edit/[id]/_page/TestEditContent.tsx
+++ b/src/app/admin/test/edit/[id]/_page/TestEditContent.tsx
@@ -2,7 +2,6 @@
 
 import Link from 'next/link'
 import { Reorder } from 'motion/react'
-import type { Metadata } from 'next'
 import {
   AdminListCard,
   AdminPageHeader,
@@ -10,18 +9,27 @@ import {
 } from '@/app/admin/_components'
 import Button from '@/components/common/Button'
 import { LoadingSpinner } from '@/components/common/LoadingSpinner'
-import { useTestCreate } from '@/app/admin/test/create/_hooks'
+import { useTestEdit } from '../_hooks/useTestEdit'
 import { QuestionForm } from '@/app/admin/test/create/_components'
 import { Question } from '@/app/admin/test/create/_types'
 import { TEST_TYPE_TABS } from '@/app/admin/test/create/_constants'
+import type { TestFormData } from '@/app/admin/test/create/_types'
 
-export default function TestCreatePage() {
-  const { state, actions } = useTestCreate()
+interface TestEditContentProps {
+  testId: number
+  initialData: TestFormData
+}
+
+export default function TestEditContent({
+  testId,
+  initialData,
+}: TestEditContentProps) {
+  const { state, actions } = useTestEdit(testId, initialData)
 
   return (
     <div className="flex min-w-[600px] flex-col gap-8">
       <AdminPageHeader
-        title="새 테스트 생성"
+        title="테스트 수정"
         leftContent={
           <Link
             href="/admin/test"
@@ -110,22 +118,6 @@ export default function TestCreatePage() {
                 className="border-gray-light min-h-[120px] w-full rounded-2xl border bg-gray-50/50 p-6 text-sm outline-none focus:border-violet-300 focus:bg-white"
                 maxLength={100}
               />
-            </div>
-          </div>
-
-          <div className="flex items-start gap-4 rounded-2xl border border-blue-100 bg-blue-50/50 p-5">
-            <div className="mt-1 flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-blue-800 text-xs font-bold text-blue-800">
-              i
-            </div>
-            <div className="space-y-1">
-              <h4 className="text-sm font-bold text-blue-900">
-                노출 상태 안내
-              </h4>
-              <p className="text-xs leading-relaxed text-blue-700 opacity-80">
-                새로 생성되는 테스트는 기본적으로{' '}
-                <span className="font-bold underline">비노출</span> 상태로
-                저장됩니다. 노출 설정은 목록에서 변경할 수 있습니다.
-              </p>
             </div>
           </div>
         </div>

--- a/src/app/admin/test/edit/[id]/page.tsx
+++ b/src/app/admin/test/edit/[id]/page.tsx
@@ -1,0 +1,55 @@
+import { notFound } from 'next/navigation'
+import type { Metadata } from 'next'
+import { fetchAdminTestDetail } from '@/app/admin/test/_api/adminFetchTestDetail'
+import type { TestFormData } from '@/app/admin/test/create/_types'
+import TestEditContent from './_page/TestEditContent'
+
+export const dynamic = 'force-dynamic'
+
+export const metadata: Metadata = {
+  title: '어드민 테스트 수정',
+}
+
+interface TestEditPageProps {
+  params: Promise<{ id: string }>
+}
+
+export default async function TestEditPage({ params }: TestEditPageProps) {
+  const { id } = await params
+  const testId = Number(id)
+
+  if (isNaN(testId)) notFound()
+
+  let initialData: TestFormData | undefined
+
+  try {
+    const result = await fetchAdminTestDetail(testId)
+    const item = result.data
+
+    initialData = {
+      name: item.name,
+      description: item.description ?? '',
+      profiling_type: item.profiling_type,
+      questions: item.questions.map((q, idx) => ({
+        key: q.id.toString(),
+        question_key: q.question_key,
+        question_text: q.question_text,
+        selection_type: q.selection_type,
+        is_required: q.is_required,
+        sort_order: idx + 1,
+        options: q.options.map((o, oIdx) => ({
+          key: o.id.toString(),
+          answer_option_key: o.answer_option_key,
+          answer_option_text: o.answer_option_text,
+          sort_order: oIdx + 1,
+        })),
+      })),
+    }
+  } catch {
+    notFound()
+  }
+
+  if (!initialData) notFound()
+
+  return <TestEditContent testId={testId} initialData={initialData} />
+}


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->

테스트 목록에 수정 버튼을 추가하고 수정 페이지를 구현 중복된 훅 로직을 `useTestForm`으로 통합

## 📌 관련 이슈

<!-- Closes #이슈번호 -->

Closes #183

## 🧩 작업 내용 (주요 변경사항)

- 테스트 목록에 수정 버튼 추가
- /admin/test/edit/[id] RSC 페이지 및 TestEditContent 구현
- useTestForm 공통 훅 추출
- useTestCreate/useTestEdit를 wrapper로 전환
- patchAdminTestPublish → toggleAdminTestPublish 명칭 수정
- 테스트 생성 페이지 metadata를 layout.tsx로 분리

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

https://github.com/user-attachments/assets/1f9d5609-8d4c-4b7f-9ead-6eaf5b7d291e


## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료
