### PR TITLE
fix: S3 presigned 연동용 presigned-url·analyze 라우트 프록시 (#191)

### DIFF
--- a/src/app/api/v1/profilings/images/analyze/route.ts
+++ b/src/app/api/v1/profilings/images/analyze/route.ts
@@ -1,14 +1,29 @@
 /**
- * AI 분석 테스트 제출 (MSW 미가로챔 시 fallback)
+ * AI 분석 테스트 제출
  * POST /api/v1/profilings/images/analyze
  * Body: { image_url, image_type (OOTD|INTERIOR), product_type (DIFFUSER|PERFUME) }
+ *
+ * - NEXT_PUBLIC_USE_MOCK_API=true: 로컬 mock result_id
+ * - 그 외: 백엔드 프록시
  */
+import { cookies } from 'next/headers'
 import { NextResponse } from 'next/server'
 import { mockProfilingResultDetail } from '@/mocks/data/profilingResults'
 
+const USE_MOCK = process.env.NEXT_PUBLIC_USE_MOCK_API === 'true'
+
 export async function POST(request: Request) {
-  const auth = request.headers.get('Authorization')
-  if (!auth?.startsWith('Bearer ')) {
+  const cookieStore = await cookies()
+  const token = cookieStore.get('access_token')?.value
+  const authHeader = request.headers.get('Authorization')
+  const bearer =
+    authHeader?.startsWith('Bearer ') && authHeader.length > 7
+      ? authHeader
+      : token
+        ? `Bearer ${token}`
+        : null
+
+  if (!bearer) {
     return NextResponse.json(
       {
         success: false,
@@ -84,14 +99,59 @@ export async function POST(request: Request) {
     )
   }
 
-  return NextResponse.json(
-    {
-      success: true,
-      data: {
-        result_id: mockProfilingResultDetail.id,
-        message: '사진 분석이 완료되었습니다.',
+  if (USE_MOCK) {
+    return NextResponse.json(
+      {
+        success: true,
+        data: {
+          result_id: mockProfilingResultDetail.id,
+          message: '사진 분석이 완료되었습니다.',
+        },
       },
+      { status: 201 }
+    )
+  }
+
+  const baseUrl = process.env.NEXT_PUBLIC_API_URL?.trim()
+  if (!baseUrl) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          code: 'MISSING_API_URL',
+          message: 'NEXT_PUBLIC_API_URL is not configured.',
+          details: null,
+        },
+      },
+      { status: 500 }
+    )
+  }
+
+  const upstream = await fetch(`${baseUrl}/api/v1/profilings/images/analyze`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      Authorization: bearer,
     },
-    { status: 201 }
-  )
+    body: JSON.stringify({ image_url, image_type, product_type }),
+    cache: 'no-store',
+  })
+
+  const text = await upstream.text()
+  let data: unknown = null
+  try {
+    data = text ? JSON.parse(text) : null
+  } catch {
+    data = {
+      success: false,
+      error: {
+        code: 'UPSTREAM_PARSE_ERROR',
+        message: '서버 응답을 해석하지 못했습니다.',
+        details: null,
+      },
+    }
+  }
+
+  return NextResponse.json(data, { status: upstream.status })
 }

--- a/src/app/api/v1/profilings/images/presigned-url/route.ts
+++ b/src/app/api/v1/profilings/images/presigned-url/route.ts
@@ -1,10 +1,14 @@
 /**
- * 이미지 업로드용 presigned URL 발급 (MSW 미가로챔 시 fallback)
+ * 이미지 업로드용 presigned URL 발급
  * PUT /api/v1/profilings/images/presigned-url
- * Body: { file_name, image_format (jpeg|jpg|png|webp), file_size }
+ *
+ * - NEXT_PUBLIC_USE_MOCK_API=true: 로컬 mock 응답(같은 오리진 mock-upload)
+ * - 그 외: 백엔드 프록시 — Body { file_name, file_size } 만 전달
  */
+import { cookies } from 'next/headers'
 import { NextResponse } from 'next/server'
 
