### PR TITLE
[Feat] 랜딩 페이지 리디자인 및 헤더 모바일 메뉴 추가 (#204)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,36 +1,13 @@
-'use client'
-import LandingCard from '@/components/Landing/LandingCard'
+import LandingHero from '@/components/Landing/LandingHero'
 import LandingCarousel from '@/components/Landing/LandingCarousel'
+import LandingCard from '@/components/Landing/LandingCard'
+
 export default function Home() {
   return (
-    <div className="flex min-h-screen w-full flex-col items-center">
+    <>
+      <LandingHero />
       <LandingCarousel />
-      <h1 className="mb-4 text-center text-[36px] font-semibold">
-        나의 향기 찾기
-      </h1>
-      <p className="mb-8 text-center text-[18px] font-normal text-neutral-600">
-        당신에게 딱 맞는 향기를 찾는 세 가지 방법
-      </p>
-      <div className="mb-30 flex justify-center gap-6">
-        <LandingCard
-          title="취향 테스트"
-          description="당신의 취향과 라이프스타일을 분석하여 일상에 어울리는 향기를 추천합니다"
-          link="/find-my-scent/taste-test"
-          imgSrc="/LandingTasteTest.svg"
-        />
-        <LandingCard
-          title="웰니스 케어 진단"
-          description="건강 상태와 컨디션을 체크하여 심신 안정에 도움이 되는 아로마 테라피를 제안합니다"
-          link="/find-my-scent/wellness"
-          imgSrc="/LandingWellness.svg"
-        />
-        <LandingCard
-          title="AI 비주얼 분석"
-          description="인테리어, OOTD, 차량 등 사진을 업로드하면 AI가 분위기를 분석하여 어울리는 향기를 추천합니다"
-          link="/find-my-scent/ai-visual"
-          imgSrc="/LandingAiVisual.svg"
-        />
-      </div>
-    </div>
+      <LandingCard />
+    </>
   )
 }

--- a/src/components/Landing/LandingCard.tsx
+++ b/src/components/Landing/LandingCard.tsx
@@ -1,24 +1,132 @@
-function LandingCard({
-  title,
-  description,
-  link,
-  imgSrc,
-}: {
-  title: string
-  description: string
-  link: string
-  imgSrc: string
-}) {
+'use client'
+import Link from 'next/link'
+import { motion, type Variants } from 'motion/react'
+
+const cards = [
+  {
+    index: 0,
+    title: '취향 테스트',
+    meta: '약 3분 · 7문항',
+    description:
+      '생활 방식과 취향을 분석해 나의 일상에 꼭 맞는 향기를 추천합니다',
+    link: '/find-my-scent/taste-test',
+    imgSrc: '/LandingTasteTest.svg',
+  },
+  {
+    index: 1,
+    title: '웰니스 케어 진단',
+    meta: '약 2분 · 5문항',
+    description:
+      '현재 컨디션과 건강 상태를 체크해 심신 안정에 도움이 되는 아로마를 제안합니다',
+    link: '/find-my-scent/wellness',
+    imgSrc: '/LandingWellness.svg',
+  },
+  {
+    index: 2,
+    title: 'AI 비주얼 분석',
+    meta: '이미지 업로드 · AI 즉시 분석',
+    description:
+      '인테리어·OOTD·공간 사진을 올리면 AI가 분위기를 읽고 어울리는 향기를 찾아줍니다',
+    link: '/find-my-scent/ai-visual',
+    imgSrc: '/LandingAiVisual.svg',
+  },
+]
+
+const containerVariant: Variants = {
+  hidden: {},
+  show: { transition: { staggerChildren: 0.12, delayChildren: 0.05 } },
+}
+
+const cardVariant: Variants = {
+  hidden: { opacity: 0, y: 24 },
+  show: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.5, ease: [0.25, 0.46, 0.45, 0.94] },
+  },
+}
+
+export default function LandingCard() {
   return (
-    <div className="flex h-78.25 w-91 flex-col gap-4 rounded-[24px] bg-[#FBF9F7] p-8.25 shadow-md">
-      <img src={imgSrc} alt={title} className="mb-2 h-16.25 w-16.25" />
-      <h2 className="text-2xl font-bold">{title}</h2>
-      <p>{description}</p>
-      <a href={link} className="text-black-primary">
-        시작하기 →
-      </a>
-    </div>
+    <section className="flex min-h-screen w-full flex-col items-center justify-center py-16">
+      <motion.h2
+        initial={{ opacity: 0, y: 16 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true, amount: 0.8 }}
+        transition={{ duration: 0.5 }}
+        className="mb-3 text-center text-4xl font-semibold"
+      >
+        나의 향기 찾기
+      </motion.h2>
+
+      <motion.p
+        initial={{ opacity: 0, y: 12 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true, amount: 0.8 }}
+        transition={{ duration: 0.5, delay: 0.1 }}
+        className="text-gray-primary mb-10 text-center text-base sm:text-lg"
+      >
+        세 가지 분석 방법으로 당신만의 시그니처 향을 찾아드립니다
+      </motion.p>
+
+      <motion.div
+        className="flex flex-wrap justify-center gap-4 px-4 sm:gap-5 sm:px-6 lg:gap-6 lg:px-8"
+        variants={containerVariant}
+        initial="hidden"
+        whileInView="show"
+        viewport={{ once: true, amount: 0.15 }}
+      >
+        {cards.map((card) => (
+          <CardItem key={card.index} {...card} />
+        ))}
+      </motion.div>
+    </section>
   )
 }
 
