### PR TITLE
feat: 로그인 BFF·비로그인 게이트·AI비주얼 presigned/분석 분리 (#196)

### DIFF
--- a/src/app/api/v1/auth/social/[provider]/authorize-url/route.ts
+++ b/src/app/api/v1/auth/social/[provider]/authorize-url/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+/**
+ * 소셜 authorize URL — 브라우저는 localhost 동일 출처로만 호출 (CORS 회피).
+ * 서버에서만 upstream(duckdns 등)으로 요청합니다.
+ */
+function upstreamBase(): string | null {
+  const u = process.env.NEXT_PUBLIC_API_URL?.trim()
+  return u || null
+}
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ provider: string }> }
+) {
+  const base = upstreamBase()
+  if (!base) {
+    return NextResponse.json(
+      {
+        success: false,
+        data: null,
+        error: {
+          code: 'MISSING_API_URL',
+          message: 'NEXT_PUBLIC_API_URL is not configured.',
+        },
+      },
+      { status: 500 }
+    )
+  }
+
+  const { provider } = await context.params
+  const search = request.nextUrl.search
+  const root = base.replace(/\/$/, '')
+
+  const primaryUrl = `${root}/api/v1/auth/social/${provider}/authorize-url${search}`
+  let upstream = await fetch(primaryUrl, {
+    headers: { Accept: 'application/json' },
+    cache: 'no-store',
+  })
+
+  if (upstream.status === 404) {
+    const fallbackUrl = `${root}/api/v1/auth/${provider}/authorize-url${search}`
+    upstream = await fetch(fallbackUrl, {
+      headers: { Accept: 'application/json' },
+      cache: 'no-store',
+    })
+  }
+
+  const text = await upstream.text()
+  const contentType =
+    upstream.headers.get('content-type') || 'application/json; charset=utf-8'
+
+  return new NextResponse(text, {
+    status: upstream.status,
+    headers: { 'Content-Type': contentType },
+  })
+}

--- a/src/app/find-my-scent/_api/aiVisualClient.ts
+++ b/src/app/find-my-scent/_api/aiVisualClient.ts
@@ -1,11 +1,19 @@
 /**
  * AI 비주얼 분석 API (명세 기준)
- * 1. PUT presigned-url → 2. PUT 파일 업로드 → 3. POST analyze → result_id
- * - MSW: /api/v1/profilings/images/*, /api/v1/profilings/results/:id
+ * 1. 파일 첨부 시: PUT presigned-url → PUT S3 업로드
+ * 2. 「분석 시작」버튼: POST /api/v1/profilings/images/analyze 만 호출
  */
 
 export type PhotoType = 'INTERIOR' | 'OOTD'
 export type ProductType = 'DIFFUSER' | 'PERFUME'