+const USE_MOCK = process.env.NEXT_PUBLIC_USE_MOCK_API === 'true'
 const ALLOWED_FORMATS = ['jpeg', 'jpg', 'png', 'webp']
 const MOCK_IMAGE_URL = 'https://cdn.example.com/images/ai-visual-mock.jpg'
 const MOCK_KEY = 'images/ai-visual-mock.jpg'
@@ -17,9 +21,18 @@ function getOrigin(request: Request): string {
   }
 }
 
-export async function PUT(request: Request) {
+function resolveBearer(request: Request): string | null {
   const auth = request.headers.get('Authorization')
-  if (!auth?.startsWith('Bearer ')) {
+  if (auth?.startsWith('Bearer ') && auth.length > 7) return auth
+  return null
+}
+
+export async function PUT(request: Request) {
+  const cookieStore = await cookies()
+  const token = cookieStore.get('access_token')?.value
+  const bearer = resolveBearer(request) ?? (token ? `Bearer ${token}` : null)
+
+  if (!bearer) {
     return NextResponse.json(
       {
         success: false,
@@ -33,7 +46,11 @@ export async function PUT(request: Request) {
     )
   }
 
-  let body: { file_name?: string; image_format?: string; file_size?: number }
+  let body: {
+    file_name?: string
+    file_size?: number
+    image_format?: string
+  }
   try {
     body = await request.json()
   } catch {
@@ -50,27 +67,14 @@ export async function PUT(request: Request) {
     )
   }
 
-  const { file_name, image_format, file_size } = body ?? {}
-  if (!file_name || !image_format || file_size == null) {
+  const { file_name, file_size, image_format } = body ?? {}
+  if (!file_name || file_size == null) {
     return NextResponse.json(
       {
         success: false,
         error: {
           code: 'BAD_REQUEST',
-          message: 'file_name, image_format, file_size는 필수입니다.',
-          details: null,
-        },
-      },
-      { status: 400 }
-    )
-  }
-  if (!ALLOWED_FORMATS.includes(image_format.toLowerCase())) {
-    return NextResponse.json(
-      {
-        success: false,
-        error: {
-          code: 'BAD_REQUEST',
-          message: '허용되지 않는 파일 형식입니다.',
+          message: 'file_name, file_size는 필수입니다.',
           details: null,
         },
       },
@@ -78,19 +82,84 @@ export async function PUT(request: Request) {
     )
   }
 
-  const origin = getOrigin(request)
-  const presigned_url = `${origin}/api/v1/profilings/images/mock-upload`
+  if (USE_MOCK) {
+    if (
+      image_format != null &&
+      !ALLOWED_FORMATS.includes(String(image_format).toLowerCase())
+    ) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            code: 'BAD_REQUEST',
+            message: '허용되지 않는 파일 형식입니다.',
+            details: null,
+          },
+        },
+        { status: 400 }
+      )
+    }
 
-  return NextResponse.json(
+    const origin = getOrigin(request)
+    const presigned_url = `${origin}/api/v1/profilings/images/mock-upload`
+
+    return NextResponse.json(
+      {
+        success: true,
+        data: {
+          presigned_url,
+          image_url: MOCK_IMAGE_URL,
+          key: MOCK_KEY,
+          expires_in: 300,
+        },
+      },
+      { status: 201 }
+    )
+  }
+
+  const baseUrl = process.env.NEXT_PUBLIC_API_URL?.trim()
+  if (!baseUrl) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          code: 'MISSING_API_URL',
+          message: 'NEXT_PUBLIC_API_URL is not configured.',
+          details: null,
+        },
+      },
+      { status: 500 }
+    )
+  }
+
+  const upstream = await fetch(
+    `${baseUrl}/api/v1/profilings/images/presigned-url`,
     {
-      success: true,
-      data: {
-        presigned_url,
-        image_url: MOCK_IMAGE_URL,
-        key: MOCK_KEY,
-        expires_in: 300,
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+        Authorization: bearer,
       },
-    },
-    { status: 201 }
+      body: JSON.stringify({ file_name, file_size }),
+      cache: 'no-store',
+    }
   )
+
+  const text = await upstream.text()
+  let data: unknown = null
+  try {
+    data = text ? JSON.parse(text) : null
+  } catch {
+    data = {
+      success: false,
+      error: {
+        code: 'UPSTREAM_PARSE_ERROR',
+        message: '서버 응답을 해석하지 못했습니다.',
+        details: null,
+      },
+    }
+  }
+
+  return NextResponse.json(data, { status: upstream.status })
 }

