### PR TITLE
feat: 닉네임 변경, 회원탈퇴 기능 추가

### DIFF
--- a/src/app/api/v1/users/me/nickname/route.ts
+++ b/src/app/api/v1/users/me/nickname/route.ts
@@ -1,0 +1,223 @@
+import { cookies } from 'next/headers'
+import { NextRequest, NextResponse } from 'next/server'
+import { postTokenRefresh } from '@/lib/api/auth'
+
+type NicknameUpdateResponse = {
+  success: boolean
+  data: {
+    id: number
+    nickname: string
+    updated_at: string
+  } | null
+  error?: {
+    code: string
+    message: string
+    details?: unknown
+  }
+}
+
+const BASE_COOKIE_OPTIONS = {
+  httpOnly: true,
+  secure: process.env.NODE_ENV === 'production',
+  sameSite: 'lax' as const,
+  path: '/',
+}
+
+const clearAuthCookies = (response: NextResponse) => {
+  response.cookies.set('access_token', '', { maxAge: 0, path: '/' })
+  response.cookies.set('refresh_token', '', { maxAge: 0, path: '/' })
+}
+
+const parseJsonSafely = async <T>(response: Response): Promise<T | null> => {
+  return response.json().catch(() => null)
+}
+
+const fetchNicknameUpdate = async (
+  baseUrl: string,
+  accessToken: string,
+  requestBody: string
+) => {
+  return fetch(`${baseUrl}/api/v1/users/me/nickname`, {
+    method: 'PATCH',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: requestBody,
+    cache: 'no-store',
+  })
+}
+
+type NicknameUpdateRequest = {
+  nickname?: string
+}
+
+const NICKNAME_PATTERN = /^[A-Za-z0-9가-힣]{2,8}$/
+
+export async function PATCH(request: NextRequest) {
+  try {
+    const body = (await request
+      .json()
+      .catch(() => null)) as NicknameUpdateRequest | null
+    const nickname = body?.nickname?.trim()
+
+    if (!nickname || !NICKNAME_PATTERN.test(nickname)) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            code: 'NICKNAME_UPDATE_INVALID_REQUEST',
+            message: '닉네임 변경 요청이 올바르지 않습니다.',
+            details: {
+              field: 'nickname',
+              reason: '2_to_8_alnum_or_korean_complete_only',
+            },
+          },
+        },
+        { status: 400 }
+      )
+    }
+
+    const baseUrl = process.env.NEXT_PUBLIC_API_URL?.trim()
+    if (!baseUrl) {
+      return NextResponse.json(
+        {
+          success: false,
+          data: null,
+          error: {
+            code: 'MISSING_API_URL',
+            message: 'NEXT_PUBLIC_API_URL is not configured.',
+          },
+        },
+        { status: 500 }
+      )
+    }
+
+    const cookieStore = await cookies()
+    let accessToken = cookieStore.get('access_token')?.value
+    const refreshToken = cookieStore.get('refresh_token')?.value
+    const requestBody = JSON.stringify({ nickname })
+
+    if (!accessToken && !refreshToken) {
+      return NextResponse.json(
+        {
+          success: false,
+          data: null,
+          error: {
+            code: 'NOT_AUTHENTICATED',
+            message: '인증이 필요합니다.',
+          },
+        },
+        { status: 401 }
+      )
+    }
+
+    if (accessToken) {
+      const upstream = await fetchNicknameUpdate(
+        baseUrl,
+        accessToken,
+        requestBody
+      )
+      if (upstream.ok) {
+        const data = await parseJsonSafely<NicknameUpdateResponse>(upstream)
+        return NextResponse.json(data, { status: upstream.status })
+      }
+
+      if (upstream.status !== 401) {
+        const errorBody =
+          await parseJsonSafely<NicknameUpdateResponse>(upstream)
+        return NextResponse.json(
+          errorBody ?? {
+            success: false,
+            data: null,
+            error: {
+              code: 'NICKNAME_UPDATE_FAILED',
+              message: '닉네임 변경에 실패했습니다.',
+            },
+          },
+          { status: upstream.status }
+        )
+      }
+    }
+
+    if (!refreshToken) {
+      const response = NextResponse.json(
+        {
+          success: false,
+          data: null,
+          error: {
+            code: 'NOT_AUTHENTICATED',
+            message: '인증이 필요합니다.',
+          },
+        },
+        { status: 401 }
+      )
+      clearAuthCookies(response)
+      return response
+    }
+
+    try {
+      const refreshed = await postTokenRefresh(refreshToken)
+      accessToken = refreshed.data.access_token
+
+      const upstream = await fetchNicknameUpdate(
+        baseUrl,
+        accessToken,
+        requestBody
+      )
+      const responseBody =
+        await parseJsonSafely<NicknameUpdateResponse>(upstream)
+
+      const response = NextResponse.json(
+        responseBody ?? {
+          success: false,
+          data: null,
+          error: {
+            code: 'NICKNAME_UPDATE_FAILED',
+            message: '닉네임 변경에 실패했습니다.',
+          },
+        },
+        { status: upstream.status }
+      )
+
+      response.cookies.set('access_token', refreshed.data.access_token, {
+        ...BASE_COOKIE_OPTIONS,
+        maxAge: refreshed.data.expires_in,
+      })
+      response.cookies.set('refresh_token', refreshed.data.refresh_token, {
+        ...BASE_COOKIE_OPTIONS,
+        maxAge: refreshed.data.refresh_expires_in,
+      })
+
+      return response
+    } catch {
+      const response = NextResponse.json(
+        {
+          success: false,
+          data: null,
+          error: {
+            code: 'NOT_AUTHENTICATED',
+            message: '인증이 필요합니다.',
+          },
+        },
+        { status: 401 }
+      )
+      clearAuthCookies(response)
+      return response
+    }
+  } catch (error) {
+    console.error('Nickname update API error:', error)
+    return NextResponse.json(
+      {
+        success: false,
+        data: null,
+        error: {
+          code: 'NICKNAME_UPDATE_FAILED',
+          message: '닉네임 변경 중 오류가 발생했습니다.',
+        },
+      },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/v1/users/me/route.ts
+++ b/src/app/api/v1/users/me/route.ts
@@ -1,70 +1,199 @@
 import { cookies } from 'next/headers'
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
+import { postTokenRefresh } from '@/lib/api/auth'
 import type { ApiResponse, User } from '@/types'
+
+const BASE_COOKIE_OPTIONS = {
+  httpOnly: true,
+  secure: process.env.NODE_ENV === 'production',
+  sameSite: 'lax' as const,
+  path: '/',
+}
+
+const clearAuthCookies = (response: NextResponse) => {
+  response.cookies.set('access_token', '', { maxAge: 0, path: '/' })
+  response.cookies.set('refresh_token', '', { maxAge: 0, path: '/' })
+}
+
+const parseJsonSafely = async <T>(response: Response): Promise<T | null> => {
+  return response.json().catch(() => null)
+}
+
+const fetchUsersMe = async ({
+  method,
+  accessToken,
+  baseUrl,
+  requestBody,
+}: {
+  method: 'GET' | 'DELETE'
+  accessToken: string
+  baseUrl: string
+  requestBody?: string
+}) => {
+  const headers: Record<string, string> = {
+    Accept: 'application/json',
+    Authorization: `Bearer ${accessToken}`,
+  }
+
+  if (method === 'DELETE') {
+    headers['Content-Type'] = 'application/json'
+  }
+
+  return fetch(`${baseUrl}/api/v1/users/me`, {
+    method,
+    headers,
+    body: method === 'DELETE' ? requestBody : undefined,
+    cache: 'no-store',
+  })
+}
+
+const proxyUsersMe = async ({
+  method,
+  requestBody,
+}: {
+  method: 'GET' | 'DELETE'
+  requestBody?: string
+}) => {
+  const baseUrl = process.env.NEXT_PUBLIC_API_URL?.trim()
+
+  if (!baseUrl) {
+    return NextResponse.json(
+      {
+        success: false,
+        data: null,
+        error: {
+          code: 'MISSING_API_URL',
+          message: 'NEXT_PUBLIC_API_URL is not configured.',
+        },
+      },
+      { status: 500 }
+    )
+  }
+
+  const cookieStore = await cookies()
+  let accessToken = cookieStore.get('access_token')?.value
+  const refreshToken = cookieStore.get('refresh_token')?.value
+
+  if (!accessToken && !refreshToken) {
+    return NextResponse.json(
+      {
+        success: false,
+        data: null,
+        error: {
+          code: 'NOT_AUTHENTICATED',
+          message: '인증이 필요합니다.',
+        },
+      },
+      { status: 401 }
+    )
+  }
+
+  if (accessToken) {
+    const upstream = await fetchUsersMe({
+      method,
+      accessToken,
+      baseUrl,
+      requestBody,
+    })
+
+    if (upstream.ok) {
+      const body = await parseJsonSafely<ApiResponse<User | null>>(upstream)
+      return NextResponse.json(body, { status: upstream.status })
+    }
+
+    if (upstream.status !== 401) {
+      const errorBody =
+        await parseJsonSafely<ApiResponse<User | null>>(upstream)
+      return NextResponse.json(
+        errorBody ?? {
+          success: false,
+          data: null,
+          error: {
+            code: 'USERS_ME_FETCH_FAILED',
+            message:
+              method === 'GET'
+                ? 'Failed to fetch user profile.'
+                : 'Failed to withdraw user account.',
+          },
+        },
+        { status: upstream.status }
+      )
+    }
+  }
+
+  if (!refreshToken) {
+    const response = NextResponse.json(
+      {
+        success: false,
+        data: null,
+        error: {
+          code: 'NOT_AUTHENTICATED',
+          message: '인증이 필요합니다.',
+        },
+      },
+      { status: 401 }
+    )
+    clearAuthCookies(response)
+    return response
+  }
+
+  try {
+    const refreshed = await postTokenRefresh(refreshToken)
+    accessToken = refreshed.data.access_token
+
+    const upstream = await fetchUsersMe({
+      method,
+      accessToken,
+      baseUrl,
+      requestBody,
+    })
+    const body = await parseJsonSafely<ApiResponse<User | null>>(upstream)
+
+    const response = NextResponse.json(
+      body ?? {
+        success: false,
+        data: null,
+        error: {
+          code: 'USERS_ME_FETCH_FAILED',
+          message:
+            method === 'GET'
+              ? 'Failed to fetch user profile.'
+              : 'Failed to withdraw user account.',
+        },
+      },
+      { status: upstream.status }
+    )
+
+    response.cookies.set('access_token', refreshed.data.access_token, {
+      ...BASE_COOKIE_OPTIONS,
+      maxAge: refreshed.data.expires_in,
+    })
+    response.cookies.set('refresh_token', refreshed.data.refresh_token, {
+      ...BASE_COOKIE_OPTIONS,
+      maxAge: refreshed.data.refresh_expires_in,
+    })
+
+    return response
+  } catch {
+    const response = NextResponse.json(
+      {
+        success: false,
+        data: null,
+        error: {
+          code: 'NOT_AUTHENTICATED',
+          message: '인증이 필요합니다.',
+        },
+      },
+      { status: 401 }
+    )
+    clearAuthCookies(response)
+    return response
+  }
+}
 
 export async function GET() {
   try {
-    const baseUrl = process.env.NEXT_PUBLIC_API_URL?.trim()
-
-    if (!baseUrl) {
-      return NextResponse.json(
-        {
-          success: false,
-          data: null,
-          error: {
-            code: 'MISSING_API_URL',
-            message: 'NEXT_PUBLIC_API_URL is not configured.',
-          },
-        },
-        { status: 500 }
-      )
-    }
-
-    const cookieStore = await cookies()
-    const token = cookieStore.get('access_token')?.value
-
-    if (!token) {
-      return NextResponse.json(
-        {
-          success: false,
-          data: null,
-          error: {
-            code: 'UNAUTHORIZED',
-            message: 'No access token found.',
-          },
-        },
-        { status: 401 }
-      )
-    }
-
-    const response = await fetch(`${baseUrl}/api/v1/users/me`, {
-      method: 'GET',
-      headers: {
-        Accept: 'application/json',
-        Authorization: `Bearer ${token}`,
-      },
-      cache: 'no-store',
-    })
-
-    const data = (await response
-      .json()
-      .catch(() => null)) as ApiResponse<User> | null
-
-    if (!response.ok || !data) {
-      return NextResponse.json(
-        {
-          success: false,
-          data: null,
-          error: {
-            code: data?.error?.code ?? 'USERS_ME_FETCH_FAILED',
-            message: data?.error?.message ?? 'Failed to fetch user profile.',
-          },
-        },
-        { status: response.status || 500 }
-      )
-    }
-
-    return NextResponse.json(data, { status: response.status })
+    return proxyUsersMe({ method: 'GET' })
   } catch (error) {
     console.error('Users me API error:', error)
     return NextResponse.json(
@@ -74,6 +203,54 @@ export async function GET() {
         error: {
           code: 'USERS_ME_FAILED',
           message: 'An error occurred while fetching profile.',
+        },
+      },
+      { status: 500 }
+    )
+  }
+}
+
+type WithdrawRequest = {
+  confirm_text?: string
+}
+
+export async function DELETE(request: NextRequest) {
+  try {
+    const body = (await request
+      .json()
+      .catch(() => null)) as WithdrawRequest | null
+    const confirmText = body?.confirm_text
+
+    if (confirmText !== '회원탈퇴') {
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            code: 'INVALID_WITHDRAW_REQUEST',
+            message: '회원탈퇴 파라미터가 올바르지 않습니다.',
+            details: {
+              field: 'confirm_text',
+              reason: 'must_equal_회원탈퇴',
+            },
+          },
+        },
+        { status: 400 }
+      )
+    }
+
+    return proxyUsersMe({
+      method: 'DELETE',
+      requestBody: JSON.stringify({ confirm_text: confirmText }),
+    })
+  } catch (error) {
+    console.error('Users withdraw API error:', error)
+    return NextResponse.json(
+      {
+        success: false,
+        data: null,
+        error: {
+          code: 'USERS_WITHDRAW_FAILED',
+          message: 'An error occurred while withdrawing account.',
         },
       },
       { status: 500 }

--- a/src/app/login/callback/CallbackClient.tsx
+++ b/src/app/login/callback/CallbackClient.tsx
@@ -35,7 +35,6 @@ export default function CallbackClient() {
           localStorage.setItem('user', JSON.stringify(result.user))
           login(result.user)
 
-          alert(`${result.user.nickname}님, 환영합니다!`)
           router.replace('/')
         } else {
           throw new Error(result.error)

--- a/src/app/profile/profileModal/NicknameModal.tsx
+++ b/src/app/profile/profileModal/NicknameModal.tsx
@@ -1,7 +1,27 @@
 'use client'
+import { useState } from 'react'
 import ManageProfileIcon from '@/assets/icons/manageProfile.svg'
 import Input from '@/components/common/Input'
 import Button from '@/components/common/Button'
+import { useAuthStore } from '@/store/useAuthStore'
+import { useModalStore } from '@/store/useModalStore'
+
+type NicknameUpdateResponse = {
+  success: boolean
+  data?: {
+    id: number
+    nickname: string
+    updated_at: string
+  }
+  error?: {
+    code?: string
+    message?: string
+  }
+}
+
+const NICKNAME_PATTERN = /^[A-Za-z0-9가-힣]{2,8}$/
+const NICKNAME_RULE_MESSAGE =
+  '닉네임은 2~8글자의 영어, 숫자, 한글(완성형)만 사용할 수 있습니다.'
 
 export type NicknameModalProps = {
   isOpen: boolean
@@ -9,6 +29,83 @@ export type NicknameModalProps = {
 }
 
 export default function NicknameModal({ isOpen, onClose }: NicknameModalProps) {
+  const user = useAuthStore((state) => state.user)
+  const [newNickname, setNewNickname] = useState('')
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const openAlert = useModalStore((state) => state.openAlert)
+
+  const currentNickname = user?.nickname ?? 'DeepScent 사용자'
+
+  const handleSubmit = async () => {
+    const trimmedNickname = newNickname.trim()
+
+    if (!trimmedNickname) {
+      setErrorMessage('새 닉네임을 입력해주세요.')
+      return
+    }
+
+    if (!NICKNAME_PATTERN.test(trimmedNickname)) {
+      setErrorMessage(NICKNAME_RULE_MESSAGE)
+      return
+    }
+
+    if (trimmedNickname === currentNickname) {
+      setErrorMessage('현재 닉네임과 동일합니다.')
+      return
+    }
+
+    try {
+      setIsSubmitting(true)
+      setErrorMessage(null)
+
+      const response = await fetch('/api/v1/users/me/nickname', {
+        method: 'PATCH',
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        body: JSON.stringify({ nickname: trimmedNickname }),
+      })
+
+      const result = (await response
+        .json()
+        .catch(() => null)) as NicknameUpdateResponse | null
+
+      if (!response.ok || !result?.success || !result.data) {
+        setErrorMessage(result?.error?.message ?? '닉네임 변경에 실패했습니다.')
+        return
+      }
+
+      useAuthStore.setState((state) => {
+        const nextUser = state.user
+          ? { ...state.user, nickname: result.data!.nickname }
+          : state.user
+
+        if (nextUser) {
+          localStorage.setItem('user', JSON.stringify(nextUser))
+        }
+
+        return { user: nextUser }
+      })
+
+      onClose()
+      openAlert({
+        type: 'success',
+        title: '닉네임 변경 완료',
+        content: '새 닉네임이 정상적으로 반영되었습니다.',
+        confirmText: '확인',
+      })
+    } catch {
+      setErrorMessage(
+        '네트워크 오류가 발생했습니다. 잠시 후 다시 시도해주세요.'
+      )
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
   return (
     <>
       <div className="flex items-center border-b border-[#f3f4f6] p-4">
@@ -23,17 +120,31 @@ export default function NicknameModal({ isOpen, onClose }: NicknameModalProps) {
       <div className="flex flex-col gap-6 p-6">
         <Input
           className="w-99.5"
-          placeholder="DeepScent 사용자"
+          value={currentNickname}
           label="현재 닉네임"
           labelClassName="font-semibold text-[14px]"
+          disabled
         />
         <Input
           className="w-99.5"
-          placeholder="DeepScent 사용자"
+          placeholder="새 닉네임을 입력해주세요"
           label="새 닉네임"
           labelClassName="font-semibold text-[14px]"
+          value={newNickname}
+          onChange={(event) => {
+            setNewNickname(event.target.value)
+            if (errorMessage) setErrorMessage(null)
+          }}
+          status={errorMessage ? 'error' : 'default'}
+          helperText={errorMessage ?? NICKNAME_RULE_MESSAGE}
         />
-        <Button size={'w398h52'} rounded={'md'} className="mt-4">
+        <Button
+          size={'w398h52'}
+          rounded={'md'}
+          className="mt-4"
+          onClick={handleSubmit}
+          disabled={isSubmitting}
+        >
           변경하기
         </Button>
       </div>

--- a/src/app/profile/profileModal/WithdrawModal.tsx
+++ b/src/app/profile/profileModal/WithdrawModal.tsx
@@ -1,7 +1,20 @@
 'use client'
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
 import ExitIcon from '@/assets/icons/exit.svg'
 import Input from '@/components/common/Input'
 import Button from '@/components/common/Button'
+import { useAuthStore } from '@/store/useAuthStore'
+import { useModalStore } from '@/store/useModalStore'
+
+type WithdrawResponse = {
+  success: boolean
+  data?: null
+  error?: {
+    code?: string
+    message?: string
+  }
+}
 
 export type WithdrawModalProps = {
   isOpen: boolean
@@ -9,6 +22,65 @@ export type WithdrawModalProps = {
 }
 
 export default function WithdrawModal({ isOpen, onClose }: WithdrawModalProps) {
+  const router = useRouter()
+  const logout = useAuthStore((state) => state.logout)
+  const openAlert = useModalStore((state) => state.openAlert)
+  const [confirmText, setConfirmText] = useState('')
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const navigateToLogin = () => {
+    router.replace('/login')
+  }
+
+  const handleWithdraw = async () => {
+    if (confirmText.trim() !== '회원탈퇴') {
+      setErrorMessage('확인 문구로 "회원탈퇴"를 정확히 입력해주세요.')
+      return
+    }
+
+    try {
+      setIsSubmitting(true)
+      setErrorMessage(null)
+
+      const response = await fetch('/api/v1/users/me', {
+        method: 'DELETE',
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        body: JSON.stringify({ confirm_text: '회원탈퇴' }),
+      })
+
+      const result = (await response
+        .json()
+        .catch(() => null)) as WithdrawResponse | null
+
+      if (!response.ok || !result?.success) {
+        setErrorMessage(result?.error?.message ?? '회원 탈퇴에 실패했습니다.')
+        return
+      }
+
+      await logout()
+      onClose()
+      openAlert({
+        type: 'success',
+        title: '회원 탈퇴 완료',
+        content: '그동안 DeepScent를 이용해주셔서 감사합니다.',
+        confirmText: '확인',
+        onConfirm: navigateToLogin,
+        onCancel: navigateToLogin,
+      })
+    } catch {
+      setErrorMessage(
+        '네트워크 오류가 발생했습니다. 잠시 후 다시 시도해주세요.'
+      )
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
   return (
     <>
       <div className="flex items-center border-b border-[#f3f4f6] p-4">
@@ -23,17 +95,24 @@ export default function WithdrawModal({ isOpen, onClose }: WithdrawModalProps) {
       <div className="flex flex-col gap-6 p-6">
         <Input
           className="w-99.5"
-          placeholder="원하는 상품이 없습니다."
-          label="사유"
+          placeholder="회원탈퇴"
+          label="확인 문구"
           labelClassName="font-semibold text-[14px]"
+          value={confirmText}
+          onChange={(event) => setConfirmText(event.target.value)}
+          status={errorMessage ? 'error' : 'default'}
+          helperText={
+            errorMessage ??
+            '계정 삭제를 진행하려면 확인 문구로 회원탈퇴를 입력해주세요.'
+          }
         />
-        <Input
-          className="w-99.5"
-          placeholder="비밀번호를 입력해주세요"
-          label="비밀번호"
-          labelClassName="font-semibold text-[14px]"
-        />
-        <Button size={'w398h52'} rounded={'md'} className="mt-4">
+        <Button
+          size={'w398h52'}
+          rounded={'md'}
+          className="mt-4"
+          onClick={handleWithdraw}
+          disabled={isSubmitting}
+        >
           탈퇴 하기
         </Button>
       </div>


### PR DESCRIPTION
## ✨ PR 개요
프로필 관리 기능을 실제 API와 연동했습니다.
닉네임 변경, 회원 탈퇴, 로그인 후 UX 메시지 정리, 닉네임 유효성 검증(프론트/서버)을 포함한 계정 관리 흐름 안정화 작업입니다.
<!-- 어떤 작업을 했는지 간략히 요약 -->

## 📌 관련 이슈

<!-- Closes #이슈번호 -->

Closes #188 

## 🧩 작업 내용 (주요 변경사항)

- 회원 탈퇴 API 연동 추가
- 닉네임 변경 API 라우트 신규 추가 및 연동
- 닉네임 유효성 검증 추가
규칙: 2~8자, 영문/숫자/한글 완성형만 허용

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트

- [ ] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [ ] 불필요한 console.log 제거
- [ ] 로컬에서 실행 확인 완료
