### PR TITLE
[feat] 로그인 직후 로컬에 어드민 저장(#198)

### DIFF
--- a/src/app/login/callback/CallbackClient.tsx
+++ b/src/app/login/callback/CallbackClient.tsx
@@ -5,6 +5,29 @@ import { useSearchParams, useRouter } from 'next/navigation'
 import { LoadingSpinner } from '@/components/common/LoadingSpinner'
 import { loginWithKakaoAction } from '@/lib/auth/sessionActions'
 import { useAuthStore } from '@/store/useAuthStore'
+import type { User } from '@/types'
+
+async function fetchLatestUserProfile(): Promise<User | null> {
+  try {
+    const response = await fetch('/api/v1/users/me', {
+      credentials: 'include',
+      headers: { Accept: 'application/json' },
+    })
+
+    const body = (await response.json().catch(() => null)) as {
+      success?: boolean
+      data?: User
+    } | null
+
+    if (response.ok && body?.success && body.data) {
+      return body.data
+    }
+  } catch {
+    // 프로필 동기화 실패 시 콜백 응답 user를 fallback으로 사용
+  }
+
+  return null
+}
 
 export default function CallbackClient() {
   const searchParams = useSearchParams()
@@ -31,10 +54,14 @@ export default function CallbackClient() {
         const result = await loginWithKakaoAction(code, state)
 
         if (result.success) {
-          // user 정보는 UI 표시용으로 localStorage에 저장
-          localStorage.setItem('user', JSON.stringify(result.user))
-          login(result.user)
+          const latestUser = await fetchLatestUserProfile()
+          const userToStore = latestUser ?? result.user
 
+          // user 정보는 UI 표시용으로 localStorage에 저장
+          localStorage.setItem('user', JSON.stringify(userToStore))
+          login(userToStore)
+
+          alert(`${userToStore.nickname}님, 환영합니다!`)
           router.replace('/')
         } else {
           throw new Error(result.error)


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->
로그인 직후 로컬스토리지에 어드민여부를 저장합니다
## 📌 관련 이슈

<!-- Closes #이슈번호 -->

Closes #198 

## 🧩 작업 내용 (주요 변경사항)

- 콜백응답에 보정용 함수를 붙여 로그인 직후 로컬스토리지에 저장되도록 했습니다
-

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트

- [ ] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [ ] 불필요한 console.log 제거
- [ ] 로컬에서 실행 확인 완료
