### PR TITLE
feat: 향 상세 BFF·상품 UI 폴리시·테스트 결과·배경 톤 (#208)

### DIFF
--- a/src/app/api/v1/scents/blends/[blendId]/route.ts
+++ b/src/app/api/v1/scents/blends/[blendId]/route.ts
@@ -1,0 +1,46 @@
+/**
+ * 조합 상세 — 브라우저는 같은 출처로 호출하고, 서버에서 실 API로 프록시 (CORS 회피)
+ * NEXT_PUBLIC_API_URL 미설정 시 MSW와 동일한 목 데이터 응답
+ */
+import { NextResponse } from 'next/server'
+import { mockBlendDetails } from '@/mocks/data/comboDetails'
+
+export async function GET(
+  _request: Request,
+  context: { params: Promise<{ blendId: string }> }
+) {
+  const { blendId } = await context.params
+  const baseUrl = process.env.NEXT_PUBLIC_API_URL?.trim()
+
+  if (baseUrl) {
+    const upstream = await fetch(`${baseUrl}/api/v1/scents/blends/${blendId}`, {
+      headers: { Accept: 'application/json' },
+      cache: 'no-store',
+    })
+    const body = await upstream.text()
+    return new NextResponse(body, {
+      status: upstream.status,
+      headers: {
+        'Content-Type':
+          upstream.headers.get('Content-Type') || 'application/json',
+      },
+    })
+  }
+
+  const id = Number(blendId)
+  const found = mockBlendDetails.find((item) => item.id === id)
+  if (!found) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          code: 'SCENT_COMBINATION_NOT_FOUND',
+          message: '조합 향 정보를 찾을 수 없습니다.',
+          details: { combination_id: id },
+        },
+      },
+      { status: 404 }
+    )
+  }
+  return NextResponse.json({ success: true, data: { ...found } })
+}

--- a/src/app/api/v1/scents/elements/[elementId]/route.ts
+++ b/src/app/api/v1/scents/elements/[elementId]/route.ts
@@ -1,0 +1,49 @@
+/**
+ * 단품 상세 — 브라우저는 같은 출처로 호출하고, 서버에서 실 API로 프록시 (CORS 회피)
+ * NEXT_PUBLIC_API_URL 미설정 시 MSW와 동일한 목 데이터 응답
+ */
+import { NextResponse } from 'next/server'
+import { mockElementDetails } from '@/mocks/data/singlesDetails'
+
+export async function GET(
+  _request: Request,
+  context: { params: Promise<{ elementId: string }> }
+) {
+  const { elementId } = await context.params
+  const baseUrl = process.env.NEXT_PUBLIC_API_URL?.trim()
+
+  if (baseUrl) {
+    const upstream = await fetch(
+      `${baseUrl}/api/v1/scents/elements/${elementId}`,
+      {
+        headers: { Accept: 'application/json' },
+        cache: 'no-store',
+      }
+    )
+    const body = await upstream.text()
+    return new NextResponse(body, {
+      status: upstream.status,
+      headers: {
+        'Content-Type':
+          upstream.headers.get('Content-Type') || 'application/json',
+      },
+    })
+  }
+
+  const id = Number(elementId)
+  const found = mockElementDetails.find((item) => item.id === id)
+  if (!found) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          code: 'INVALID_PATH_PARAMETER',
+          message: '경로 파라미터가 올바르지 않습니다.',
+          details: { field: 'element_id', reason: 'not_found' },
+        },
+      },
+      { status: 404 }
+    )
+  }
+  return NextResponse.json({ success: true, data: { ...found } })
+}