-export default LandingCard
+function CardItem({
+  index,
+  title,
+  meta,
+  description,
+  link,
+  imgSrc,
+}: (typeof cards)[number]) {
+  return (
+    <motion.div
+      variants={cardVariant}
+      whileHover={{ y: -4, transition: { duration: 0.1 } }}
+      className="flex w-full flex-none flex-col rounded-3xl bg-white p-8 sm:min-h-[480px] sm:w-80 sm:p-10"
+    >
+      <span className="text-gray-secondary mb-6 text-xs font-semibold">
+        {String(index + 1).padStart(2, '0')}
+      </span>
+
+      <img
+        src={imgSrc}
+        alt=""
+        aria-hidden
+        className="mb-6 h-14 w-14 transition-transform duration-300 sm:h-16 sm:w-16"
+      />
+
+      <div className="flex flex-1 flex-col gap-3">
+        <h3 className="text-2xl leading-tight font-bold sm:text-3xl">
+          {title}
+        </h3>
+        <span className="bg-gray-white text-gray-primary inline-flex w-fit items-center rounded-full px-3 py-1 text-xs font-medium">
+          {meta}
+        </span>
+        <p className="text-gray-primary text-sm leading-relaxed sm:text-base">
+          {description}
+        </p>
+      </div>
+
+      <Link
+        href={link}
+        className="bg-black-primary mt-6 flex w-full items-center justify-center rounded-2xl py-3.5 text-sm font-medium text-white transition-opacity hover:opacity-80"
+      >
+        테스트 시작하기
+      </Link>
+    </motion.div>
+  )
+}

--- a/src/components/Landing/LandingCarousel.tsx
+++ b/src/components/Landing/LandingCarousel.tsx
@@ -1,88 +1,133 @@
 'use client'
