### PR TITLE
[Feat] 어드민 추천관리 파이프라인 스냅샷 생성 기능 추가 (#185)

### DIFF
--- a/src/app/admin/recommend/_actions/recommendActions.ts
+++ b/src/app/admin/recommend/_actions/recommendActions.ts
@@ -12,13 +12,22 @@ import {
   createAdminProductPool,
   createAdminProductMap,
 } from '../_api/adminCreateRecommend'
+import { createAdminPipelineSnapshot } from '../_api/adminCreatePipeline'
 import { RECOMMEND_API } from '../_api'
 import {
   RecommendTabId,
   ProductPoolCreateBody,
   ProductPoolsListResponse,
+  BlendMapsListResponse,
+  ProductMapsListResponse,
+  PipelineSnapshotBody,
 } from '../_types'
+import { fetchAdminTests } from '@/app/admin/test/_api/adminFetchTest'
+import { TestListResponse } from '@/app/admin/test/_types'
 import { extractError } from '@/app/admin/_lib/actionUtils'
+
+const REVALIDATE_DELAY_MS = 100
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
 /**
  * 채택된 제품 후보군 목록 조회 Server Action
@@ -35,7 +44,7 @@ export async function fetchAdoptedPoolsAction(): Promise<ProductPoolsListRespons
     return {
       success: false,
       data: { results: [], page: 1, size: 5, count: 0, total_pages: 0 },
-    } as ProductPoolsListResponse
+    }
   }
 }
 
@@ -45,7 +54,7 @@ export async function fetchAdoptedPoolsAction(): Promise<ProductPoolsListRespons
 export async function deleteRecommendAction(tabId: RecommendTabId, id: number) {
   try {
     await deleteAdminRecommend(tabId, id)
-
+    await delay(REVALIDATE_DELAY_MS)
     revalidatePath('/admin/recommend')
 
     return { success: true as const }
@@ -74,6 +83,7 @@ export async function toggleRecommendStatusAction(
       )
     }
 
+    await delay(REVALIDATE_DELAY_MS)
     revalidatePath('/admin/recommend')
     return { success: true as const }
   } catch (error) {
@@ -87,7 +97,7 @@ export async function toggleRecommendStatusAction(
 export async function createProductPoolAction(body: ProductPoolCreateBody) {
   try {
     await createAdminProductPool(body)
-
+    await delay(REVALIDATE_DELAY_MS)
     revalidatePath('/admin/recommend')
     return { success: true as const }
   } catch (error) {
@@ -101,7 +111,7 @@ export async function createProductPoolAction(body: ProductPoolCreateBody) {
 export async function createProductMapAction(product_pool_id: number) {
   try {
     await createAdminProductMap(product_pool_id)
-
+    await delay(REVALIDATE_DELAY_MS)
     revalidatePath('/admin/recommend')
     return { success: true as const }
   } catch (error) {
@@ -115,10 +125,72 @@ export async function createProductMapAction(product_pool_id: number) {
 export async function createBlendMapAction(input_type: string) {
   try {
     await createAdminBlendMap(input_type)
-
+    await delay(REVALIDATE_DELAY_MS)
     revalidatePath('/admin/recommend')
     return { success: true as const }
   } catch (error) {
     return { success: false as const, ...extractError(error) }
+  }
+}
+
+/**
+ * 파이프라인 스냅샷 생성 Server Action
+ */
+export async function createPipelineSnapshotAction(body: PipelineSnapshotBody) {
+  try {
+    await createAdminPipelineSnapshot(body)
+    await delay(REVALIDATE_DELAY_MS)
+    revalidatePath('/admin/recommend')
+    return { success: true as const }
+  } catch (error) {
+    return { success: false as const, ...extractError(error) }
+  }
+}
+
+/**
+ * 발행 중인 향조합 추천맵 목록 조회 (파이프라인 폼 드롭다운용)
+ */
+export async function fetchPublishedBlendMapsAction(): Promise<BlendMapsListResponse> {
+  try {
+    return await RECOMMEND_API.blendMaps({
+      publish_status: 'PUBLISHED',
+      size: 4,
+    })
+  } catch {
+    return {
+      success: false,
+      data: { results: [], page: 1, size: 4, count: 0, total_pages: 0 },
+    }
+  }
+}
+
+/**
+ * 발행 중인 제품 추천맵 목록 조회 (파이프라인 폼 드롭다운용)
+ */
+export async function fetchPublishedProductMapsAction(): Promise<ProductMapsListResponse> {
+  try {
+    return await RECOMMEND_API.productMaps({
+      publish_status: 'PUBLISHED',
+      size: 2,
+    })
+  } catch {
+    return {
+      success: false,
+      data: { results: [], page: 1, size: 2, count: 0, total_pages: 0 },
+    }
+  }
+}
+
+/**
+ * 발행 중인 테스트 목록 조회 (파이프라인 폼 드롭다운용)
+ */
+export async function fetchPublishedTestsAction(): Promise<TestListResponse> {
+  try {
+    return await fetchAdminTests({ publish_status: 'PUBLISHED', size: 4 })
+  } catch {
+    return {
+      success: false,
+      data: { results: [], page: 1, size: 4, count: 0, total_pages: 0 },
+    }
   }
 }

--- a/src/app/admin/recommend/_api/adminCreatePipeline.ts
+++ b/src/app/admin/recommend/_api/adminCreatePipeline.ts
@@ -1,0 +1,11 @@
+import { authFetch } from '@/lib/api'
+import { PipelineSnapshotBody, PipelineSnapshotResponse } from '../_types'
+
+/**
+ * 파이프라인 스냅샷 생성 API
+ * POST /api/v1/admin/matches/pipeline/snapshot
+ */
+export const createAdminPipelineSnapshot = (
+  body: PipelineSnapshotBody
+): Promise<PipelineSnapshotResponse> =>
+  authFetch.post('/api/v1/admin/matches/pipeline/snapshot', body)

--- a/src/app/admin/recommend/_api/index.ts
+++ b/src/app/admin/recommend/_api/index.ts
@@ -1,3 +1,4 @@
 export * from './adminFetchRecommend'
 export * from './adminPatchRecommend'
 export * from './adminCreateRecommend'
+export * from './adminCreatePipeline'

--- a/src/app/admin/recommend/_page/PipelineForm.tsx
+++ b/src/app/admin/recommend/_page/PipelineForm.tsx
@@ -1,0 +1,237 @@
+'use client'
+
+import React, { use, useEffect } from 'react'
+import { cn } from '@/lib/cn'
+import { TYPE_LABELS, PRODUCT_TYPE_LABELS } from '@/app/admin/_constants/labels'
+import { formatDate } from '@/app/admin/_utils'
+import {
+  BlendMapsListResponse,
+  ProductMapsListResponse,
+  PipelineSnapshotBody,
+} from '../_types'
+import { TestListResponse } from '@/app/admin/test/_types'
+
+interface PipelineFormProps {
+  formData: PipelineSnapshotBody
+  onChange: (updates: Partial<PipelineSnapshotBody>) => void
+  blendMapsPromise: Promise<BlendMapsListResponse>
+  productMapsPromise: Promise<ProductMapsListResponse>
+  testsPromise: Promise<TestListResponse>
+}
+
+export const PipelineForm = ({
+  formData,
+  onChange,
+  blendMapsPromise,
+  productMapsPromise,
+  testsPromise,
+}: PipelineFormProps) => {
+  const blendMapsRes = use(blendMapsPromise)
+  const productMapsRes = use(productMapsPromise)
+  const testsRes = use(testsPromise)
+
+  const blendMaps = blendMapsRes?.data?.results ?? []
+  const productMaps = productMapsRes?.data?.results ?? []
+  const tests = testsRes?.data?.results ?? []
+
+  // 첫 항목 자동 선택
+  useEffect(() => {
+    if (blendMaps.length > 0 && formData.blend_match_map_id === 0) {
+      onChange({
+        blend_match_map_id: blendMaps[0].id,
+        input_type: blendMaps[0].input_type,
+      })
+    }
+  }, [blendMaps])
+
+  useEffect(() => {
+    if (productMaps.length > 0 && formData.product_match_map_id === 0) {
+      onChange({ product_match_map_id: productMaps[0].id })
+    }
+  }, [productMaps])
+
+  return (
+    <div className="flex max-h-[60vh] flex-col gap-6 overflow-y-auto py-4 pr-1">
+      {/* 향조합 추천맵 선택 */}
+      <div className="flex flex-col gap-2">
+        <label className="text-base font-bold">
+          향조합 추천맵 <span className="text-red-500">*</span>
+        </label>
+        {blendMaps.length > 0 ? (
+          <div className="flex flex-col gap-1.5">
+            {blendMaps.map((m) => (
+              <button
+                key={m.id}
+                type="button"
+                onClick={() =>
+                  onChange({
+                    blend_match_map_id: m.id,
+                    input_type: m.input_type,
+                  })
+                }
+                className={cn(
+                  'border-gray-light flex cursor-pointer items-center gap-3 rounded-lg border p-3 transition-colors',
+                  formData.blend_match_map_id === m.id
+                    ? 'bg-gray-white'
+                    : 'text-gray-primary'
+                )}
+              >
+                <span
+                  className={cn(
+                    'h-3.5 w-3.5 rounded-full border-2',
+                    formData.blend_match_map_id === m.id
+                      ? 'border-black-primary bg-black-primary'
+                      : 'border-gray-light'
+                  )}
+                />
+                <span>
+                  #{m.id} · {TYPE_LABELS[m.input_type] ?? m.input_type}
+                </span>
+                <span className="text-gray-secondary ml-auto text-xs">
+                  {formatDate(m.created_at)}
+                </span>
+              </button>
+            ))}
+          </div>
+        ) : (
+          <div className="bg-gray-white text-gray-secondary rounded-lg py-6 text-center text-sm">
+            발행 중인 향조합 추천맵이 없습니다.
+          </div>
+        )}
+      </div>
+
+      {/* 제품 추천맵 선택 */}
+      <div className="flex flex-col gap-2">
+        <label className="text-base font-bold">
+          제품 추천맵 <span className="text-red-500">*</span>
+        </label>
+        {productMaps.length > 0 ? (
+          <div className="flex flex-col gap-1.5">
+            {productMaps.map((m) => (
+              <button
+                key={m.id}
+                type="button"
+                onClick={() => onChange({ product_match_map_id: m.id })}
+                className={cn(
+                  'border-gray-light flex cursor-pointer items-center gap-3 rounded-lg border p-3 transition-colors',
+                  formData.product_match_map_id === m.id
+                    ? 'bg-gray-white'
+                    : 'text-gray-primary'
+                )}
+              >
+                <span
+                  className={cn(
+                    'h-3.5 w-3.5 rounded-full border-2',
+                    formData.product_match_map_id === m.id
+                      ? 'border-black-primary bg-black-primary'
+                      : 'border-gray-light'
+                  )}
+                />
+                <span>
+                  #{m.id}{' '}
+                  <span className="text-[14px]">
+                    제품 후보군 ID - {m.product_pool_id}
+                  </span>
+                </span>
+                <span className="text-gray-secondary ml-auto text-xs">
+                  {formatDate(m.created_at)}
+                </span>
+              </button>
+            ))}
+          </div>
+        ) : (
+          <div className="bg-gray-white text-gray-secondary rounded-lg py-6 text-center text-sm">
+            발행 중인 제품 추천맵이 없습니다.
+          </div>
+        )}
+      </div>
+
+      {/* 제품 유형 선택 */}
+      <div className="flex flex-col gap-2">
+        <label className="text-base font-bold">
+          제품 유형 <span className="text-red-500">*</span>
+        </label>
+        <div className="flex gap-2">
+          {Object.entries(PRODUCT_TYPE_LABELS).map(([value, label]) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => onChange({ product_type: value })}
+              className={cn(
+                'flex-1 cursor-pointer rounded-xl py-2.5 text-sm font-semibold transition-all',
+                formData.product_type === value
+                  ? 'bg-black-primary text-white'
+                  : 'bg-gray-light'
+              )}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* 테스트 선택 (optional) */}
+      <div className="flex flex-col gap-2">
+        <label className="text-base font-bold">
+          연결할 테스트{' '}
+          <span className="text-xs font-normal text-gray-400">(선택)</span>
+        </label>
+        <div className="flex flex-col gap-1.5">
+          <button
+            type="button"
+            onClick={() => onChange({ profiling_form_id: undefined })}
+            className={cn(
+              'border-gray-light flex cursor-pointer items-center gap-3 rounded-lg border p-3 transition-colors',
+              formData.profiling_form_id === undefined
+                ? 'bg-gray-white'
+                : 'text-gray-primary'
+            )}
+          >
+            <span
+              className={cn(
+                'h-3.5 w-3.5 rounded-full border-2',
+                formData.profiling_form_id === undefined
+                  ? 'border-black-primary bg-black-primary'
+                  : 'border-gray-light'
+              )}
+            />
+            <span>연결 안 함</span>
+          </button>
+          {tests.map((t) => (
+            <button
+              key={t.id}
+              type="button"
+              onClick={() => onChange({ profiling_form_id: t.id })}
+              className={cn(
+                'border-gray-light flex cursor-pointer items-center gap-3 rounded-lg border p-3 transition-colors',
+                formData.profiling_form_id === t.id
+                  ? 'bg-gray-white'
+                  : 'text-gray-primary'
+              )}
+            >
+              <span
+                className={cn(
+                  'h-3.5 w-3.5 rounded-full border-2',
+                  formData.profiling_form_id === t.id
+                    ? 'border-black-primary bg-black-primary'
+                    : 'border-gray-light'
+                )}
+              />
+              <span>
+                #{t.id} · {t.name}
+              </span>
+              <span className="text-gray-secondary ml-auto text-xs">
+                {TYPE_LABELS[t.profiling_type] ?? t.profiling_type}
+              </span>
+            </button>
+          ))}
+          {tests.length === 0 && (
+            <div className="bg-gray-white text-gray-secondary rounded-lg py-4 text-center text-sm">
+              발행 중인 테스트가 없습니다.
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/admin/recommend/_page/RecommendAdminContent.tsx
+++ b/src/app/admin/recommend/_page/RecommendAdminContent.tsx
@@ -9,6 +9,7 @@ import {
   AdminTableError,
   AdminTableLoading,
 } from '@/app/admin/_components'
+import Button from '@/components/common/Button'
 import { RECOMMEND_TAB_HEADERS } from '@/constants/admin'
 import { RecommendTabId, RECOMMEND_TABS } from '@/app/admin/recommend/_types'
 import { RecommendPostModal } from '@/app/admin/recommend/_page'
@@ -43,6 +44,10 @@ export default function RecommendAdminContent({
     openModal(<RecommendPostModal activeTab={activeTab} />)
   }
 
+  const handleOpenPipelineModal = () => {
+    openModal(<RecommendPostModal activeTab="pipeline" />)
+  }
+
   return (
     <AdminListCard className={cn(isPending && 'pointer-events-none')}>
       <AdminPageHeader
@@ -57,11 +62,21 @@ export default function RecommendAdminContent({
         onFilterChange={onFilterChange}
         onReset={() => resetParams(['status', 'input_type'])}
       />
-      <AdminTabGroup
-        tabs={RECOMMEND_TABS}
-        activeTab={activeTab}
-        onChange={onTabChange}
-      />
+      <div className="flex items-center justify-between">
+        <AdminTabGroup
+          tabs={RECOMMEND_TABS}
+          activeTab={activeTab}
+          onChange={onTabChange}
+        />
+        <Button
+          color="primary"
+          rounded="sm"
+          onClick={handleOpenPipelineModal}
+          className="mb-4 shrink-0 text-sm font-semibold"
+        >
+          파이프라인 생성
+        </Button>
+      </div>
       <AdminTable headers={RECOMMEND_TAB_HEADERS[activeTab]}>
         <ErrorBoundary fallback={<AdminTableError />}>
           <Suspense

--- a/src/app/admin/recommend/_page/RecommendPostModal.tsx
+++ b/src/app/admin/recommend/_page/RecommendPostModal.tsx
@@ -16,12 +16,18 @@ import {
   createBlendMapAction,
   createProductPoolAction,
   createProductMapAction,
+  createPipelineSnapshotAction,
   fetchAdoptedPoolsAction,
+  fetchPublishedBlendMapsAction,
+  fetchPublishedProductMapsAction,
+  fetchPublishedTestsAction,
 } from '../_actions/recommendActions'
+import { PipelineSnapshotBody } from '../_types'
+import { PipelineForm } from './PipelineForm'
 import { LoadingSpinner } from '@/components/common/LoadingSpinner'
 
 interface RecommendPostModalProps {
-  activeTab: RecommendTabId
+  activeTab: RecommendTabId | 'pipeline'
 }
 
 // 제품 추천맵 폼 로딩
@@ -36,7 +42,9 @@ export const RecommendPostModal = ({ activeTab }: RecommendPostModalProps) => {
   const [isSubmitting, setIsSubmitting] = useState(false)
 
   const activeTabLabel =
-    RECOMMEND_TABS.find((t) => t.id === activeTab)?.label || ''
+    activeTab === 'pipeline'
+      ? '파이프라인'
+      : RECOMMEND_TABS.find((t) => t.id === activeTab)?.label || ''
 
   // 각 탭별 폼 default 값 설정
   const [formData, setFormData] = useState({
@@ -63,9 +71,30 @@ export const RecommendPostModal = ({ activeTab }: RecommendPostModalProps) => {
     typeof fetchAdoptedPoolsAction
   > | null>(null)
 
+  const [pipelinePromises, setPipelinePromises] = useState<{
+    blendMaps: ReturnType<typeof fetchPublishedBlendMapsAction>
+    productMaps: ReturnType<typeof fetchPublishedProductMapsAction>
+    tests: ReturnType<typeof fetchPublishedTestsAction>
+  } | null>(null)
+
+  const [pipelineData, setPipelineData] = useState<PipelineSnapshotBody>({
+    input_type: 'PREFERENCE',
+    product_type: 'DIFFUSER',
+    profiling_form_id: undefined,
+    blend_match_map_id: 0,
+    product_match_map_id: 0,
+  })
+
   useEffect(() => {
     if (activeTab === 'product-maps') {
       setPoolsPromise(fetchAdoptedPoolsAction())
+    }
+    if (activeTab === 'pipeline') {
+      setPipelinePromises({
+        blendMaps: fetchPublishedBlendMapsAction(),
+        productMaps: fetchPublishedProductMapsAction(),
+        tests: fetchPublishedTestsAction(),
+      })
     }
   }, [activeTab])
 
@@ -124,6 +153,29 @@ export const RecommendPostModal = ({ activeTab }: RecommendPostModalProps) => {
           })
           return
         }
+      } else if (activeTab === 'pipeline') {
+        if (
+          !pipelineData.blend_match_map_id ||
+          !pipelineData.product_match_map_id
+        ) {
+          openAlert({
+            type: 'danger',
+            title: '입력 오류',
+            content: '향조합 추천맵과 제품 추천맵을 선택해주세요.',
+            confirmText: '확인',
+          })
+          return
+        }
+        const result = await createPipelineSnapshotAction(pipelineData)
+        if (!result.success) {
+          openAlert({
+            type: 'danger',
+            title: result.message ?? '등록 실패',
+            content: result.reason ?? '파이프라인 생성에 실패했습니다.',
+            confirmText: '확인',
+          })
+          return
+        }
       }
       closeModal()
     } finally {
@@ -156,6 +208,22 @@ export const RecommendPostModal = ({ activeTab }: RecommendPostModalProps) => {
                 value={formData.product_pool_id}
                 onChange={(val) => handleChange('product_pool_id', Number(val))}
                 poolsPromise={poolsPromise}
+              />
+            )}
+          </Suspense>
+        )
+      case 'pipeline':
+        return (
+          <Suspense fallback={<ProductMapsFormFallback />}>
+            {pipelinePromises && (
+              <PipelineForm
+                formData={pipelineData}
+                onChange={(updates) =>
+                  setPipelineData((prev) => ({ ...prev, ...updates }))
+                }
+                blendMapsPromise={pipelinePromises.blendMaps}
+                productMapsPromise={pipelinePromises.productMaps}
+                testsPromise={pipelinePromises.tests}
               />
             )}
           </Suspense>

--- a/src/app/admin/recommend/_types/PipelineTypes.ts
+++ b/src/app/admin/recommend/_types/PipelineTypes.ts
@@ -1,0 +1,20 @@
+export interface PipelineSnapshotBody {
+  input_type: string
+  product_type: string
+  profiling_form_id?: number
+  blend_match_map_id: number
+  product_match_map_id: number
+}
+
+export interface PipelineSnapshotItem {
+  id: number
+  input_type: string
+  product_type: string
+  is_active: boolean
+  created_at: string
+}
+
+export interface PipelineSnapshotResponse {
+  success: boolean
+  data: PipelineSnapshotItem
+}

--- a/src/app/admin/recommend/_types/index.ts
+++ b/src/app/admin/recommend/_types/index.ts
@@ -1,5 +1,6 @@
 export * from './BlendMapsTypes'
 export * from './ProductPoolsTypes'
 export * from './ProductMapsTypes'
+export * from './PipelineTypes'
 export * from './RecommendTab'
 export * from './RecommendData'

--- a/src/app/admin/test/create/page.tsx
+++ b/src/app/admin/test/create/page.tsx
@@ -2,7 +2,6 @@
 
 import Link from 'next/link'
 import { Reorder } from 'motion/react'
-import type { Metadata } from 'next'
 import {
   AdminListCard,
   AdminPageHeader,


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->

추천관리에 파이프라인 스냅샷 생성 기능을 추가
blend-map + product-map + (optional)테스트를 묶는 최종 파이프라인 연결

## 📌 관련 이슈

<!-- Closes #이슈번호 -->

Closes #185 

## 🧩 작업 내용 (주요 변경사항)

- PipelineForm 컴포넌트 구현
- POST /api/v1/admin/matches/pipeline/snapshot API 및 Server Action 추가
-  파이프라인 생성 버튼 추가
- 발행 중인 blend-maps / product-maps / tests 조회 Server Action 추가

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

https://github.com/user-attachments/assets/300cec11-0aa6-4c08-8637-cabaeb7567c8


## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료