--- a/src/app/find-my-scent/_components/AIVisualModal.tsx
+++ b/src/app/find-my-scent/_components/AIVisualModal.tsx
@@ -402,11 +402,6 @@ export function AIVisualModal({
                 {s3Error && (
                   <p className="mt-3 text-sm text-red-600">{s3Error}</p>
                 )}
-                {isUploadingS3 && (
-                  <p className="mt-3 text-sm text-neutral-600">
-                    Presigned URL 발급 및 이미지 업로드 중…
-                  </p>
-                )}
                 {submitError && (
                   <p className="mt-3 text-sm text-red-600">{submitError}</p>
                 )}

--- a/src/app/find-my-scent/_components/TestResultPage.tsx
+++ b/src/app/find-my-scent/_components/TestResultPage.tsx
@@ -1,25 +1,17 @@
+'use client'
+
 /** 테스트 결과 페이지 — 상단(아이콘/타이틀/부타이틀) + 컨텐츠 박스 */
 import type { ComponentProps } from 'react'
 import Image from 'next/image'
+import { useAuthStore } from '@/store/useAuthStore'
 import type { ResultPageType } from '../_types'
 import { ResultContentBox } from './ResultContentBox'
 
-const RESULT_HEADER_CONFIG: Record<
-  ResultPageType,
-  { title: string; subtitle: string }
-> = {
-  PREFERENCE: {
-    title: '당신을 위한 조합 향기를 찾았습니다!',
-    subtitle: '질문을 통해 취향에 맞는 조합 향기를 추천해드립니다',
-  },
-  HEALTH: {
-    title: '웰니스 향기 분석 완료!',
-    subtitle: '당신의 건강 상태에 맞는 아로마 테라피를 찾았습니다',
-  },
-  AI: {
-    title: 'AI 조합 향기 분석 완료!',
-    subtitle: '이미지 기반으로 최적의 조합 향기를 찾았습니다',
-  },
+/** 유형별 부타이틀 — 타이틀은 닉네임 기반으로 공통 처리 */
+const RESULT_SUBTITLE: Record<ResultPageType, string> = {
+  PREFERENCE: '질문을 통해 취향에 맞는 아로마 테라피를 찾았습니다',
+  HEALTH: '질문을 통해 건강 상태에 맞는 아로마 테라피를 찾았습니다',
+  AI: 'AI 조합 향기 분석 완료! 첨부해주신 이미지 기반으로 최적의 아로마 테라피를 찾았습니다',
 }
 
 /** 결과 유형별 재테스트 경로 (다른 테스트는 모달에서 선택) */
@@ -34,8 +26,9 @@ const styles = {
   inner: 'mx-auto w-full max-w-[1200px]',
   header: 'flex flex-col items-center gap-4 pb-8 text-center',
   iconWrap: 'relative h-[104px] w-[104px] shrink-0',
-  title: 'text-xl font-bold text-[var(--color-black-primary)]',
-  subtitle: 'text-sm leading-relaxed text-neutral-600',
+  title:
+    'text-2xl font-bold text-[var(--color-black-primary)] sm:text-[1.75rem]',
+  subtitle: 'text-base leading-relaxed text-neutral-600 sm:text-lg',
   content: 'mt-0',
 } as const
 
@@ -52,7 +45,10 @@ export function TestResultPage({
   resultType,
   contentBoxProps,
 }: TestResultPageProps) {
-  const { title, subtitle } = RESULT_HEADER_CONFIG[resultType]
+  const user = useAuthStore((s) => s.user)
+  const displayName = user?.nickname?.trim() || '고객'
+  const title = `${displayName}님을 위한 조합 향기 분석이 완료되었습니다!`
+  const subtitle = RESULT_SUBTITLE[resultType]
   const { retest } = RESULT_PATHS[resultType]
 
   return (
@@ -69,7 +65,7 @@ export function TestResultPage({
             />
           </div>
           <h1 className={styles.title}>{title}</h1>
-          <p className={styles.subtitle}>{subtitle}</p>
+          <p className={`${styles.subtitle} max-w-2xl`}>{subtitle}</p>
         </header>
 
         <div className={styles.content}>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -42,7 +42,7 @@
   --color-kakao: #fee500;
 
   /* 배경 색상 */
-  --background-light-bg: #f6efe3;
+  --background-light-bg: #fffbf4;
 
   /* 상태 배지 색상 */
   --color-status-success-bg: #f0fdf4;

--- a/src/app/products/_api/productsClient.ts
+++ b/src/app/products/_api/productsClient.ts
@@ -1,9 +1,28 @@
 /**
  * 향(단품/조합) API — 명세 최종본 기준
  * - 목데이터(MSW): NEXT_PUBLIC_USE_MOCK_API=true 시 같은 origin 요청 → MSW가 가로챔
- * - 실제 API: NEXT_PUBLIC_API_URL 사용 (lib/api client와 동일)
+ * - 목록: NEXT_PUBLIC_API_URL 사용 (lib/api client와 동일)
+ * - 상세: 브라우저는 같은 출처 `/api/v1/scents/...` 로만 요청 → Route Handler가 실 API 프록시 (CORS 회피)
  */
-import { apiFetch } from '@/lib/api'
+import { apiFetch, handleResponse } from '@/lib/api'
+
+/** 클라이언트는 같은 출처, 서버(SSR 등)는 환경 변수 base로 직접 요청 */
+async function fetchScentDetailJson<T>(path: string): Promise<T> {
+  const base =
+    typeof window === 'undefined'
+      ? process.env.NEXT_PUBLIC_API_URL?.trim() || 'http://localhost:3000'
+      : ''
+  const res = await fetch(`${base}${path}`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    cache: 'no-store',
+  })
+  const ok = await handleResponse(res)
+  return ok.json() as Promise<T>
+}
 
 // ─── 공통: API 한글 이름 → 프론트 id/라벨 매핑 ─────────────────────────────
 
@@ -95,7 +114,7 @@ export type ElementDetailResponse = {
 export async function fetchElementDetail(
   elementId: number
 ): Promise<ElementDetailResponse> {
-  return apiFetch.get<ElementDetailResponse>(
+  return fetchScentDetailJson<ElementDetailResponse>(
     `/api/v1/scents/elements/${elementId}`
   )
 }
@@ -169,5 +188,7 @@ export type BlendDetailResponse = {
 export async function fetchBlendDetail(
   blendId: number
 ): Promise<BlendDetailResponse> {
-  return apiFetch.get<BlendDetailResponse>(`/api/v1/scents/blends/${blendId}`)
+  return fetchScentDetailJson<BlendDetailResponse>(
+    `/api/v1/scents/blends/${blendId}`
+  )
 }

--- a/src/components/magicui/shine-border.tsx
+++ b/src/components/magicui/shine-border.tsx
@@ -24,6 +24,9 @@ export function ShineBorder({
   const width = borderWidth ?? shineSize ?? 1
   return (
     <div className={cn('relative rounded-[inherit]', className)} {...props}>
+      <div className="relative z-0 min-h-0 w-full rounded-[inherit]">
+        {children}
+      </div>
       <div
         style={
           {
@@ -42,9 +45,8 @@ export function ShineBorder({
             ...style,
           } as React.CSSProperties
         }
-        className="motion-safe:animate-shine pointer-events-none absolute inset-0 size-full rounded-[inherit] will-change-[background-position]"
+        className="motion-safe:animate-shine pointer-events-none absolute inset-0 z-[30] size-full rounded-[inherit] will-change-[background-position]"
       />
-      {children}
     </div>
   )
 }

--- a/src/components/products/ProductCard.tsx
+++ b/src/components/products/ProductCard.tsx
@@ -54,11 +54,11 @@ export function ProductCard({
                 alt={name}
                 fill
                 sizes="(max-width: 768px) 100vw, 33vw"
-                className="block rounded-[20px_20px_0_0] object-contain p-1"
+                className="block rounded-t-2xl object-contain p-1"
                 priority={priority}
               />
             ) : (
-              <div className="h-full w-full rounded-[20px_20px_0_0] bg-neutral-100" />
+              <div className="h-full w-full rounded-t-2xl bg-neutral-100" />
             )}
           </Lens>
         </div>

--- a/src/components/products/ProductDetailModal.tsx
+++ b/src/components/products/ProductDetailModal.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/constants/accordLabelStyles'
 import Button from '@/components/common/Button'
 import { buttonVariants } from '@/components/common/Button/Button.variants'
+import { Lens } from '@/components/magicui/lens'
 import { cn } from '@/lib/cn'
 
 // ─── 스타일 ─────────────────────────────────────────────────────────────────
@@ -137,13 +138,18 @@ export function ProductDetailModal({
             </div>
           )}
           {!isLoading && product?.imageUrl?.trim() && (
-            <Image
-              src={product.imageUrl}
-              alt={product.name}
-              fill
-              sizes="(max-width: 896px) 100vw, 60vw"
-              className={styles.image}
-            />
+            <Lens
+              className="h-full min-h-0 w-full"
+              ariaLabel="상품 이미지 확대 영역"
+            >
+              <Image
+                src={product.imageUrl}
+                alt={product.name}
+                fill
+                sizes="(max-width: 896px) 100vw, 60vw"
+                className={styles.image}
+              />
+            </Lens>
           )}
         </div>
 

--- a/src/components/products/ScentListSkeleton.tsx
+++ b/src/components/products/ScentListSkeleton.tsx
@@ -6,7 +6,7 @@ import { useEffect, useState } from 'react'
 const CARD_COUNT = 8
 
 /** 스켈레톤 최소 노출 시간(ms). 이 시간만큼 지난 뒤 실제 목록 표시 */
-export const SCENT_LIST_SKELETON_DELAY_MS = 3000
+export const SCENT_LIST_SKELETON_DELAY_MS = 800
 
 type SkeletonDelayProps = {
   /** 스켈레톤을 보여줄 최소 시간(ms) */


### PR DESCRIPTION
## ✨ PR 개요
향 단품/조합 상세 조회 시 브라우저 CORS를 피하기 위해 Next API Route로 BFF 프록시를 추가하고, 상품 카드·모달·목록 스켈레톤 등 UI를 다듬었습니다. find-my-scent 테스트 결과 헤더 문구를 닉네임 기반으로 통일하고, 라이트 배경 톤을 조정했습니다.


## 📌 관련 이슈
Closes #208 

## 🧩 작업 내용 (주요 변경사항)
- **API / CORS**
  - `GET /api/v1/scents/elements/[elementId]`, `GET /api/v1/scents/blends/[blendId]` Route Handler 추가: `NEXT_PUBLIC_API_URL`이 있으면 실 API로 프록시, 없으면 기존 목 데이터 응답
  - `productsClient`의 `fetchElementDetail` / `fetchBlendDetail`은 브라우저에서 같은 출처 경로로 요청하도록 변경
- **상품 UI**
  - `ProductDetailModal` 상품 이미지에 목록 카드와 동일한 `Lens` 확대 효과 적용
  - `ShineBorder` 자식·샤인 레이어 z-index 정리로 렌즈/클릭 영역과 겹침 개선
  - `ProductCard` 이미지 영역 라운드 클래스 정리 (`rounded-t-2xl`)
  - `ScentListSkeleton` 최소 노출 시간 3000ms → 800ms
- **find-my-scent**
  - `TestResultPage`: 결과 타이틀을 닉네임 기반 문구로 통일, 부타이틀·타이포 조정 (`use client` + `useAuthStore`)
  - `AIVisualModal`: Presigned 업로드 중 별도 안내 문구 제거
- **스타일**
  - `globals.css`: `--background-light-bg` 톤 조정 (`#fffbf4`)

## 💬 리뷰 포인트
<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항
<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트
- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료