-import { useState } from 'react'
-
-const slides = [
-  {
-    img: '/Landing1.svg',
-    title: 'DeepCent Déprimés Diffuser',
-    button: '제품 보러 가기 >',
-    link: '#',
-  },
-  {
-    img: '/Landing3.svg',
-    title: 'DeepCent Déprimés Diffuser',
-    button: '향수 추천 받기 >',
-    link: '#',
-  },
-]
+import { useState, useEffect, useRef } from 'react'
+import Link from 'next/link'
+import { motion, AnimatePresence } from 'motion/react'
+import { CAROUSEL_INTERVAL, slides } from '@/constants/landingCarousel'
 
 export default function LandingCarousel() {
-  const [activeSlide, setActiveSlide] = useState(0)
-  const goToPrev = () =>
-    setActiveSlide((prev) => (prev === 0 ? slides.length - 1 : prev - 1))
-  const goToNext = () =>
-    setActiveSlide((prev) => (prev === slides.length - 1 ? 0 : prev + 1))
+  const [active, setActive] = useState(0)
+  const [inView, setInView] = useState(false)
+  const sectionRef = useRef<HTMLElement>(null)
+
+  useEffect(() => {
+    const el = sectionRef.current
+    if (!el) return
+    const observer = new IntersectionObserver(
+      ([entry]) => setInView(entry.isIntersecting),
+      { threshold: 0.1 }
+    )
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
+  useEffect(() => {
+    if (!inView) return
+    const id = setTimeout(
+      () => setActive((i) => (i + 1) % slides.length),
+      CAROUSEL_INTERVAL
+    )
+    return () => clearTimeout(id)
+  }, [active, inView])
+
+  const prev = () => setActive((i) => (i === 0 ? slides.length - 1 : i - 1))
+  const next = () => setActive((i) => (i + 1) % slides.length)
 
   return (
-    <div className="relative mb-20 flex h-225.75 w-full flex-col items-center overflow-hidden">
-      <div className="relative mx-auto mb-6 h-225.75 w-full overflow-hidden rounded-none">
-        {/* 슬라이드 영역 */}
-        <div
-          className="flex w-full transition-transform duration-500 ease-in-out"
-          style={{ transform: `translateX(-${activeSlide * 100}%)` }}
-        >
-          {slides.map((slide, idx) => (
-            <div key={idx} className="flex h-225.75 w-full flex-none">
-              {/* 왼쪽 이미지 */}
-              <div className="flex h-full w-1/2 items-center justify-center bg-[#e7dccb]">
-                <img
-                  src={slide.img}
-                  alt="캐러셀 이미지"
-                  className="h-full w-full object-cover"
-                />
-              </div>
-              {/* 오른쪽 텍스트 */}
-              <div className="flex h-full w-1/2 flex-col items-start justify-center px-12">
-                <h2 className="mb-6 font-serif text-[70px] leading-tight font-semibold tracking-wide">
-                  {slide.title}
-                </h2>
-                <a
-                  href={slide.link}
-                  className="inline-block rounded-full bg-black px-6 py-2 text-[32px] text-white"
-                >
-                  {slide.button}
-                </a>
-              </div>
-            </div>
-          ))}
+    <section
+      ref={sectionRef}
+      className="flex min-h-[calc(100vh-56px)] w-full flex-col items-center"
+    >
+      <div className="flex flex-1 flex-col items-center justify-center gap-5">
+        <div className="relative mb-10 flex h-72 w-72 sm:h-80 sm:w-80">
+          <AnimatePresence mode="wait">
+            <motion.img
+              key={active}
+              src={slides[active].img}
+              alt={slides[active].title.replace('\n', ' ')}
+              initial={{ opacity: 0, scale: 0.98 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 1.02 }}
+              transition={{ duration: 0.6, ease: [0.25, 0.46, 0.45, 0.94] }}
+              className="h-full w-full object-contain"
+            />
+          </AnimatePresence>
         </div>
-        {/* 좌우 버튼 */}
-        <button
-          onClick={goToPrev}
-          className="absolute top-1/2 left-2 flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-full bg-white/80 shadow hover:bg-white"
-          aria-label="이전 슬라이드"
-        >
-          &#8592;
-        </button>
-        <button
-          onClick={goToNext}
-          className="absolute top-1/2 right-2 flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-full bg-white/80 shadow hover:bg-white"
-          aria-label="다음 슬라이드"
-        >
-          &#8594;
-        </button>
+
+        <AnimatePresence mode="wait">
+          <motion.div
+            key={`text-${active}`}
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -10 }}
+            transition={{ duration: 0.5, ease: [0.25, 0.46, 0.45, 0.94] }}
+            className="flex flex-col items-center gap-3 px-6 text-center"
+          >
+            <div className="flex items-center gap-3">
+              <span className="bg-black-primary/25 h-px w-6" />
+              <span className="text-gray-secondary text-xs font-medium tracking-[0.25em] uppercase">
+                {slides[active].eyebrow}
+              </span>
+              <span className="bg-black-primary/25 h-px w-6" />
+            </div>
+            <h2 className="text-4xl leading-tight font-semibold tracking-tight whitespace-pre-line sm:text-5xl">
+              {slides[active].title}
+            </h2>
+            <p className="text-gray-primary text-base sm:text-lg">
+              {slides[active].subtitle}
+            </p>
+            <Link
+              href={slides[active].link}
+              className="bg-black-primary mt-3 inline-flex items-center gap-2 rounded-full px-7 py-3 text-sm font-medium text-white transition-opacity hover:opacity-75"
+            >
+              {slides[active].cta}
+              <span aria-hidden>→</span>
+            </Link>
+          </motion.div>
+        </AnimatePresence>
       </div>
-      {/* 인디케이터 */}
-      <div className="mb-12 flex items-center justify-center gap-2">
+
+      <div className="flex items-center gap-5 pb-2">
+        <button
+          onClick={prev}
+          aria-label="이전 슬라이드"
+          className="text-black-primary/35 hover:text-black-primary cursor-pointer text-sm transition-colors"
+        >
+          ←
+        </button>
+
         {slides.map((_, idx) => (
           <button
             key={idx}
-            className={`h-3 w-3 rounded-full ${activeSlide === idx ? 'bg-black opacity-80' : 'bg-black opacity-30'}`}
-            onClick={() => setActiveSlide(idx)}
+            onClick={() => setActive(idx)}
             aria-label={`슬라이드 ${idx + 1}`}
-          />
+            className="bg-black-primary/15 relative h-1 w-12 cursor-pointer overflow-hidden rounded-full"
+          >
+            {idx < active && (
+              <div className="bg-black-primary/50 absolute inset-0 rounded-full" />
+            )}
+            {idx === active && (
+              <motion.div
+                key={`${active}-${inView}`}
+                className="bg-black-primary absolute inset-0 origin-left rounded-full"
+                initial={{ scaleX: 0 }}
+                animate={{ scaleX: 1 }}
+                transition={{
+                  duration: CAROUSEL_INTERVAL / 1000,
+                  ease: 'linear',
+                }}
+              />
+            )}
+          </button>
         ))}
+
+        <button
+          onClick={next}
+          aria-label="다음 슬라이드"
+          className="text-black-primary/35 hover:text-black-primary cursor-pointer text-sm transition-colors"
+        >
+          →
+        </button>
       </div>
-    </div>
+    </section>
   )
 }

