### PR TITLE
[feat] 향기저장소 api 연동 및 테스트 세분화(#187)

### DIFF
--- a/src/app/api/v1/users/me/analysis-results/route.ts
+++ b/src/app/api/v1/users/me/analysis-results/route.ts
@@ -1,0 +1,172 @@
+import { cookies } from 'next/headers'
+import { NextRequest, NextResponse } from 'next/server'
+import { postTokenRefresh } from '@/lib/api/auth'
+
+const BASE_COOKIE_OPTIONS = {
+  httpOnly: true,
+  secure: process.env.NODE_ENV === 'production',
+  sameSite: 'lax' as const,
+  path: '/',
+}
+
+const clearAuthCookies = (response: NextResponse) => {
+  response.cookies.set('access_token', '', { maxAge: 0, path: '/' })
+  response.cookies.set('refresh_token', '', { maxAge: 0, path: '/' })
+}
+
+const buildBackendUrl = (baseUrl: string, request: NextRequest): string => {
+  const url = new URL(request.url)
+  const query = url.searchParams.toString()
+  const suffix = query ? `?${query}` : ''
+  return `${baseUrl}/api/v1/users/me/analysis-results${suffix}`
+}
+
+const fetchAnalysisResults = async (url: string, accessToken: string) => {
+  return fetch(url, {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+    },
+    cache: 'no-store',
+  })
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const baseUrl = process.env.NEXT_PUBLIC_API_URL?.trim()
+
+    if (!baseUrl) {
+      return NextResponse.json(
+        {
+          success: false,
+          data: null,
+          error: {
+            code: 'MISSING_API_URL',
+            message: 'NEXT_PUBLIC_API_URL is not configured.',
+          },
+        },
+        { status: 500 }
+      )
+    }
+
+    const cookieStore = await cookies()
+    let accessToken = cookieStore.get('access_token')?.value
+    const refreshToken = cookieStore.get('refresh_token')?.value
+    const backendUrl = buildBackendUrl(baseUrl, request)
+
+    if (!accessToken && !refreshToken) {
+      return NextResponse.json(
+        {
+          success: false,
+          data: null,
+          error: {
+            code: 'NOT_AUTHENTICATED',
+            message: '인증이 필요합니다.',
+          },
+        },
+        { status: 401 }
+      )
+    }
+
+    // 1) access 토큰으로 우선 요청
+    if (accessToken) {
+      const upstream = await fetchAnalysisResults(backendUrl, accessToken)
+      if (upstream.ok) {
+        const data = await upstream.json()
+        return NextResponse.json(data, { status: upstream.status })
+      }
+
+      // 401이 아니면 그대로 전달
+      if (upstream.status !== 401) {
+        const errorData = await upstream.json().catch(() => null)
+        return NextResponse.json(
+          errorData ?? {
+            success: false,
+            data: null,
+            error: {
+              code: 'ANALYSIS_RESULTS_FETCH_FAILED',
+              message: '테스트 결과 목록 조회에 실패했습니다.',
+            },
+          },
+          { status: upstream.status }
+        )
+      }
+    }
+
+    // 2) access 토큰이 없거나 만료된 경우 refresh 시도
+    if (!refreshToken) {
+      const response = NextResponse.json(
+        {
+          success: false,
+          data: null,
+          error: {
+            code: 'NOT_AUTHENTICATED',
+            message: '인증이 필요합니다.',
+          },
+        },
+        { status: 401 }
+      )
+      clearAuthCookies(response)
+      return response
+    }
+
+    try {
+      const refreshed = await postTokenRefresh(refreshToken)
+      accessToken = refreshed.data.access_token
+
+      const upstream = await fetchAnalysisResults(backendUrl, accessToken)
+      const body = await upstream.json().catch(() => null)
+
+      const response = NextResponse.json(
+        body ?? {
+          success: false,
+          data: null,
+          error: {
+            code: 'ANALYSIS_RESULTS_FETCH_FAILED',
+            message: '테스트 결과 목록 조회에 실패했습니다.',
+          },
+        },
+        { status: upstream.status }
+      )
+
+      response.cookies.set('access_token', refreshed.data.access_token, {
+        ...BASE_COOKIE_OPTIONS,
+        maxAge: refreshed.data.expires_in,
+      })
+      response.cookies.set('refresh_token', refreshed.data.refresh_token, {
+        ...BASE_COOKIE_OPTIONS,
+        maxAge: refreshed.data.refresh_expires_in,
+      })
+
+      return response
+    } catch {
+      const response = NextResponse.json(
+        {
+          success: false,
+          data: null,
+          error: {
+            code: 'NOT_AUTHENTICATED',
+            message: '인증이 필요합니다.',
+          },
+        },
+        { status: 401 }
+      )
+      clearAuthCookies(response)
+      return response
+    }
+  } catch (error) {
+    console.error('Analysis results API error:', error)
+    return NextResponse.json(
+      {
+        success: false,
+        data: null,
+        error: {
+          code: 'ANALYSIS_RESULTS_FAILED',
+          message: '테스트 결과 목록을 조회하는 중 오류가 발생했습니다.',
+        },
+      },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/profile/storage/_types.ts
+++ b/src/app/profile/storage/_types.ts
@@ -1,18 +1,48 @@
-export interface StorageItem {
+export type AnalysisInputDataType =
+  | 'PREFERENCE'
+  | 'HEALTH'
+  | 'OOTD'
+  | 'INTERIOR'
+
+export interface AnalysisResultCategoryName {
+  kr: string
+  en: string
+}
+
+export interface AnalysisResultCategory {
+  name: AnalysisResultCategoryName
+}
+
+export interface AnalysisResultElement {
+  name: string
+  category: AnalysisResultCategoryName
+}
+
+export interface AnalysisResultBlend {
   id: number
-  input_data_type: string
+  name: string
+  image_url: string
+  categories: AnalysisResultCategory[]
+  contained_elements: AnalysisResultElement[]
+}
+
+export interface AnalysisResultItem {
+  id: number
+  input_data_type: AnalysisInputDataType
   product_type: string
-  recommended_blend: {
-    id: number
-    name: string
-    image_url: string
-    element_category: string
-    blend_category: string[]
-  }
+  matched_blend: AnalysisResultBlend | null
   created_at: string
 }
 
-export interface StorageApiResponse {
+export interface AnalysisResultListData {
+  results: AnalysisResultItem[]
+  page: number
+  size: number
+  count: number
+  total_pages: number
+}
+
+export interface AnalysisResultListApiResponse {
   success: boolean
-  data?: StorageItem[]
+  data?: AnalysisResultListData
 }

--- a/src/app/profile/storage/page.tsx
+++ b/src/app/profile/storage/page.tsx
@@ -1,9 +1,13 @@
 'use client'
 
 import StorageCard from '@/components/storage/StorageCard'
-import type { StorageApiResponse } from './_types'
+import type {
+  AnalysisInputDataType,
+  AnalysisResultItem,
+  AnalysisResultListApiResponse,
+} from './_types'
 import { useEffect, useState } from 'react'
-import { apiFetch } from '@/lib/api'
+import { resolveApiMediaUrl } from '@/lib/resolveApiMediaUrl'
 import HeartIcon from '@/assets/icons/heart.svg'
 import AdminTestIcon from '@/assets/icons/adminTest.svg'
 import AdminRecommendationIcon from '@/assets/icons/adminRecommendation.svg'
@@ -11,14 +15,90 @@ import AdminRecommendationIcon from '@/assets/icons/adminRecommendation.svg'
 const TAB_LIST = [
   { key: 'preference', label: '취향 테스트', icon: AdminTestIcon },
   { key: 'wellness', label: '웰니스 케어 진단', icon: HeartIcon },
-  { key: 'ai', label: 'AI 추천', icon: AdminRecommendationIcon },
+  { key: 'ai_ootd', label: 'AI OOTD', icon: AdminRecommendationIcon },
+  { key: 'ai_interior', label: 'AI 인테리어', icon: AdminRecommendationIcon },
 ] as const
 
 type TabKey = (typeof TAB_LIST)[number]['key']
 
+const ANALYSIS_RESULTS_API_PATH = '/api/v1/users/me/analysis-results'
+const DEFAULT_SORT = 'created_at_desc'
+const DEFAULT_PAGE = 1
+const DEFAULT_SIZE = 50
+
+const TAB_TO_INPUT_TYPES: Record<TabKey, AnalysisInputDataType[]> = {
+  preference: ['PREFERENCE'],
+  wellness: ['HEALTH'],
+  ai_ootd: ['OOTD'],
+  ai_interior: ['INTERIOR'],
+}
+
+const toAccordId = (raw: string | undefined): string => {
+  if (!raw) return 'base'
+  return raw.trim().toLowerCase()
+}
+
+const mapBlendCategories = (item: AnalysisResultItem): string[] => {
+  if (!item.matched_blend) return ['base']
+
+  const elements = Array.isArray(item.matched_blend.contained_elements)
+    ? item.matched_blend.contained_elements
+    : []
+
+  const ids = elements
+    .map((element) => toAccordId(element.category.en))
+    .filter(Boolean)
+
+  const uniqueIds = Array.from(new Set(ids))
+  return uniqueIds.length > 0 ? uniqueIds : ['base']
+}
+
+const getElementCategory = (item: AnalysisResultItem): string => {
+  if (!item.matched_blend) return 'base'
+
+  const elements = Array.isArray(item.matched_blend.contained_elements)
+    ? item.matched_blend.contained_elements
+    : []
+
+  const first = elements[0]
+  return toAccordId(first?.category.en)
+}
+
+const requestAnalysisResults = async (params: {
+  input_data_type: AnalysisInputDataType
+  sort: string
+  page: number
+  size: number
+}): Promise<AnalysisResultListApiResponse> => {
+  const query = new URLSearchParams({
+    input_data_type: params.input_data_type,
+    sort: params.sort,
+    page: String(params.page),
+    size: String(params.size),
+  }).toString()
+
+  const response = await fetch(`${ANALYSIS_RESULTS_API_PATH}?${query}`, {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json',
+    },
+    cache: 'no-store',
+  })
+
+  const data = (await response
+    .json()
+    .catch(() => null)) as AnalysisResultListApiResponse | null
+
+  if (!response.ok || !data) {
+    throw new Error('데이터를 불러오지 못했습니다')
+  }
+
+  return data
+}
+
 export default function ProfileStoragePage() {
   const [activeTab, setActiveTab] = useState<TabKey>('preference')
-  const [storageData, setStorageData] = useState<any[]>([])
+  const [storageData, setStorageData] = useState<AnalysisResultItem[]>([])
   const [tabCounts, setTabCounts] = useState<Record<TabKey, number> | null>(
     null
   )
@@ -26,57 +106,87 @@ export default function ProfileStoragePage() {
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
-    async function fetchStorage() {
+    async function fetchTabCounts() {
+      try {
+        const [preferenceRes, healthRes, ootdRes, interiorRes] =
+          await Promise.all([
+            requestAnalysisResults({
+              input_data_type: 'PREFERENCE',
+              sort: DEFAULT_SORT,
+              page: DEFAULT_PAGE,
+              size: 1,
+            }),
+            requestAnalysisResults({
+              input_data_type: 'HEALTH',
+              sort: DEFAULT_SORT,
+              page: DEFAULT_PAGE,
+              size: 1,
+            }),
+            requestAnalysisResults({
+              input_data_type: 'OOTD',
+              sort: DEFAULT_SORT,
+              page: DEFAULT_PAGE,
+              size: 1,
+            }),
+            requestAnalysisResults({
+              input_data_type: 'INTERIOR',
+              sort: DEFAULT_SORT,
+              page: DEFAULT_PAGE,
+              size: 1,
+            }),
+          ])
+
+        setTabCounts({
+          preference: preferenceRes.data?.count ?? 0,
+          wellness: healthRes.data?.count ?? 0,
+          ai_ootd: ootdRes.data?.count ?? 0,
+          ai_interior: interiorRes.data?.count ?? 0,
+        })
+      } catch {
+        setTabCounts({ preference: 0, wellness: 0, ai_ootd: 0, ai_interior: 0 })
+      }
+    }
+
+    fetchTabCounts()
+  }, [])
+
+  useEffect(() => {
+    async function fetchStorageByTab() {
       setLoading(true)
       setError(null)
+
       try {
-        const res = await apiFetch<StorageApiResponse>('/api/v1/storage')
-        if (!res.success || !res.data) {
-          setError('데이터를 불러오지 못했습니다')
-          setStorageData([])
-          setTabCounts({ preference: 0, wellness: 0, ai: 0 })
-          return
-        }
-        setStorageData(res.data)
-        setTabCounts({
-          preference: res.data.filter(
-            (item) => item.input_data_type === 'PREFERENCE'
-          ).length,
-          wellness: res.data.filter(
-            (item) => item.input_data_type === 'WELLNESS'
-          ).length,
-          ai: res.data.filter((item) => item.input_data_type === 'AI_VISUAL')
-            .length,
-        })
+        const inputTypes = TAB_TO_INPUT_TYPES[activeTab]
+        const responses = await Promise.all(
+          inputTypes.map((inputType) =>
+            requestAnalysisResults({
+              input_data_type: inputType,
+              sort: DEFAULT_SORT,
+              page: DEFAULT_PAGE,
+              size: DEFAULT_SIZE,
+            })
+          )
+        )
+
+        const mergedResults = responses
+          .flatMap((res) => (res.success && res.data ? res.data.results : []))
+          .sort(
+            (a, b) =>
+              new Date(b.created_at).getTime() -
+              new Date(a.created_at).getTime()
+          )
+
+        setStorageData(mergedResults)
       } catch (e: any) {
         setError(e?.message || '데이터를 불러오지 못했습니다')
+        setStorageData([])
       } finally {
         setLoading(false)
       }
     }
-    fetchStorage()
-  }, [])
-  const handleDelete = async (id: number) => {
-    try {
-      await apiFetch.delete(`/api/v1/storage/${id}`)
-      setStorageData((prev) => {
-        const newData = prev.filter((item) => item.id !== id)
-        setTabCounts({
-          preference: newData.filter(
-            (item) => item.input_data_type === 'PREFERENCE'
-          ).length,
-          wellness: newData.filter(
-            (item) => item.input_data_type === 'WELLNESS'
-          ).length,
-          ai: newData.filter((item) => item.input_data_type === 'AI_VISUAL')
-            .length,
-        })
-        return newData
-      })
-    } catch (e) {
-      alert('삭제에 실패했습니다.')
-    }
-  }
+
+    fetchStorageByTab()
+  }, [activeTab])
 
   return (
     <div className="mb-6 flex flex-col items-center text-2xl">
@@ -86,7 +196,7 @@ export default function ProfileStoragePage() {
       </p>
 
       {/* 상단 탭 버튼 */}
-      <div className="my-8 flex h-13.5 w-141 items-center justify-center gap-4 rounded-full bg-white">
+      <div className="my-8 flex h-13.5 w-195 items-center justify-center gap-4 rounded-full bg-white">
         {TAB_LIST.map((tab) => (
           <button
             key={tab.key}
@@ -113,31 +223,23 @@ export default function ProfileStoragePage() {
       <div className="flex flex-wrap justify-center">
         {loading && <div>로딩 중...</div>}
         {error && <div className="text-red-500">{error}</div>}
+        {!loading && !error && storageData.length === 0 && (
+          <div className="text-gray-500">저장된 결과가 없습니다.</div>
+        )}
         {!loading &&
           !error &&
-          storageData
-            .filter((item) => {
-              if (activeTab === 'preference')
-                return item.input_data_type === 'PREFERENCE'
-              if (activeTab === 'wellness')
-                return item.input_data_type === 'WELLNESS'
-              if (activeTab === 'ai')
-                return item.input_data_type === 'AI_VISUAL'
-              return true
-            })
-            .map((item) => (
-              <StorageCard
-                key={item.id}
-                blendName={item.recommended_blend.name}
-                blendImageUrl={item.recommended_blend.image_url}
-                productType={item.product_type}
-                elementCategory={item.recommended_blend.element_category}
-                blendCategory={item.recommended_blend.blend_category}
-                createdAt={item.created_at}
-                onDelete={() => handleDelete(item.id)}
-                onDetail={() => console.log('자세히 보기 클릭')}
-              />
-            ))}
+          storageData.map((item) => (
+            <StorageCard
+              key={item.id}
+              blendName={item.matched_blend?.name ?? '추천 블렌드 생성 중'}
+              blendImageUrl={resolveApiMediaUrl(item.matched_blend?.image_url)}
+              productType={item.product_type}
+              elementCategory={getElementCategory(item)}
+              blendCategory={mapBlendCategories(item)}
+              createdAt={item.created_at ?? ''}
+              onDetail={() => console.log('자세히 보기 클릭')}
+            />
+          ))}
       </div>
     </div>
   )

--- a/src/components/storage/StorageCard.tsx
+++ b/src/components/storage/StorageCard.tsx
@@ -33,12 +33,14 @@ export default function StorageCard({
           />
         ) : null}
         {/* 삭제 아이콘 */}
-        <button
-          onClick={onDelete}
-          className="absolute top-4 right-4 rounded-[10px] bg-white p-2 shadow"
-        >
-          <Trashicon className="h-4 w-4" />
-        </button>
+        {onDelete ? (
+          <button
+            onClick={onDelete}
+            className="absolute top-4 right-4 rounded-[10px] bg-white p-2 shadow"
+          >
+            <Trashicon className="h-4 w-4" />
+          </button>
+        ) : null}
       </div>
       {/* 하단 내용 */}
       <div className="flex flex-1 flex-col px-6 py-4">

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -11,7 +11,24 @@ const DEFAULT_HEADERS: Record<string, string> = {
 }
 
 const AUTH_REFRESH_PATH = '/api/auth/refresh'
-const RETRY_HEADER = 'x-auth-retried'
+
+let refreshPromise: Promise<Response> | null = null
+
+const requestTokenRefresh = async (): Promise<Response> => {
+  if (!refreshPromise) {
+    refreshPromise = fetch(AUTH_REFRESH_PATH, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+    }).finally(() => {
+      refreshPromise = null
+    })
+  }
+
+  return refreshPromise
+}
 
 type RefreshErrorPayload = {
   success?: boolean
@@ -76,50 +93,36 @@ export const appFetch = createFetch({
         typeof window !== 'undefined' &&
         !requestArgs.url.includes(AUTH_REFRESH_PATH)
       ) {
-        const headers = new Headers(requestArgs.options.headers as HeadersInit)
-        const hasRetried = headers.get(RETRY_HEADER) === '1'
+        const refreshResponse = await requestTokenRefresh()
 
-        if (!hasRetried) {
-          const refreshResponse = await fetch(AUTH_REFRESH_PATH, {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              Accept: 'application/json',
-            },
+        if (refreshResponse.ok) {
+          const retryResponse = await fetch(requestArgs.url, {
+            ...requestArgs.options,
           })
 
-          if (refreshResponse.ok) {
-            headers.set(RETRY_HEADER, '1')
-
-            const retryResponse = await fetch(requestArgs.url, {
-              ...requestArgs.options,
-              headers: Object.fromEntries(headers.entries()),
-            })
-
-            if (retryResponse.ok) {
-              return retryResponse
-            }
-
-            return handleResponse(retryResponse)
+          if (retryResponse.ok) {
+            return retryResponse
           }
 
-          const refreshError = (await refreshResponse
-            .json()
-            .catch(() => null)) as RefreshErrorPayload | null
-
-          const { useModalStore } = await import('@/store/useModalStore')
-          useModalStore.getState().openAlert({
-            type: 'danger',
-            title: '인증이 만료되었습니다.',
-            content:
-              refreshError?.error?.message ||
-              '세션이 만료되었습니다. 다시 로그인해 주세요.',
-            confirmText: '로그인으로 이동',
-            onConfirm: () => {
-              window.location.href = '/login'
-            },
-          })
+          return handleResponse(retryResponse)
         }
+
+        const refreshError = (await refreshResponse
+          .json()
+          .catch(() => null)) as RefreshErrorPayload | null
+
+        const { useModalStore } = await import('@/store/useModalStore')
+        useModalStore.getState().openAlert({
+          type: 'danger',
+          title: '인증이 만료되었습니다.',
+          content:
+            refreshError?.error?.message ||
+            '세션이 만료되었습니다. 다시 로그인해 주세요.',
+          confirmText: '로그인으로 이동',
+          onConfirm: () => {
+            window.location.href = '/login'
+          },
+        })
       }
 
       return handleResponse(response)

--- a/src/mocks/data/storage.ts
+++ b/src/mocks/data/storage.ts
@@ -3,12 +3,18 @@ const data = [
     id: 1,
     input_data_type: 'PREFERENCE',
     product_type: 'DIFFUSER',
-    recommended_blend: {
+    matched_blend: {
       id: 5,
       name: '포근한 숲',
       image_url: '/img/5.svg',
-      element_category: 'base',
-      blend_category: ['#포근', '#휴식'],
+      categories: [
+        { name: { kr: '휴식', en: 'Rest' } },
+        { name: { kr: '기분전환', en: 'Refresh' } },
+      ],
+      contained_elements: [
+        { name: '리차징', category: { kr: '베이스', en: 'Base' } },
+        { name: '라벤더', category: { kr: '아로마틱', en: 'Aromatic' } },
+      ],
     },
     created_at: '2026-02-28T14:30:00Z',
   },
@@ -16,12 +22,18 @@ const data = [
     id: 7,
     input_data_type: 'PREFERENCE',
     product_type: 'CANDLE',
-    recommended_blend: {
+    matched_blend: {
       id: 11,
       name: '달콤한 라벤더',
       image_url: '/img/11.svg',
-      element_category: 'floral',
-      blend_category: ['#휴식', '#기분전환'],
+      categories: [
+        { name: { kr: '휴식', en: 'Rest' } },
+        { name: { kr: '기분전환', en: 'Refresh' } },
+      ],
+      contained_elements: [
+        { name: '로즈', category: { kr: '플로럴', en: 'Floral' } },
+        { name: '라벤더', category: { kr: '아로마틱', en: 'Aromatic' } },
+      ],
     },
     created_at: '2026-03-04T12:00:00Z',
   },
@@ -29,38 +41,56 @@ const data = [
     id: 8,
     input_data_type: 'PREFERENCE',
     product_type: 'PERFUME',
-    recommended_blend: {
+    matched_blend: {
       id: 12,
       name: '상큼한 시트러스',
       image_url: '/img/12.svg',
-      element_category: 'citrus',
-      blend_category: ['#기분전환', '#집중'],
+      categories: [
+        { name: { kr: '기분전환', en: 'Refresh' } },
+        { name: { kr: '집중', en: 'Focus' } },
+      ],
+      contained_elements: [
+        { name: '자몽', category: { kr: '시트러스', en: 'Citrus' } },
+        { name: '오렌지', category: { kr: '시트러스', en: 'Citrus' } },
+      ],
     },
     created_at: '2026-03-04T13:30:00Z',
   },
   {
     id: 2,
-    input_data_type: 'WELLNESS',
+    input_data_type: 'HEALTH',
     product_type: 'CANDLE',
-    recommended_blend: {
+    matched_blend: {
       id: 6,
       name: '상쾌한 바람',
       image_url: '/img/6.svg',
-      element_category: 'citrus',
-      blend_category: ['#운동', '#집중'],
+      categories: [
+        { name: { kr: '운동', en: 'Workout' } },
+        { name: { kr: '집중', en: 'Focus' } },
+      ],
+      contained_elements: [
+        { name: '레몬', category: { kr: '시트러스', en: 'Citrus' } },
+        { name: '민트', category: { kr: '아로마틱', en: 'Aromatic' } },
+      ],
     },
     created_at: '2026-03-01T09:15:00Z',
   },
   {
     id: 3,
-    input_data_type: 'AI_VISUAL',
+    input_data_type: 'OOTD',
     product_type: 'PERFUME',
-    recommended_blend: {
+    matched_blend: {
       id: 7,
       name: '따뜻한 햇살',
       image_url: '/img/7.svg',
-      element_category: 'floral',
-      blend_category: ['#기분전환', '#로맨틱'],
+      categories: [
+        { name: { kr: '기분전환', en: 'Refresh' } },
+        { name: { kr: '로맨틱', en: 'Romantic' } },
+      ],
+      contained_elements: [
+        { name: '로즈', category: { kr: '플로럴', en: 'Floral' } },
+        { name: '앰버', category: { kr: '오리엔탈', en: 'Oriental' } },
+      ],
     },
     created_at: '2026-03-02T18:45:00Z',
   },
@@ -68,38 +98,56 @@ const data = [
     id: 4,
     input_data_type: 'PREFERENCE',
     product_type: 'DIFFUSER',
-    recommended_blend: {
+    matched_blend: {
       id: 8,
       name: '싱그러운 잎새',
       image_url: '/img/8.svg',
-      element_category: 'woody',
-      blend_category: ['#포근', '#운동'],
+      categories: [
+        { name: { kr: '포근', en: 'Cozy' } },
+        { name: { kr: '운동', en: 'Workout' } },
+      ],
+      contained_elements: [
+        { name: '시더우드', category: { kr: '우디', en: 'Woody' } },
+        { name: '파촐리', category: { kr: '오리엔탈', en: 'Oriental' } },
+      ],
     },
     created_at: '2026-03-03T10:00:00Z',
   },
   {
     id: 5,
-    input_data_type: 'WELLNESS',
+    input_data_type: 'HEALTH',
     product_type: 'CANDLE',
-    recommended_blend: {
+    matched_blend: {
       id: 9,
       name: '달콤한 과일',
       image_url: '/img/9.svg',
-      element_category: 'oriental',
-      blend_category: ['#로맨틱', '#숙면'],
+      categories: [
+        { name: { kr: '로맨틱', en: 'Romantic' } },
+        { name: { kr: '숙면', en: 'Sleep' } },
+      ],
+      contained_elements: [
+        { name: '바닐라', category: { kr: '오리엔탈', en: 'Oriental' } },
+        { name: '머스크', category: { kr: '애니멀릭', en: 'Animalic' } },
+      ],
     },
     created_at: '2026-03-03T15:30:00Z',
   },
   {
     id: 6,
-    input_data_type: 'AI_VISUAL',
+    input_data_type: 'INTERIOR',
     product_type: 'PERFUME',
-    recommended_blend: {
+    matched_blend: {
       id: 10,
       name: '시원한 바다',
       image_url: '/img/10.svg',
-      element_category: 'base',
-      blend_category: ['#집중', '#숙면'],
+      categories: [
+        { name: { kr: '집중', en: 'Focus' } },
+        { name: { kr: '숙면', en: 'Sleep' } },
+      ],
+      contained_elements: [
+        { name: '해조', category: { kr: '베이스', en: 'Base' } },
+        { name: '민트', category: { kr: '아로마틱', en: 'Aromatic' } },
+      ],
     },
     created_at: '2026-03-04T08:20:00Z',
   },

--- a/src/mocks/handlers/storageHandlers.ts
+++ b/src/mocks/handlers/storageHandlers.ts
@@ -2,19 +2,39 @@ import { http, HttpResponse } from 'msw'
 import data from '../data/storage'
 
 export const storageHandlers = [
-  // 스토리지 목록 조회
-  http.get('*/api/v1/storage', () => {
+  // 테스트 결과 목록 조회
+  http.get('*/api/v1/users/me/analysis-results', ({ request }) => {
+    const url = new URL(request.url)
+    const inputDataType = url.searchParams.get('input_data_type')
+    const page = Number(url.searchParams.get('page') ?? 1)
+    const size = Number(url.searchParams.get('size') ?? 10)
+
+    let filtered = data
+    if (inputDataType === 'PREFERENCE') {
+      filtered = data.filter((item) => item.input_data_type === 'PREFERENCE')
+    }
+    if (inputDataType === 'HEALTH') {
+      filtered = data.filter((item) => item.input_data_type === 'HEALTH')
+    }
+    if (inputDataType === 'OOTD') {
+      filtered = data.filter((item) => item.input_data_type === 'OOTD')
+    }
+    if (inputDataType === 'INTERIOR') {
+      filtered = data.filter((item) => item.input_data_type === 'INTERIOR')
+    }
+
+    const start = (page - 1) * size
+    const results = filtered.slice(start, start + size)
+
     return HttpResponse.json({
       success: true,
-      data,
+      data: {
+        results,
+        page,
+        size,
+        count: filtered.length,
+        total_pages: Math.ceil(filtered.length / size),
+      },
     })
-  }),
-
-  // 스토리지 아이템 삭제
-  http.delete('*/api/v1/storage/:id', ({ params }) => {
-    const id = Number(params.id)
-    const idx = data.findIndex((item) => item.id === id)
-    if (idx !== -1) data.splice(idx, 1)
-    return HttpResponse.json({ success: true })
   }),
 ]


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->
향기 저장소 api 연동 및 탭/카운트/목록 조회를 input_data_type 기준으로 분리했습니다.
## 📌 관련 이슈

<!-- Closes #이슈번호 -->

Closes #187 

## 🧩 작업 내용 (주요 변경사항)

- 향기 저장소 API를 /api/v1/users/me/analysis-results 기반으로 연동
- input_data_type 기준 4개 탭(취향/웰니스/AI OOTD/AI 인테리어) 분류 조회 및 탭별 카운트 조회 구현
- matched_blend null 케이스 대응(런타임 에러 방지 및 fallback 렌더링)

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->
현재 작업중 matched_blend가 null로 들어오고있어 더미데이터로 카드가 나오고있습니다 
이후 matched_blend가 정상적으로 들어오면 바로 작업 재개 하겠습니다
## ✅ PR 체크리스트

- [ ] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [ ] 불필요한 console.log 제거
- [ ] 로컬에서 실행 확인 완료
