### PR TITLE
feat: 결과 페이지 null 추천 데이터 대응 및 기본 상품 링크 보강(#200)

### DIFF
--- a/src/app/find-my-scent/_api/profilingClient.ts
+++ b/src/app/find-my-scent/_api/profilingClient.ts
@@ -187,7 +187,24 @@ export function resultDetailToContentBoxProps(detail: ProfilingResultDetail): {
   /** 추천한 향기와 어울리는 연관 추천 상품 보러가기 버튼 링크 */
   primaryButtonHref: string
 } {
-  const { recommended_blend, recommended_products } = detail
+  const { recommended_blend, recommended_products, input_data_summary } = detail
+
+  if (recommended_blend == null) {
+    const summary = input_data_summary?.trim() ?? ''
+    return {
+      productImageUrl: '',
+      productName: '추천 블렌드 준비 중',
+      description:
+        summary ||
+        '아직 추천 블렌드 정보가 없습니다. 잠시 후 새로고침하거나 테스트를 다시 진행해 주세요.',
+      scentTypeLabel: undefined,
+      showRecommendLabel: false,
+      scentTypeTags: [],
+      noteTags: [],
+      primaryButtonHref: recommended_products[0]?.purchase_url ?? '',
+    }
+  }
+
   const scentTypeTags =
     recommended_blend.contained_elements?.map(
       (e) => e.category?.en ?? e.category?.kr ?? ''

--- a/src/app/find-my-scent/_components/AIVisualModal.tsx
+++ b/src/app/find-my-scent/_components/AIVisualModal.tsx
@@ -51,8 +51,9 @@ const styles = {
     'flex min-h-[550px] w-full max-w-[1000px] flex-col rounded-2xl bg-white shadow-[0_24px_48px_-12px_rgba(0,0,0,0.18)] ring-1 ring-black/5',
   header:
     'relative flex shrink-0 flex-col items-center justify-center px-10 pt-8 pb-5 text-center',
+  /** 제품 유형 선택 모달(ProductTypeSelectModal) closeBtn 과 동일 — 헤더 패딩에 맞춰 top-8 만 다름 */
   closeBtn:
-    'absolute right-6 top-8 flex h-11 w-11 items-center justify-center rounded-full text-neutral-500 transition-colors hover:bg-neutral-100 hover:text-black',
+    'absolute right-6 top-8 flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-neutral-400 shadow-none transition-[color,box-shadow,transform] duration-150 ease-out hover:translate-y-px hover:scale-[0.96] hover:text-[var(--color-black-primary)] hover:shadow-[0_2px_6px_rgba(0,0,0,0.14)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-300 focus-visible:ring-offset-2 active:translate-y-0.5 active:scale-[0.92] active:shadow-[0_1px_3px_rgba(0,0,0,0.12)]',
   titleWrap: 'flex w-full flex-none items-center justify-center gap-2',
   titleIcon: 'relative h-8 w-8 shrink-0',
   title:

--- a/src/app/find-my-scent/_components/ResultContentBox.tsx
+++ b/src/app/find-my-scent/_components/ResultContentBox.tsx
@@ -34,6 +34,9 @@ export type ResultContentBoxProps = {
 
 const DEFAULT_PRIMARY_LABEL = '추천한 향기와 어울리는 연관 추천 상품 보러가기 →'
 
+/** API에 purchase_url 이 없을 때 외부 기본 링크로 유도 */
+const PRIMARY_BUTTON_FALLBACK_HREF = 'https://www.coupang.com/'
+
 const styles = {
   card: 'h-[770px] w-full max-w-[1200px] rounded-2xl bg-white px-6 py-6 shadow-[0_4px_20px_rgba(0,0,0,0.08)]',
   topRow: 'flex items-center gap-3 pb-4 border-b border-neutral-100',
@@ -75,6 +78,8 @@ export function ResultContentBox({
   resultType,
 }: ResultContentBoxProps) {
   const [isOtherTestModalOpen, setIsOtherTestModalOpen] = useState(false)
+  const resolvedPrimaryHref =
+    primaryButtonHref?.trim() || PRIMARY_BUTTON_FALLBACK_HREF
 
   return (
     <>
@@ -184,9 +189,9 @@ export function ResultContentBox({
           </div>
         </div>
 
-        {/* 하단 버튼 3개 */}
+        {/* 하단 버튼 3개 — 상품 URL 없으면 콤보 상품 목록으로 연결 */}
         <div className={styles.buttons}>
-          <Link href={primaryButtonHref} className={styles.btnPrimary}>
+          <Link href={resolvedPrimaryHref} className={styles.btnPrimary}>
             {primaryButtonLabel}
           </Link>
           <Link href={retestButtonHref} className={styles.btnSecondary}>

--- a/src/app/find-my-scent/_lib/loadProfilingResultPageProps.ts
+++ b/src/app/find-my-scent/_lib/loadProfilingResultPageProps.ts
@@ -2,6 +2,7 @@ import {
   fetchProfilingResult,
   resultDetailToContentBoxProps,
 } from '../_api/profilingClient'
+import { FetchError } from '@/lib/api/fetchError'
 import { mockProfilingResultDetail } from '@/mocks/data/profilingResults'
 
 const USE_MOCK = process.env.NEXT_PUBLIC_USE_MOCK_API === 'true'
@@ -61,7 +62,7 @@ export async function loadProfilingResultPageProps(
         (res as { error?: { message?: string } }).error?.message ??
         '결과를 불러오지 못했습니다.',
     }
-  } catch {
+  } catch (err) {
     if (USE_MOCK) {
       return {
         ok: true,
@@ -70,9 +71,15 @@ export async function loadProfilingResultPageProps(
         ),
       }
     }
+    const message =
+      err instanceof FetchError
+        ? err.message
+        : err instanceof Error
+          ? err.message
+          : '결과를 불러오지 못했습니다.'
     return {
       ok: false,
-      errorMessage: '결과를 불러오지 못했습니다.',
+      errorMessage: message,
     }
   }
 }

--- a/src/app/find-my-scent/_types/index.ts
+++ b/src/app/find-my-scent/_types/index.ts
@@ -98,7 +98,8 @@ export type ProfilingResultDetail = {
   input_data_type: string
   product_type: string
   input_data_summary: string
-  recommended_blend: ProfilingResultBlend
+  /** 분석·추천 파이프라인이 아직 없으면 null 일 수 있음 */
+  recommended_blend: ProfilingResultBlend | null
   recommended_products: { purchase_url: string }[]
   created_at: string
 }


### PR DESCRIPTION
## ✨ PR 개요
- #200 — 프로필링 결과 API가 `recommended_blend: null` 등 불완전 데이터를 줄 때 결과 페이지가 깨지지 않도록 처리하고, 추천 상품 URL이 없을 때 기본 링크를 둡니다.

## 📌 관련 이슈
<!-- Closes #이슈번호 -->
Closes #200 

## 🧩 작업 내용 (주요 변경사항)
- **타입**: `ProfilingResultDetail.recommended_blend`를 `null` 허용으로 명시
- **매핑**: `resultDetailToContentBoxProps`에서 `recommended_blend`가 없을 때 안전하게 처리 (요약 텍스트 활용, 태그/라벨 없음)
- **에러 메시지**: `loadProfilingResultPageProps`의 `catch`에서 `FetchError` 등 실제 메시지 노출
- **결과 UI**: `primaryButtonHref`가 비어 있을 때 **쿠팡(`https://www.coupang.com/`)** 으로 이동하는 fallback으로 첫 번째 버튼 유지
- **모달**: AI 비주얼 모달 닫기 버튼 스타일을 제품 유형 선택 모달과 동일한 hover/그림자/눌림 느낌으로 정리 (해당 변경이 브랜치에 포함된 경우)


## 💬 리뷰 포인트
<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항
- 근본적으로는 백엔드가 `success: true`와 함께 `recommended_blend: null`을 주는 스펙이 의도인지 확인 권장

## ✅ PR 체크리스트
- [ ] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [ ] 불필요한 console.log 제거
- [ ] 로컬에서 실행 확인 완료