--- a/src/components/Landing/LandingHero.tsx
+++ b/src/components/Landing/LandingHero.tsx
@@ -1,0 +1,60 @@
+'use client'
+import { motion } from 'motion/react'
+import Image from 'next/image'
+
+export default function LandingHero() {
+  return (
+    <section className="relative flex min-h-screen w-full items-center justify-center overflow-hidden">
+      <Image
+        src="/img/landing.jpg"
+        alt="Landing-hero"
+        fill
+        className="object-cover"
+      />
+
+      <div className="absolute inset-0 bg-black/55" />
+
+      {/* 텍스트 */}
+      <div className="relative z-10 flex flex-col items-center gap-5 px-6 text-center text-white">
+        <motion.span
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, ease: [0.25, 0.46, 0.45, 0.94] }}
+          className="text-xs font-medium tracking-[0.3em] text-white/60 uppercase"
+        >
+          Deepscent
+        </motion.span>
+
+        <motion.h1
+          initial={{ opacity: 0, y: 16 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{
+            duration: 0.7,
+            delay: 0.1,
+            ease: [0.25, 0.46, 0.45, 0.94],
+          }}
+          className="text-5xl leading-tight font-bold tracking-tight sm:text-6xl lg:text-7xl"
+        >
+          당신만을 위한
+          <br />
+          맞춤 향 추천
+        </motion.h1>
+
+        <motion.p
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{
+            duration: 0.7,
+            delay: 0.2,
+            ease: [0.25, 0.46, 0.45, 0.94],
+          }}
+          className="max-w-lg text-base leading-relaxed text-white/75 sm:text-lg"
+        >
+          취향 테스트·웰니스 진단·AI 비주얼 분석으로
+          <br />
+          나에게 꼭 맞는 향기와 제품까지 한번에 찾아드립니다
+        </motion.p>
+      </div>
+    </section>
+  )
+}

