### PR TITLE
fix: 퀴즈 다중선택 규칙·제출 UX 정리 및 결과 페이지 목 폴백 제거(#189)

### DIFF
--- a/src/app/find-my-scent/_components/ProfilingResultLoadError.tsx
+++ b/src/app/find-my-scent/_components/ProfilingResultLoadError.tsx
@@ -1,0 +1,29 @@
+import Link from 'next/link'
+
+const RETEST_HREF = {
+  PREFERENCE: '/find-my-scent/taste-test',
+  HEALTH: '/find-my-scent/wellness',
+} as const
+
+type ProfilingResultLoadErrorProps = {
+  message: string
+  resultType: keyof typeof RETEST_HREF
+}
+
+/** 실 API 환경에서 결과 조회 실패 시 (목 폴백 없음) */
+export function ProfilingResultLoadError({
+  message,
+  resultType,
+}: ProfilingResultLoadErrorProps) {
+  return (
+    <div className="flex min-h-[50vh] flex-col items-center justify-center gap-4 bg-[var(--background-light-bg)] px-4 py-16 text-center">
+      <p className="max-w-md text-sm text-neutral-600">{message}</p>
+      <Link
+        href={RETEST_HREF[resultType]}
+        className="rounded-xl bg-[var(--color-black-primary)] px-6 py-3 text-sm font-medium text-white transition-opacity hover:opacity-90"
+      >
+        테스트 다시 하기
+      </Link>
+    </div>
+  )
+}

--- a/src/app/find-my-scent/_components/QuizView.tsx
+++ b/src/app/find-my-scent/_components/QuizView.tsx
@@ -1,17 +1,12 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import type { ProfilingType, QuizQuestion, TestType } from '../_types'
 import type { ProductTypeChoice } from './ProductTypeSelectModal'
 import { useQuizStep } from '../_hooks'
 import { buildSubmitPayload, submitProfiling } from '../_api/profilingClient'
 import { ErrorFeedbackModal } from '@/components/common/ErrorFeedback'
-import {
-  AlertModal,
-  ModalOverlay,
-  ModalPortal,
-} from '@/components/common/Modal'
 import { TestQuizHeader } from './TestQuizHeader'
 import { TestProgressBar } from './TestProgressBar'
 import { TestQuestionCard } from './TestQuestionCard'
@@ -21,10 +16,6 @@ const RESULT_PATH: Record<TestType, string> = {
   PREFERENCE: '/find-my-scent/taste-test/result',
   HEALTH: '/find-my-scent/wellness/result',
 }
-
-const MIN_SELECTION_WARNING_MESSAGE =
-  '다중선택 문제유형은 지문을 최소 2개이상 선택해야 합니다'
-const WARNING_AUTO_CLOSE_MS = 3000
 
 const styles = {
   wrap: 'min-h-screen bg-[var(--background-light-bg)] px-4 py-8',
@@ -56,8 +47,6 @@ export function QuizView({
     canGoNext,
     isFirst,
     isLast,
-    showMinSelectionWarning,
-    closeMinSelectionWarning,
     handleToggle,
     handlePrev,
     handleNext,
@@ -68,6 +57,7 @@ export function QuizView({
 
   const handleNextOrSubmit = async () => {
     if (isLast) {
+      if (isSubmitting) return
       setIsSubmitting(true)
       setSubmitError(null)
       try {
@@ -98,13 +88,6 @@ export function QuizView({
     }
     handleNext()
   }
-
-  // 다중선택 최소 개수 경고 모달 3초 후 자동 닫기
-  useEffect(() => {
-    if (!showMinSelectionWarning) return
-    const timer = setTimeout(closeMinSelectionWarning, WARNING_AUTO_CLOSE_MS)
-    return () => clearTimeout(timer)
-  }, [showMinSelectionWarning, closeMinSelectionWarning])
 
   if (!question) {
     return (
@@ -142,23 +125,6 @@ export function QuizView({
           isOpen
           onClose={() => setSubmitError(null)}
         />
-      )}
-
-      {showMinSelectionWarning && (
-        <ModalPortal>
-          <ModalOverlay onClose={closeMinSelectionWarning}>
-            <div onClick={(e) => e.stopPropagation()}>
-              <AlertModal
-                isOpen
-                onClose={closeMinSelectionWarning}
-                type="danger"
-                title="경고"
-                content={MIN_SELECTION_WARNING_MESSAGE}
-                showButtons={false}
-              />
-            </div>
-          </ModalOverlay>
-        </ModalPortal>
       )}
     </>
   )

--- a/src/app/find-my-scent/_components/TestQuizFooter.tsx
+++ b/src/app/find-my-scent/_components/TestQuizFooter.tsx
@@ -29,7 +29,8 @@ export function TestQuizFooter({
   onNext,
 }: TestQuizFooterProps) {
   const prevClassName = cn(styles.prev, isFirst && styles.prevHidden)
-  const nextDisabled = !canGoNext || isSubmitting
+  // 제출 중에도 버튼은 비활성화하지 않음(이중 제출은 상위 핸들러에서 방지)
+  const nextDisabled = !canGoNext
   const nextClassName = cn(
     styles.next,
     nextDisabled ? styles.nextInactive : styles.nextActive

--- a/src/app/find-my-scent/_hooks/useQuizStep.ts
+++ b/src/app/find-my-scent/_hooks/useQuizStep.ts
@@ -11,17 +11,13 @@ export function useQuizStep(questions: QuizQuestion[]) {
   const total = questions.length
   const [step, setStep] = useState(0)
   const [answers, setAnswers] = useState<AnswersState>({})
-  const [showMinSelectionWarning, setShowMinSelectionWarning] = useState(false)
 
   // 현재 질문 조회
   const question = questions[step]
   const selectedIds = answers[question?.id] ?? []
 
-  // 다중선택 규칙 적용
-  const minSelections = question?.questionType === 'MULTI' ? 2 : 1
-
-  // 다음 질문으로 이동 가능 여부
-  const canGoNext = !question?.required || selectedIds.length >= minSelections
+  // 다음 질문으로 이동 가능 여부 — 필수: 단일·다중 모두 1개 이상 선택
+  const canGoNext = !question?.required || selectedIds.length >= 1
   const isFirst = step === 0
   const isLast = step === total - 1
 
@@ -46,15 +42,9 @@ export function useQuizStep(questions: QuizQuestion[]) {
     if (step > 0) setStep((s) => s - 1)
   }
 
-  // 다음 질문으로 이동 핸들러 (필수 아님 + 다중선택에서 1개만 선택 시 경고 모달 표시)
+  // 다음 질문으로 이동 핸들러
   const handleNext = () => {
     if (isLast) return
-    const isMultiNotRequired =
-      question?.questionType === 'MULTI' && !question?.required
-    if (isMultiNotRequired && selectedIds.length === 1) {
-      setShowMinSelectionWarning(true)
-      return
-    }
     if (!canGoNext) return
     setStep((s) => s + 1)
   }
@@ -68,8 +58,6 @@ export function useQuizStep(questions: QuizQuestion[]) {
     canGoNext,
     isFirst,
     isLast,
-    showMinSelectionWarning,
-    closeMinSelectionWarning: () => setShowMinSelectionWarning(false),
     handleToggle,
     handlePrev,
     handleNext,

--- a/src/app/find-my-scent/_lib/loadProfilingResultPageProps.ts
+++ b/src/app/find-my-scent/_lib/loadProfilingResultPageProps.ts
@@ -1,0 +1,78 @@
+import {
+  fetchProfilingResult,
+  resultDetailToContentBoxProps,
+} from '../_api/profilingClient'
+import { mockProfilingResultDetail } from '@/mocks/data/profilingResults'
+
+const USE_MOCK = process.env.NEXT_PUBLIC_USE_MOCK_API === 'true'
+
+export type ProfilingResultPageLoad =
+  | {
+      ok: true
+      contentBoxProps: ReturnType<typeof resultDetailToContentBoxProps>
+    }
+  | { ok: false; errorMessage: string }
+
+/**
+ * 결과 페이지용 데이터 로드.
+ * - NEXT_PUBLIC_USE_MOCK_API=true: 실패·누락 시 mockProfilingResultDetail 폴백
+ * - false: 실 API만 사용, 실패 시 ok:false (목 폴백 없음)
+ */
+export async function loadProfilingResultPageProps(
+  resultIdParam: string | undefined
+): Promise<ProfilingResultPageLoad> {
+  const resultId = resultIdParam ? Number(resultIdParam) : null
+
+  if (resultId == null || !Number.isInteger(resultId) || resultId <= 0) {
+    if (USE_MOCK) {
+      return {
+        ok: true,
+        contentBoxProps: resultDetailToContentBoxProps(
+          mockProfilingResultDetail
+        ),
+      }
+    }
+    return {
+      ok: false,
+      errorMessage:
+        '결과 정보가 없습니다. 테스트를 완료한 뒤 다시 시도해 주세요.',
+    }
+  }
+
+  try {
+    const res = await fetchProfilingResult(resultId)
+    if (res.success && res.data) {
+      return {
+        ok: true,
+        contentBoxProps: resultDetailToContentBoxProps(res.data),
+      }
+    }
+    if (USE_MOCK) {
+      return {
+        ok: true,
+        contentBoxProps: resultDetailToContentBoxProps(
+          mockProfilingResultDetail
+        ),
+      }
+    }
+    return {
+      ok: false,
+      errorMessage:
+        (res as { error?: { message?: string } }).error?.message ??
+        '결과를 불러오지 못했습니다.',
+    }
+  } catch {
+    if (USE_MOCK) {
+      return {
+        ok: true,
+        contentBoxProps: resultDetailToContentBoxProps(
+          mockProfilingResultDetail
+        ),
+      }
+    }
+    return {
+      ok: false,
+      errorMessage: '결과를 불러오지 못했습니다.',
+    }
+  }
+}

--- a/src/app/find-my-scent/taste-test/result/page.tsx
+++ b/src/app/find-my-scent/taste-test/result/page.tsx
@@ -1,39 +1,27 @@
-/** 취향 테스트 결과 페이지 — result_id 있으면 API 조회, 없거나 실패 시 목데이터 */
-import {
-  fetchProfilingResult,
-  resultDetailToContentBoxProps,
-} from '../../_api/profilingClient'
+/** 취향 테스트 결과 페이지 — result_id 있으면 API 조회, 목 모드에서만 실패 시 목 폴백 */
+import { loadProfilingResultPageProps } from '../../_lib/loadProfilingResultPageProps'
+import { ProfilingResultLoadError } from '../../_components/ProfilingResultLoadError'
 import { ResultPageWithAnalyzing } from '../../_components/ResultPageWithAnalyzing'
-import { mockProfilingResultDetail } from '@/mocks/data/profilingResults'
 
 type PageProps = { searchParams: Promise<{ result_id?: string }> }
 
 export default async function TasteTestResultPage({ searchParams }: PageProps) {
   const params = await searchParams
-  const resultId = params.result_id ? Number(params.result_id) : null
+  const loaded = await loadProfilingResultPageProps(params.result_id)
 
-  let contentBoxProps: ReturnType<typeof resultDetailToContentBoxProps>
-  if (resultId != null && Number.isInteger(resultId) && resultId > 0) {
-    try {
-      const res = await fetchProfilingResult(resultId)
-      if (res.success && res.data) {
-        contentBoxProps = resultDetailToContentBoxProps(res.data)
-      } else {
-        contentBoxProps = resultDetailToContentBoxProps(
-          mockProfilingResultDetail
-        )
-      }
-    } catch {
-      contentBoxProps = resultDetailToContentBoxProps(mockProfilingResultDetail)
-    }
-  } else {
-    contentBoxProps = resultDetailToContentBoxProps(mockProfilingResultDetail)
+  if (!loaded.ok) {
+    return (
+      <ProfilingResultLoadError
+        message={loaded.errorMessage}
+        resultType="PREFERENCE"
+      />
+    )
   }
 
   return (
     <ResultPageWithAnalyzing
       resultType="PREFERENCE"
-      contentBoxProps={contentBoxProps}
+      contentBoxProps={loaded.contentBoxProps}
     />
   )
 }

--- a/src/app/find-my-scent/wellness/result/page.tsx
+++ b/src/app/find-my-scent/wellness/result/page.tsx
@@ -1,39 +1,27 @@
-/** 웰니스 테스트 결과 페이지 — result_id 있으면 API 조회, 없거나 실패 시 목데이터 */
-import {
-  fetchProfilingResult,
-  resultDetailToContentBoxProps,
-} from '../../_api/profilingClient'
+/** 웰니스 테스트 결과 페이지 — result_id 있으면 API 조회, 목 모드에서만 실패 시 목 폴백 */
+import { loadProfilingResultPageProps } from '../../_lib/loadProfilingResultPageProps'
+import { ProfilingResultLoadError } from '../../_components/ProfilingResultLoadError'
 import { ResultPageWithAnalyzing } from '../../_components/ResultPageWithAnalyzing'
-import { mockProfilingResultDetail } from '@/mocks/data/profilingResults'
 
 type PageProps = { searchParams: Promise<{ result_id?: string }> }
 
 export default async function WellnessResultPage({ searchParams }: PageProps) {
   const params = await searchParams
-  const resultId = params.result_id ? Number(params.result_id) : null
+  const loaded = await loadProfilingResultPageProps(params.result_id)
 
-  let contentBoxProps: ReturnType<typeof resultDetailToContentBoxProps>
-  if (resultId != null && Number.isInteger(resultId) && resultId > 0) {
-    try {
-      const res = await fetchProfilingResult(resultId)
-      if (res.success && res.data) {
-        contentBoxProps = resultDetailToContentBoxProps(res.data)
-      } else {
-        contentBoxProps = resultDetailToContentBoxProps(
-          mockProfilingResultDetail
-        )
-      }
-    } catch {
-      contentBoxProps = resultDetailToContentBoxProps(mockProfilingResultDetail)
-    }
-  } else {
-    contentBoxProps = resultDetailToContentBoxProps(mockProfilingResultDetail)
+  if (!loaded.ok) {
+    return (
+      <ProfilingResultLoadError
+        message={loaded.errorMessage}
+        resultType="HEALTH"
+      />
+    )
   }
 
   return (
     <ResultPageWithAnalyzing
       resultType="HEALTH"
-      contentBoxProps={contentBoxProps}
+      contentBoxProps={loaded.contentBoxProps}
     />
   )
 }


### PR DESCRIPTION
## ✨ PR 개요
- 취향/건강 **프로파일링 퀴즈**의 다중선택·다음/제출 동작을 정리했습니다.
- **실 API 환경**(`NEXT_PUBLIC_USE_MOCK_API !== 'true'`)에서 결과 페이지가 **`mockProfilingResultDetail`로 폴백되지 않도록** 변경했습니다.


## 📌 관련 이슈
<!-- Closes #이슈번호 -->
Closes #189 

## 🧩 작업 내용 (주요 변경사항)
### 퀴즈 (`useQuizStep`, `QuizView`, `TestQuizFooter`)
- **필수 + MULTI**: 최소 선택 수를 **2개 → 1개**로 맞춰, 1개만 선택해도 **다음** 버튼이 활성화되도록 수정.
- **비필수 + MULTI**: “최소 2개 이상” **경고 모달** 및 관련 `useEffect`/UI **제거**.
- **제출 UX**: `제출 중...` 표시는 유지하되, **다음(결과 보기) 버튼을 `isSubmitting`으로 비활성화하지 않음**. 이중 제출은 `handleNextOrSubmit` 내부 **`if (isSubmitting) return`** 으로 방지.
### 결과 페이지 (`taste-test/result`, `wellness/result`)
- `loadProfilingResultPageProps`로 로드 로직 공통화.
- **`NEXT_PUBLIC_USE_MOCK_API === 'true'`**: 기존처럼 실패·`result_id` 누락 시 **목 폴백** 유지.
- **그 외(실 API 개발 등)**: API 실패·잘못된 응답·`result_id` 없음 시 **목 대신** `ProfilingResultLoadError`로 안내 + **테스트 다시 하기** 링크.


## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료