--- a/src/app/find-my-scent/_api/aiVisualClient.ts
+++ b/src/app/find-my-scent/_api/aiVisualClient.ts
@@ -7,30 +7,15 @@
 export type PhotoType = 'INTERIOR' | 'OOTD'
 export type ProductType = 'DIFFUSER' | 'PERFUME'
 
-const ALLOWED_FORMATS = ['jpeg', 'jpg', 'png', 'webp'] as const
-type ImageFormat = (typeof ALLOWED_FORMATS)[number]
-
-function getImageFormatFromFile(file: File): ImageFormat {
-  const type = file.type?.toLowerCase() ?? ''
-  if (type === 'image/jpeg' || type === 'image/jpg') return 'jpeg'
-  if (type === 'image/png') return 'png'
-  if (type === 'image/webp') return 'webp'
-  const ext = file.name.split('.').pop()?.toLowerCase() ?? ''
-  if (ext === 'jpg' || ext === 'jpeg') return 'jpeg'
-  if (ext === 'png') return 'png'
-  if (ext === 'webp') return 'webp'
-  return 'jpeg'
-}
-
-/** 개발/MSW용 토큰 (실서비스에서는 인증 컨텍스트에서 주입) */
-function getAuthHeader(): Record<string, string> {
-  const token =
-    typeof window !== 'undefined'
-      ? (window as unknown as { __AI_VISUAL_TOKEN?: string }).__AI_VISUAL_TOKEN
-      : undefined
-  return {
-    Authorization: token ? `Bearer ${token}` : 'Bearer mock_token',
+/** MSW/목 모드에서만 Bearer 부착 — 실 API는 쿠키(access_token) + BFF */
+function getAiVisualAuthHeaders(): Record<string, string> {
+  if (typeof window === 'undefined') return {}
+  if (process.env.NEXT_PUBLIC_USE_MOCK_API === 'true') {
+    return { Authorization: 'Bearer mock-dev-token' }
   }
+  const token = (window as unknown as { __AI_VISUAL_TOKEN?: string })
+    .__AI_VISUAL_TOKEN
+  return token ? { Authorization: `Bearer ${token}` } : {}
 }
 
 type PresignedUrlResponse = {
@@ -53,19 +38,21 @@ type AnalyzeResponse = {
 /**
  * 1. presigned URL 발급
  * PUT /api/v1/profilings/images/presigned-url
+ * Body: { file_name, file_size } (백엔드 명세)
  */
 async function getPresignedUrl(
   file_name: string,
-  image_format: ImageFormat,
   file_size: number
 ): Promise<{ presigned_url: string; image_url: string }> {
   const res = await fetch('/api/v1/profilings/images/presigned-url', {
     method: 'PUT',
+    credentials: 'include',
     headers: {
       'Content-Type': 'application/json',
-      ...getAuthHeader(),
+      Accept: 'application/json',
+      ...getAiVisualAuthHeaders(),
     },
-    body: JSON.stringify({ file_name, image_format, file_size }),
+    body: JSON.stringify({ file_name, file_size }),
   })
 
   const json: PresignedUrlResponse = await res.json().catch(() => ({
@@ -115,9 +102,11 @@ async function submitAnalyze(
 ): Promise<number> {
   const res = await fetch('/api/v1/profilings/images/analyze', {
     method: 'POST',
+    credentials: 'include',
     headers: {
       'Content-Type': 'application/json',
-      ...getAuthHeader(),
+      Accept: 'application/json',
+      ...getAiVisualAuthHeaders(),
     },
     body: JSON.stringify({ image_url, image_type, product_type }),
   })
@@ -142,12 +131,10 @@ export async function submitAiVisualAnalysis(
   file: File,
   productType: ProductType = 'DIFFUSER'
 ): Promise<number> {
-  const image_format = getImageFormatFromFile(file)
-  const file_name = file.name || `upload.${image_format}`
+  const file_name = file.name || 'upload.jpg'
 
   const { presigned_url, image_url } = await getPresignedUrl(
     file_name,
-    image_format,
     file.size
   )
 

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -374,7 +374,7 @@ const MOCK_AI_IMAGE_KEY = 'images/ai-visual-mock.jpg'
 /**
  * 1. 이미지 업로드용 presigned URL 발급
  * PUT /api/v1/profilings/images/presigned-url
- * Body: { file_name, image_format (jpeg|jpg|png|webp), file_size }
+ * Body: { file_name, file_size } — 실 API와 동일 (image_format은 선택, 있으면 검증)
  */
 export const presignedUrlHandler = http.put(
   '/api/v1/profilings/images/presigned-url',
@@ -412,32 +412,34 @@ export const presignedUrlHandler = http.put(
     }
 
     const { file_name, image_format, file_size } = body ?? {}
-    if (!file_name || !image_format || file_size == null) {
+    if (!file_name || file_size == null) {
       return HttpResponse.json(
         {
           success: false,
           error: {
             code: 'BAD_REQUEST',
-            message: 'file_name, image_format, file_size는 필수입니다.',
+            message: 'file_name, file_size는 필수입니다.',
             details: null,
           },
         },
         { status: 400 }
       )
     }
-    const formatLower = image_format.toLowerCase()
-    if (!IMAGE_FORMATS.includes(formatLower as ImageFormat)) {
-      return HttpResponse.json(
-        {
-          success: false,
-          error: {
-            code: 'BAD_REQUEST',
-            message: '허용되지 않는 파일 형식입니다.',
-            details: { field: 'image_format', reason: 'invalid' },
+    if (image_format != null) {
+      const formatLower = image_format.toLowerCase()
+      if (!IMAGE_FORMATS.includes(formatLower as ImageFormat)) {
+        return HttpResponse.json(
+          {
+            success: false,
+            error: {
+              code: 'BAD_REQUEST',
+              message: '허용되지 않는 파일 형식입니다.',
+              details: { field: 'image_format', reason: 'invalid' },
+            },
           },
-        },
-        { status: 400 }
-      )
+          { status: 400 }
+        )
+      }
     }
 
     // 클라이언트가 같은 출처로 PUT 할 수 있도록 mock 업로드 경로 반환 (상대 URL)


### PR DESCRIPTION
## ✨ PR 개요
AI 비주얼 이미지 업로드 플로우에서 **실 API 개발 환경** 기준으로  
`presigned-url`·`analyze` 요청이 **백엔드로 전달**되도록 Next.js 라우트를 **BFF 프록시**로 정리했습니다.

## 📌 관련 이슈
<!-- Closes #이슈번호 -->
Closes #191 

## 🧩 작업 내용 (주요 변경사항)
### `PUT /api/v1/profilings/images/presigned-url`
- **`NEXT_PUBLIC_USE_MOCK_API=true`**: 기존처럼 로컬 mock(`mock-upload` URL 등) 유지.
- **그 외**: 백엔드 `PUT .../presigned-url`로 프록시, 요청 본문은 **`{ file_name, file_size }`만** 전달.
- 인증: `Authorization` 헤더 또는 **`access_token` 쿠키**.
### `POST /api/v1/profilings/images/analyze`
- **`NEXT_PUBLIC_USE_MOCK_API=true`**: 기존 mock `result_id` 응답 유지.
- **그 외**: 백엔드로 동일 스키마 프록시.
### `aiVisualClient.ts`
- Presigned 발급 요청 본문을 **`image_format` 제거 후 `{ file_name, file_size }`** 로 통일.
- **`credentials: 'include'`** 로 쿠키 전달.
- MSW/목 모드에서만 `Bearer mock-dev-token` 사용 (실 API는 BFF가 쿠키 처리).
### MSW (`handlers.ts`)
- Presigned 핸들러를 실 API와 맞춰 **`file_name` + `file_size` 필수**, `image_format`은 선택 검증.
## 운영/인프라 참고
- 브라우저 → S3 **직접 PUT** 시 **`Failed to fetch`** 가 나면 S3 버킷 **CORS**(Origin, `PUT`, `Content-Type` 등) 설정을 확인해야 합니다. (프록시와 별개 이슈)


## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료