+
+/** PUT /api/v1/profilings/images/presigned-url 성공 data */
+export type PresignedUrlData = {
+  presigned_url: string
+  image_url: string
+  key: string
+  expires_in: number
+}
 
 /** MSW/목 모드에서만 Bearer 부착 — 실 API는 쿠키(access_token) + BFF */
 function getAiVisualAuthHeaders(): Record<string, string> {
@@ -18,14 +26,9 @@ function getAiVisualAuthHeaders(): Record<string, string> {
   return token ? { Authorization: `Bearer ${token}` } : {}
 }
 
-type PresignedUrlResponse = {
+type PresignedUrlApiResponse = {
   success: boolean
-  data?: {
-    presigned_url: string
-    image_url: string
-    key: string
-    expires_in: number
-  }
+  data?: PresignedUrlData
   error?: { code: string; message: string; details?: unknown }
 }
 
@@ -36,14 +39,13 @@ type AnalyzeResponse = {
 }
 
 /**
- * 1. presigned URL 발급
  * PUT /api/v1/profilings/images/presigned-url
- * Body: { file_name, file_size } (백엔드 명세)
+ * Body: { file_name, file_size }
  */
-async function getPresignedUrl(
+async function requestPresignedUrl(
   file_name: string,
   file_size: number
-): Promise<{ presigned_url: string; image_url: string }> {
+): Promise<PresignedUrlData> {
   const res = await fetch('/api/v1/profilings/images/presigned-url', {
     method: 'PUT',
     credentials: 'include',
@@ -55,7 +57,7 @@ async function getPresignedUrl(
     body: JSON.stringify({ file_name, file_size }),
   })
 
-  const json: PresignedUrlResponse = await res.json().catch(() => ({
+  const json: PresignedUrlApiResponse = await res.json().catch(() => ({
     success: false,
     error: { code: 'UNKNOWN', message: '응답을 파싱할 수 없습니다.' },
   }))
@@ -66,14 +68,11 @@ async function getPresignedUrl(
     )
   }
 
-  return {
-    presigned_url: json.data.presigned_url,
-    image_url: json.data.image_url,
-  }
+  return json.data
 }
 
 /**
- * 2. presigned URL로 파일 업로드
+ * presigned URL로 파일 업로드 (S3 PUT)
  */
 async function uploadToPresignedUrl(
   presigned_url: string,
@@ -92,13 +91,28 @@ async function uploadToPresignedUrl(
 }
 
 /**
- * 3. AI 분석 제출
- * POST /api/v1/profilings/images/analyze
+ * 파일 첨부 후: Presigned URL 발급 → S3 업로드까지 수행.
+ * 반환값의 image_url 을 분석 제출 시 사용합니다.
  */
-async function submitAnalyze(
+export async function uploadImageViaPresignedUrl(
+  file: File
+): Promise<PresignedUrlData> {
+  const file_name = file.name || 'upload.jpg'
+  const file_size = file.size
+
+  const data = await requestPresignedUrl(file_name, file_size)
+  await uploadToPresignedUrl(data.presigned_url, file)
+  return data
+}
+
+/**
+ * POST /api/v1/profilings/images/analyze
+ * 「분석 시작」버튼에서만 호출.
+ */
+export async function submitAiVisualAnalyze(
   image_url: string,
   image_type: PhotoType,
-  product_type: ProductType
+  product_type: ProductType = 'DIFFUSER'
 ): Promise<number> {
   const res = await fetch('/api/v1/profilings/images/analyze', {
     method: 'POST',
@@ -121,24 +135,4 @@ async function submitAnalyze(
   }
 
   return json.data.result_id
-}
-
-/**
- * AI 비주얼 분석 전체 플로우: presigned URL 발급 → 업로드 → 분석 제출 → result_id 반환
- */
-export async function submitAiVisualAnalysis(
-  photoType: PhotoType,
-  file: File,
-  productType: ProductType = 'DIFFUSER'
-): Promise<number> {
-  const file_name = file.name || 'upload.jpg'
-
-  const { presigned_url, image_url } = await getPresignedUrl(
-    file_name,
-    file.size
-  )
-
-  await uploadToPresignedUrl(presigned_url, file)
-
-  return submitAnalyze(image_url, photoType, productType)
 }

--- a/src/app/find-my-scent/_components/AIVisualModal.tsx
+++ b/src/app/find-my-scent/_components/AIVisualModal.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image'
 import { useRouter } from 'next/navigation'
 import { useRef, useState } from 'react'
 import { ModalOverlay, ModalPortal } from '@/components/common/Modal'
+import { uploadImageViaPresignedUrl } from '../_api/aiVisualClient'
 import { StepIndicator } from './StepIndicator'
 
 const ACCEPT_TYPES = 'image/jpeg,image/jpg,image/png,image/webp'
@@ -38,8 +39,11 @@ const PHOTO_TYPE_CONFIG: Record<
 export type AIVisualModalProps = {
   isOpen: boolean
   onClose: () => void
-  /** 제출 후 결과 페이지로 이동 등; Promise 반환 시 제출 중 버튼 비활성화 */
-  onAnalyze?: (photoType: PhotoType, file: File) => void | Promise<void>
+  /**
+   * S3 업로드 완료 후 저장된 image_url 로만 호출 (「분석 시작」버튼).
+   * Presigned 발급·PUT 업로드는 파일 첨부 시 모달 내부에서 처리.
+   */
+  onAnalyze?: (photoType: PhotoType, imageUrl: string) => void | Promise<void>
 }
 
 const styles = {
@@ -109,6 +113,10 @@ export function AIVisualModal({
   const [file, setFile] = useState<File | null>(null)
   const [previewUrl, setPreviewUrl] = useState<string | null>(null)
   const [uploadError, setUploadError] = useState<string | null>(null)
+  /** Presigned 발급 + S3 PUT 완료 후 서버가 준 image_url (분석 API에만 사용) */
+  const [uploadedImageUrl, setUploadedImageUrl] = useState<string | null>(null)
+  const [isUploadingS3, setIsUploadingS3] = useState(false)
+  const [s3Error, setS3Error] = useState<string | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [submitError, setSubmitError] = useState<string | null>(null)
   const inputRef = useRef<HTMLInputElement>(null)
@@ -129,6 +137,8 @@ export function AIVisualModal({
     }
     setPreviewUrl(null)
     setUploadError(null)
+    setUploadedImageUrl(null)
+    setS3Error(null)
     setSubmitError(null)
   }
 
@@ -137,8 +147,10 @@ export function AIVisualModal({
     onClose()
   }
 
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     setUploadError(null)
+    setS3Error(null)
+    setUploadedImageUrl(null)
     const next = e.target.files?.[0]
     if (!next) return
     if (!next.type.match(/^image\/(jpeg|jpg|png|webp)$/)) {
@@ -152,6 +164,19 @@ export function AIVisualModal({
     if (previewUrl) URL.revokeObjectURL(previewUrl)
     setFile(next)
     setPreviewUrl(URL.createObjectURL(next))
+
+    setIsUploadingS3(true)
+    try {
+      const data = await uploadImageViaPresignedUrl(next)
+      setUploadedImageUrl(data.image_url)
+    } catch (err) {
+      setUploadedImageUrl(null)
+      setS3Error(
+        err instanceof Error ? err.message : '이미지 업로드에 실패했습니다.'
+      )
+    } finally {
+      setIsUploadingS3(false)
+    }
   }
 
   const handleDrop = (e: React.DragEvent) => {
@@ -174,6 +199,8 @@ export function AIVisualModal({
     setFile(null)
     setPreviewUrl(null)
     setUploadError(null)
+    setUploadedImageUrl(null)
+    setS3Error(null)
   }
 
   const goNext = () => {
@@ -188,12 +215,12 @@ export function AIVisualModal({
   }
 
   const handleAnalyze = async () => {
-    if (step !== 2 || !photoType || !file) return
+    if (step !== 2 || !photoType || !uploadedImageUrl) return
     if (onAnalyze) {
       setSubmitError(null)
       setIsSubmitting(true)
       try {
-        await onAnalyze(photoType, file)
+        await onAnalyze(photoType, uploadedImageUrl)
         // onAnalyze에서 결과 페이지로 이동하므로 handleClose() 호출하지 않음 (history.back() 방지)
       } catch (err) {
         setSubmitError(
@@ -371,6 +398,14 @@ export function AIVisualModal({
                 {uploadError && (
                   <p className="mt-3 text-sm text-red-600">{uploadError}</p>
                 )}
+                {s3Error && (
+                  <p className="mt-3 text-sm text-red-600">{s3Error}</p>
+                )}
+                {isUploadingS3 && (
+                  <p className="mt-3 text-sm text-neutral-600">
+                    Presigned URL 발급 및 이미지 업로드 중…
+                  </p>
+                )}
                 {submitError && (
                   <p className="mt-3 text-sm text-red-600">{submitError}</p>
                 )}
@@ -400,10 +435,16 @@ export function AIVisualModal({
                 <button
                   type="button"
                   onClick={handleAnalyze}
-                  disabled={!file || isSubmitting}
-                  className={`${styles.btnNext} ${file && !isSubmitting ? styles.btnNextActive : styles.btnNextInactive}`}
+                  disabled={
+                    !file || !uploadedImageUrl || isUploadingS3 || isSubmitting
+                  }
+                  className={`${styles.btnNext} ${file && uploadedImageUrl && !isUploadingS3 && !isSubmitting ? styles.btnNextActive : styles.btnNextInactive}`}
                 >
-                  {isSubmitting ? '제출 중...' : '분석 시작'}
+                  {isUploadingS3
+                    ? '업로드 중...'
+                    : isSubmitting
+                      ? '분석 중...'
+                      : '분석 시작'}
                 </button>
               </>
             )}

--- a/src/app/find-my-scent/_components/ProductTypeSelectModal.tsx
+++ b/src/app/find-my-scent/_components/ProductTypeSelectModal.tsx
@@ -82,7 +82,7 @@ function DiffuserIcon({ className }: { className?: string }) {
 const styles = {
   panel: 'relative w-full max-w-lg rounded-2xl bg-white p-6 pt-12 shadow-lg',
   closeBtn:
-    'absolute right-3 top-3 flex h-14 w-14 items-center justify-center rounded-full text-neutral-500 transition-colors hover:bg-neutral-100 hover:text-black',
+    'absolute right-6 top-6 flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-neutral-400 shadow-none transition-[color,box-shadow,transform] duration-150 ease-out hover:translate-y-px hover:scale-[0.96] hover:text-[var(--color-black-primary)] hover:shadow-[0_2px_6px_rgba(0,0,0,0.14)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-300 focus-visible:ring-offset-2 active:translate-y-0.5 active:scale-[0.92] active:shadow-[0_1px_3px_rgba(0,0,0,0.12)]',
   title: 'pr-12 text-lg font-bold text-[var(--color-black-primary)]',
   sub: 'mt-2 text-sm leading-relaxed text-neutral-600',
   /** 가로: 두 선택지 나란히 */

--- a/src/app/find-my-scent/_components/ProfilingTestPage.tsx
+++ b/src/app/find-my-scent/_components/ProfilingTestPage.tsx
@@ -30,24 +30,17 @@ export function ProfilingTestPage({ testType }: { testType: TestType }) {
   const { isOpen: showErrorPopup, close: closeErrorPopup } =
     useErrorPopup(error)
 
-  if (productType === null) {
+  /** 인증 초기화 전 — 제품 유형 모달이 잠깐이라도 뜨지 않음 */
+  if (!isInitialized) {
     return (
-      <>
-        <PageCenter>
-          <p className="text-center text-sm text-neutral-500">
-            추천 받을 제품 유형을 선택해 주세요.
-          </p>
-        </PageCenter>
-        <ProductTypeSelectModal
-          isOpen
-          onSelect={setProductType}
-          onClose={() => router.back()}
-        />
-      </>
+      <PageCenter>
+        <LoadingSpinner />
+      </PageCenter>
     )
   }
 
-  if (isInitialized && isLoggedIn === false) {
+  /** 비로그인: 타입 선택 모달보다 먼저 경고 (LoginRequiredTestModal: 3초 후 /login) */
+  if (isLoggedIn === false) {
     return (
       <>
         <PageCenter>
@@ -64,6 +57,23 @@ export function ProfilingTestPage({ testType }: { testType: TestType }) {
           </div>
         </PageCenter>
         <LoginRequiredTestModal isOpen onClose={() => router.push('/login')} />
+      </>
+    )
+  }
+
+  if (productType === null) {
+    return (
+      <>
+        <PageCenter>
+          <p className="text-center text-sm text-neutral-500">
+            추천 받을 제품 유형을 선택해 주세요.
+          </p>
+        </PageCenter>
+        <ProductTypeSelectModal
+          isOpen
+          onSelect={setProductType}
+          onClose={() => router.back()}
+        />
       </>
     )
   }

--- a/src/app/find-my-scent/ai-visual/AIVisualClient.tsx
+++ b/src/app/find-my-scent/ai-visual/AIVisualClient.tsx
@@ -3,12 +3,20 @@
 /** AI 비주얼 분석 페이지 — 모달로 진입 (클라이언트 마운트 후 렌더로 hydration 회피) */
 import { useRouter } from 'next/navigation'
 import { useState, useEffect } from 'react'
-import { submitAiVisualAnalysis } from '../_api/aiVisualClient'
+import { PageCenter } from '@/components/common/PageCenter'
+import { LoadingSpinner } from '@/components/common/LoadingSpinner'
+import { useAuthStore } from '@/store/useAuthStore'
+import { submitAiVisualAnalyze } from '../_api/aiVisualClient'
 import { AIVisualModal } from '../_components/AIVisualModal'
+import { LoginRequiredTestModal } from '../_components/LoginRequiredTestModal'
+
+const loginHintBtn =
+  'mt-4 rounded-xl bg-[var(--color-black-primary)] px-6 py-3 text-sm font-medium text-white transition-opacity hover:opacity-90'
 
 export function AIVisualClient() {
   const [mounted, setMounted] = useState(false)
   const router = useRouter()
+  const { isLoggedIn, isInitialized } = useAuthStore()
 
   useEffect(() => {
     // 클라이언트에서만 모달 렌더하여 SSR/hydration 불일치 방지
@@ -16,12 +24,49 @@ export function AIVisualClient() {
     setMounted(true)
   }, [])
 
-  const handleAnalyze = async (photoType: 'INTERIOR' | 'OOTD', file: File) => {
-    const resultId = await submitAiVisualAnalysis(photoType, file)
+  const handleAnalyze = async (
+    photoType: 'INTERIOR' | 'OOTD',
+    imageUrl: string
+  ) => {
+    const resultId = await submitAiVisualAnalyze(
+      imageUrl,
+      photoType,
+      'DIFFUSER'
+    )
     router.push(`/find-my-scent/ai-visual/result?result_id=${resultId}`)
   }
 
   if (!mounted) return null
+
+  if (!isInitialized) {
+    return (
+      <PageCenter>
+        <LoadingSpinner />
+      </PageCenter>
+    )
+  }
+
+  /** 비로그인: 사진/타입 선택 모달보다 먼저 경고 (3초 후 /login) */
+  if (isLoggedIn === false) {
+    return (
+      <>
+        <PageCenter>
+          <div className="flex flex-col items-center gap-2 text-center">
+            <p className="text-neutral-500">로그인 후 이용할 수 있어요.</p>
+            <button
+              type="button"
+              onClick={() => router.push('/login')}
+              className={loginHintBtn}
+              aria-label="로그인하기"
+            >
+              로그인하기
+            </button>
+          </div>
+        </PageCenter>
+        <LoginRequiredTestModal isOpen onClose={() => router.push('/login')} />
+      </>
+    )
+  }
 
   return (
     <AIVisualModal

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -1,6 +1,7 @@
 import type { ApiResponse, AuthTokens, AuthorizeUrl, User } from '@/types'
-import { apiFetch, appFetch } from './client'
+import { appFetch } from './client'
 import { FetchError } from './fetchError'
+import type { ApiErrorResponse } from './types'
 
 type TokenRefreshData = {
   access_token: string
@@ -12,34 +13,57 @@ type TokenRefreshData = {
 
 /**
  * 소셜 로그인/회원가입 URL을 요청합니다.
- * @param provider 소셜 제공자 (e.g., 'kakao')
- * @param state CSRF 방지용 랜덤 문자열
+ * apiFetch는 NEXT_PUBLIC_API_URL을 base로 쓰므로 브라우저에서 CORS가 납니다.
+ * 동일 출처 `/api/v1/auth/social/...` Next 라우트(BFF)로만 요청합니다.
  */
 export async function getSocialAuthorizeUrl(
   provider: string,
   state: string
 ): Promise<ApiResponse<AuthorizeUrl>> {
   const redirectUri = `${window.location.origin}/login/callback`
+  const params = new URLSearchParams({
+    state,
+    redirect_uri: redirectUri,
+  })
+  const path = `/api/v1/auth/social/${provider}/authorize-url?${params.toString()}`
 
-  try {
-    return await apiFetch.get<ApiResponse<AuthorizeUrl>>(
-      `/api/v1/auth/social/${provider}/authorize-url`,
-      {
-        params: { state, redirect_uri: redirectUri },
-      }
-    )
-  } catch (error) {
-    // 백엔드 경로가 /auth/{provider}/authorize-url 인 환경을 fallback으로 지원
-    if (error instanceof FetchError && error.status === 404) {
-      return apiFetch.get<ApiResponse<AuthorizeUrl>>(
-        `/api/v1/auth/${provider}/authorize-url`,
-        {
-          params: { state, redirect_uri: redirectUri },
-        }
-      )
-    }
-    throw error
+  const response = await fetch(path, {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+  })
+
+  const body = (await response.json().catch(() => null)) as
+    | ApiResponse<AuthorizeUrl>
+    | ApiErrorResponse
+    | null
+
+  if (!body) {
+    throw new FetchError({
+      code: 'PARSE_ERROR',
+      message: 'authorize-url 응답을 해석할 수 없습니다.',
+      status: response.status,
+      statusText: response.statusText,
+      url: path,
+    })
   }
+
+  if (!response.ok) {
+    const err = body as ApiErrorResponse
+    throw new FetchError({
+      code: err.error?.code ?? 'AUTHORIZE_URL_FAILED',
+      message:
+        err.error?.message ?? `authorize-url 요청 실패 (${response.status})`,
+      status: response.status,
+      statusText: response.statusText,
+      url: path,
+      details: err.error?.details,
+    })
+  }
+
+  return body as ApiResponse<AuthorizeUrl>
 }
 
 /**


### PR DESCRIPTION
## ✨ PR 개요
- #196 — 로컬/배포 환경에서의 API·인증·테스트 진입 동작을 정리합니다.

## 📌 관련 이슈
<!-- Closes #이슈번호 -->
Closes #196 

## 🧩 작업 내용 (주요 변경사항)
### 소셜 로그인 (카카오)
- 브라우저가 `NEXT_PUBLIC_API_URL`(외부 백엔드)로 **직접** `authorize-url`을 호출하면 로컬에서 **CORS**가 발생할 수 있음.
- `GET /api/v1/auth/social/[provider]/authorize-url` **Next BFF 라우트** 추가 → 서버에서만 upstream 호출.
- `getSocialAuthorizeUrl`은 **동일 출처** `/api/v1/auth/social/...` 로만 요청하도록 변경.
### 취향·건강 테스트 / AI 비주얼
- **비로그인** 사용자: 제품 유형 선택·AI 모달(타입/파일) **이전**에 로그인 유도 모달 표시.
- 인증 초기화 전에는 로딩만 표시해 선택 UI가 잠깐이라도 뜨지 않도록 처리.
### AI 비주얼 분석
- **파일 첨부 시**: `PUT /api/v1/profilings/images/presigned-url` (`file_name`, `file_size`) → presigned URL로 **S3 PUT**까지 수행.
- **「분석 시작」 클릭 시에만** `POST /api/v1/profilings/images/analyze` 호출 (`image_url`, `image_type`, `product_type`).


## 💬 리뷰 포인트
<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항
<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트
- [ ] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [ ] 불필요한 console.log 제거
- [ ] 로컬에서 실행 확인 완료