--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -3,12 +3,13 @@ import Image from 'next/image'
 const styles = {
   footer: 'border-t border-neutral-200 bg-white',
   container: 'mx-auto max-w-6xl px-4 py-12 sm:px-6',
-  grid: 'grid grid-cols-1 gap-10 md:grid-cols-3',
+  grid: 'grid grid-cols-1 divide-y md:divide-y-0 md:grid-cols-3 md:gap-10',
   logo: 'block h-6 w-auto',
   description: 'mt-3 text-sm leading-relaxed text-neutral-600',
   snsWrap: 'mt-4 flex gap-2',
   snsIcon: 'size-10 shrink-0',
   sectionTitle: 'text-sm font-bold text-neutral-900',
+  section: 'py-8 md:py-0',
   list: 'mt-3 space-y-2',
   listItem: 'text-sm text-neutral-600',
   bottomWrap: 'mt-10 border-t border-neutral-200 pt-6',
@@ -23,7 +24,7 @@ export function Footer() {
     <footer className={styles.footer}>
       <div className={styles.container}>
         <div className={styles.grid}>
-          <div>
+          <div className={styles.section}>
             <Image
               src="/logo.svg"
               alt="DeepScent"
@@ -62,7 +63,7 @@ export function Footer() {
             </div>
           </div>
 
-          <div>
+          <div className={styles.section}>
             <h3 className={styles.sectionTitle}>서비스</h3>
             <ul className={styles.list}>
               <li>
@@ -83,7 +84,7 @@ export function Footer() {
             </ul>
           </div>
 
-          <div>
+          <div className={styles.section}>
             <h3 className={styles.sectionTitle}>고객지원</h3>
             <ul className={styles.list}>
               <li>

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,9 +1,10 @@
 'use client'
 
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import Link from 'next/link'
 import Image from 'next/image'
 import { useRouter } from 'next/navigation'
+import { motion, AnimatePresence } from 'motion/react'
 import { Dropdown } from '@/components/common/Dropdown'
 import { headerNavLinks } from '@/constants/headerNavLinks'
 import ProfileModal from '@/app/profile/profileModal/profileModal'
@@ -22,13 +23,13 @@ const styles = {
     'mx-auto flex h-14 max-w-6xl items-center justify-between px-4 sm:px-6',
   leftGroup: 'flex items-center gap-6',
   logo: 'flex items-center transition-transform hover:scale-[1.02]',
-  nav: 'flex items-center gap-1',
+  nav: 'hidden md:flex items-center gap-1',
   navItemWrapper: 'relative',
-  rightMenu: 'flex items-center gap-3',
+  rightMenu: 'hidden md:flex items-center gap-3',
   rightLink: 'text-sm font-medium text-neutral-600 hover:text-violet-700',
-  divider: 'h-3.5 w-px bg-neutral-300 shrink-0',
   chevronWrap: 'ml-0.5 shrink-0',
 } as const
+
 export function Header() {
   const {
     isLoggedIn,
@@ -37,6 +38,8 @@ export function Header() {
     logout: logoutFromStore,
   } = useAuthStore()
   const router = useRouter()
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
+  const closeMenu = () => setMobileMenuOpen(false)
 
   const profileMenuItems = useMemo(() => {
     const showAdmin =
@@ -46,8 +49,10 @@ export function Header() {
   }, [user, userProfileLoaded])
 
   const { openModal, closeModal, closeAll } = useModalStore()
+
   const openProfileModal = () => {
     closeAll()
+    closeMenu()
     openModal(
       <Modal rounded="sm" size="md" isOpen onClose={closeModal}>
         <ProfileModal
@@ -73,7 +78,9 @@ export function Header() {
       </Modal>
     )
   }
+
   const logout = async () => {
+    closeMenu()
     try {
       await logoutFromStore()
       router.push('/login')
@@ -113,7 +120,6 @@ export function Header() {
         />
       )
     }
-
     return (
       <Link href="/login" className={styles.rightLink}>
         로그인
@@ -125,6 +131,7 @@ export function Header() {
     <>
       <header className={styles.header}>
         <div className={styles.container}>
+          {/* 로고 */}
           <div className={styles.leftGroup}>
             <Link href="/" className={styles.logo} aria-label="DeepScent 홈">
               <Image
@@ -138,6 +145,7 @@ export function Header() {
               />
             </Link>
 
+            {/* 데스크탑 전용 nav */}
             <nav className={styles.nav} aria-label="메인 메뉴">
               <div className={styles.navItemWrapper}>
                 <Dropdown
@@ -191,10 +199,157 @@ export function Header() {
             </nav>
           </div>
 
+          {/* 데스크탑 전용 우측 메뉴 */}
           <div className={styles.rightMenu}>{renderRightMenu()}</div>
+
+          {/* 모바일 전용: 햄버거 버튼 */}
+          <button
+            className="flex items-center justify-center p-1 text-neutral-700 md:hidden"
+            onClick={() => setMobileMenuOpen((prev) => !prev)}
+            aria-label={mobileMenuOpen ? '메뉴 닫기' : '메뉴 열기'}
+            aria-expanded={mobileMenuOpen}
+          >
+            <svg
+              width="22"
+              height="22"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+            >
+              {mobileMenuOpen ? (
+                <>
+                  <line x1="18" y1="6" x2="6" y2="18" />
+                  <line x1="6" y1="6" x2="18" y2="18" />
+                </>
+              ) : (
+                <>
+                  <line x1="3" y1="6" x2="21" y2="6" />
+                  <line x1="3" y1="12" x2="21" y2="12" />
+                  <line x1="3" y1="18" x2="21" y2="18" />
+                </>
+              )}
+            </svg>
+          </button>
         </div>
       </header>
-      {/* useModalStore에서 모달 렌더링, Header에서는 직접 렌더링하지 않음 */}
+
+      {/* 모바일 메뉴 백드롭 */}
+      <AnimatePresence>
+        {mobileMenuOpen && (
+          <>
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.15 }}
+              className="fixed inset-0 top-14 z-30 bg-black/10 md:hidden"
+              onClick={closeMenu}
+              aria-hidden
+            />
+
+            {/* 모바일 메뉴 패널 */}
+            <motion.nav
+              initial={{ opacity: 0, y: -8 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -8 }}
+              transition={{ duration: 0.18, ease: [0.25, 0.46, 0.45, 0.94] }}
+              className="fixed inset-x-0 top-14 z-40 border-b border-neutral-200 bg-white/95 backdrop-blur md:hidden"
+              aria-label="모바일 메뉴"
+            >
+              <div className="px-4 py-5">
+                {/* 향 섹션 */}
+                <p className="mb-1.5 px-2 text-[11px] font-semibold tracking-widest text-neutral-400 uppercase">
+                  향
+                </p>
+                {headerNavLinks.perfume.map(({ href, label }) => (
+                  <Link
+                    key={href}
+                    href={href}
+                    onClick={closeMenu}
+                    className="flex items-center justify-between rounded-xl px-2 py-2.5 text-sm font-medium text-neutral-700 hover:bg-neutral-50 active:bg-neutral-100"
+                  >
+                    {label}
+                    <span className="text-neutral-300">→</span>
+                  </Link>
+                ))}
+
+                {/* 나의 향기 찾기 섹션 */}
+                <p className="mt-5 mb-1.5 px-2 text-[11px] font-semibold tracking-widest text-neutral-400 uppercase">
+                  나의 향기 찾기
+                </p>
+                {headerNavLinks.findMyScent.map(({ href, title, subtitle }) => (
+                  <Link
+                    key={href}
+                    href={href}
+                    onClick={closeMenu}
+                    className="flex items-center justify-between rounded-xl px-2 py-2.5 hover:bg-neutral-50 active:bg-neutral-100"
+                  >
+                    <span>
+                      <span className="block text-sm font-medium text-neutral-700">
+                        {title}
+                      </span>
+                      <span className="block text-xs text-neutral-400">
+                        {subtitle}
+                      </span>
+                    </span>
+                    <span className="text-neutral-300">→</span>
+                  </Link>
+                ))}
+
+                {/* 로그인 / 프로필 */}
+                <div className="mt-5 border-t border-neutral-100 pt-4">
+                  {isLoggedIn ? (
+                    <>
+                      <button
+                        onClick={openProfileModal}
+                        className="flex w-full items-center justify-between rounded-xl px-2 py-2.5 text-sm font-medium text-neutral-700 hover:bg-neutral-50"
+                      >
+                        내 정보 수정
+                        <span className="text-neutral-300">→</span>
+                      </button>
+                      <Link
+                        href="/profile/storage"
+                        onClick={closeMenu}
+                        className="flex items-center justify-between rounded-xl px-2 py-2.5 text-sm font-medium text-neutral-700 hover:bg-neutral-50"
+                      >
+                        향기 저장소
+                        <span className="text-neutral-300">→</span>
+                      </Link>
+                      {userProfileLoaded && user?.is_admin && (
+                        <Link
+                          href="/admin"
+                          onClick={closeMenu}
+                          className="flex items-center justify-between rounded-xl px-2 py-2.5 text-sm font-medium text-neutral-700 hover:bg-neutral-50"
+                        >
+                          관리자 페이지
+                          <span className="text-neutral-300">→</span>
+                        </Link>
+                      )}
+                      <button
+                        onClick={logout}
+                        className="text-danger flex w-full rounded-xl px-2 py-2.5 text-sm font-medium hover:bg-neutral-50"
+                      >
+                        로그아웃
+                      </button>
+                    </>
+                  ) : (
+                    <Link
+                      href="/login"
+                      onClick={closeMenu}
+                      className="flex items-center justify-between rounded-xl px-2 py-2.5 text-sm font-medium text-neutral-700 hover:bg-neutral-50"
+                    >
+                      로그인
+                      <span className="text-neutral-300">→</span>
+                    </Link>
+                  )}
+                </div>
+              </div>
+            </motion.nav>
+          </>
+        )}
+      </AnimatePresence>
     </>
   )
 }

--- a/src/constants/landingCarousel.ts
+++ b/src/constants/landingCarousel.ts
@@ -1,0 +1,36 @@
+export const CAROUSEL_INTERVAL = 5000
+
+export const slides = [
+  {
+    img: '/img/1.svg',
+    eyebrow: 'Collection 01',
+    title: 'Mystère\nBody Mist',
+    subtitle: '가볍게 뿌리는 나만의 시그니처',
+    cta: '나한테 맞는 향기 찾으러 가기',
+    link: '/find-my-scent/taste-test',
+  },
+  {
+    img: '/img/5.svg',
+    eyebrow: 'Collection 02',
+    title: 'Lumière\nEau de Parfum',
+    subtitle: '빛처럼 가볍게 기억처럼 오래 남는',
+    cta: '향 더 보러 가기',
+    link: '/products/single',
+  },
+  {
+    img: '/img/6.svg',
+    eyebrow: 'Collection 03',
+    title: 'Sérénité\nCandle',
+    subtitle: '자연을 그대로 담은 향',
+    cta: '캔들 보러 가기',
+    link: '/products/combo',
+  },
+  {
+    img: '/img/5.svg',
+    eyebrow: 'Collection 04',
+    title: 'Déprimés\nDiffuser',
+    subtitle: '산뜻한 하루를 시작할 수 있는 향',
+    cta: '제품 보러 가기',
+    link: '/products/single',
+  },
+]


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->

랜딩 페이지 전체 UI를 리디자인하고 헤더에 모바일 반응형 메뉴를 추가

## 📌 관련 이슈

<!-- Closes #이슈번호 -->

Closes #204

## 🧩 작업 내용 (주요 변경사항)

- LandingHero, LandingCarousel, LandingCard 컴포넌트 반응형 레이아웃 추가
- 애니메이션 추가
- Header 와 Footer에도 반응형 레이아웃을 추가하여 Header는 햄버거 아이콘 추가
- 메인 page 'use client' 제거

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->



## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->


https://github.com/user-attachments/assets/8c061b86-6a01-4099-9248-b3ccbc72a304



## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료
