### PR TITLE
[refactor] 로그인, 내정보 수정, 향기저장소 관련 코드 리팩토링(#212)

### DIFF
--- a/src/app/api/v1/users/me/analysis-results/route.ts
+++ b/src/app/api/v1/users/me/analysis-results/route.ts
@@ -1,18 +1,5 @@
-import { cookies } from 'next/headers'
 import { NextRequest, NextResponse } from 'next/server'
-import { postTokenRefresh } from '@/lib/api/auth'
-
-const BASE_COOKIE_OPTIONS = {
-  httpOnly: true,
-  secure: process.env.NODE_ENV === 'production',
-  sameSite: 'lax' as const,
-  path: '/',
-}
-
-const clearAuthCookies = (response: NextResponse) => {
-  response.cookies.set('access_token', '', { maxAge: 0, path: '/' })
-  response.cookies.set('refresh_token', '', { maxAge: 0, path: '/' })
-}
+import { getApiBaseUrl, proxyWithRefresh } from '@/lib/auth/serverAuthProxy'
 
 const buildBackendUrl = (baseUrl: string, request: NextRequest): string => {
   const url = new URL(request.url)
@@ -34,7 +21,7 @@ const fetchAnalysisResults = async (url: string, accessToken: string) => {
 
 export async function GET(request: NextRequest) {
   try {
-    const baseUrl = process.env.NEXT_PUBLIC_API_URL?.trim()
+    const baseUrl = getApiBaseUrl()
 
     if (!baseUrl) {
       return NextResponse.json(
@@ -50,113 +37,17 @@ export async function GET(request: NextRequest) {
       )
     }
 
-    const cookieStore = await cookies()
-    let accessToken = cookieStore.get('access_token')?.value
-    const refreshToken = cookieStore.get('refresh_token')?.value
     const backendUrl = buildBackendUrl(baseUrl, request)
 
-    if (!accessToken && !refreshToken) {
-      return NextResponse.json(
-        {
-          success: false,
-          data: null,
-          error: {
-            code: 'NOT_AUTHENTICATED',
-            message: '인증이 필요합니다.',
-          },
-        },
-        { status: 401 }
-      )
-    }
-
-    // 1) access 토큰으로 우선 요청
-    if (accessToken) {
-      const upstream = await fetchAnalysisResults(backendUrl, accessToken)
-      if (upstream.ok) {
-        const data = await upstream.json()
-        return NextResponse.json(data, { status: upstream.status })
-      }
-
-      // 401이 아니면 그대로 전달
-      if (upstream.status !== 401) {
-        const errorData = await upstream.json().catch(() => null)
-        return NextResponse.json(
-          errorData ?? {
-            success: false,
-            data: null,
-            error: {
-              code: 'ANALYSIS_RESULTS_FETCH_FAILED',
-              message: '테스트 결과 목록 조회에 실패했습니다.',
-            },
-          },
-          { status: upstream.status }
-        )
-      }
-    }
-
-    // 2) access 토큰이 없거나 만료된 경우 refresh 시도
-    if (!refreshToken) {
-      const response = NextResponse.json(
-        {
-          success: false,
-          data: null,
-          error: {
-            code: 'NOT_AUTHENTICATED',
-            message: '인증이 필요합니다.',
-          },
-        },
-        { status: 401 }
-      )
-      clearAuthCookies(response)
-      return response
-    }
-
-    try {
-      const refreshed = await postTokenRefresh(refreshToken)
-      accessToken = refreshed.data.access_token
-
-      const upstream = await fetchAnalysisResults(backendUrl, accessToken)
-      const body = await upstream.json().catch(() => null)
-
-      const response = NextResponse.json(
-        body ?? {
-          success: false,
-          data: null,
-          error: {
-            code: 'ANALYSIS_RESULTS_FETCH_FAILED',
-            message: '테스트 결과 목록 조회에 실패했습니다.',
-          },
-        },
-        { status: upstream.status }
-      )
-
-      response.cookies.set('access_token', refreshed.data.access_token, {
-        ...BASE_COOKIE_OPTIONS,
-        maxAge: refreshed.data.expires_in,
-      })
-      response.cookies.set('refresh_token', refreshed.data.refresh_token, {
-        ...BASE_COOKIE_OPTIONS,
-        maxAge: refreshed.data.refresh_expires_in,
-      })
-
-      return response
-    } catch {
-      const response = NextResponse.json(
-        {
-          success: false,
-          data: null,
-          error: {
-            code: 'NOT_AUTHENTICATED',
-            message: '인증이 필요합니다.',
-          },
-        },
-        { status: 401 }
-      )
-      clearAuthCookies(response)
-      return response
-    }
-  } catch (error) {
-    console.error('Analysis results API error:', error)
+    return proxyWithRefresh({
+      requestWithAccessToken: (accessToken) =>
+        fetchAnalysisResults(backendUrl, accessToken),
+      fallbackError: {
+        code: 'ANALYSIS_RESULTS_FETCH_FAILED',
+        message: '테스트 결과 목록 조회에 실패했습니다.',
+      },
+    })
+  } catch {
     return NextResponse.json(
       {
         success: false,

--- a/src/app/api/v1/users/me/nickname/route.ts
+++ b/src/app/api/v1/users/me/nickname/route.ts
@@ -1,36 +1,5 @@
-import { cookies } from 'next/headers'
 import { NextRequest, NextResponse } from 'next/server'
-import { postTokenRefresh } from '@/lib/api/auth'
-
-type NicknameUpdateResponse = {
-  success: boolean
-  data: {
-    id: number
-    nickname: string
-    updated_at: string
-  } | null
-  error?: {
-    code: string
-    message: string
-    details?: unknown
-  }
-}
-
-const BASE_COOKIE_OPTIONS = {
-  httpOnly: true,
-  secure: process.env.NODE_ENV === 'production',
-  sameSite: 'lax' as const,
-  path: '/',
-}
-
-const clearAuthCookies = (response: NextResponse) => {
-  response.cookies.set('access_token', '', { maxAge: 0, path: '/' })
-  response.cookies.set('refresh_token', '', { maxAge: 0, path: '/' })
-}
-
-const parseJsonSafely = async <T>(response: Response): Promise<T | null> => {
-  return response.json().catch(() => null)
-}
+import { getApiBaseUrl, proxyWithRefresh } from '@/lib/auth/serverAuthProxy'
 
 const fetchNicknameUpdate = async (
   baseUrl: string,
@@ -79,7 +48,7 @@ export async function PATCH(request: NextRequest) {
       )
     }
 
-    const baseUrl = process.env.NEXT_PUBLIC_API_URL?.trim()
+    const baseUrl = getApiBaseUrl()
     if (!baseUrl) {
       return NextResponse.json(
         {
@@ -94,120 +63,17 @@ export async function PATCH(request: NextRequest) {
       )
     }
 
-    const cookieStore = await cookies()
-    let accessToken = cookieStore.get('access_token')?.value
-    const refreshToken = cookieStore.get('refresh_token')?.value
     const requestBody = JSON.stringify({ nickname })
 
-    if (!accessToken && !refreshToken) {
-      return NextResponse.json(
-        {
-          success: false,
-          data: null,
-          error: {
-            code: 'NOT_AUTHENTICATED',
-            message: '인증이 필요합니다.',
-          },
-        },
-        { status: 401 }
-      )
-    }
-
-    if (accessToken) {
-      const upstream = await fetchNicknameUpdate(
-        baseUrl,
-        accessToken,
-        requestBody
-      )
-      if (upstream.ok) {
-        const data = await parseJsonSafely<NicknameUpdateResponse>(upstream)
-        return NextResponse.json(data, { status: upstream.status })
-      }
-
-      if (upstream.status !== 401) {
-        const errorBody =
-          await parseJsonSafely<NicknameUpdateResponse>(upstream)
-        return NextResponse.json(
-          errorBody ?? {
-            success: false,
-            data: null,
-            error: {
-              code: 'NICKNAME_UPDATE_FAILED',
-              message: '닉네임 변경에 실패했습니다.',
-            },
-          },
-          { status: upstream.status }
-        )
-      }
-    }
-
-    if (!refreshToken) {
-      const response = NextResponse.json(
-        {
-          success: false,
-          data: null,
-          error: {
-            code: 'NOT_AUTHENTICATED',
-            message: '인증이 필요합니다.',
-          },
-        },
-        { status: 401 }
-      )
-      clearAuthCookies(response)
-      return response
-    }
-
-    try {
-      const refreshed = await postTokenRefresh(refreshToken)
-      accessToken = refreshed.data.access_token
-
-      const upstream = await fetchNicknameUpdate(
-        baseUrl,
-        accessToken,
-        requestBody
-      )
-      const responseBody =
-        await parseJsonSafely<NicknameUpdateResponse>(upstream)
-
-      const response = NextResponse.json(
-        responseBody ?? {
-          success: false,
-          data: null,
-          error: {
-            code: 'NICKNAME_UPDATE_FAILED',
-            message: '닉네임 변경에 실패했습니다.',
-          },
-        },
-        { status: upstream.status }
-      )
-
-      response.cookies.set('access_token', refreshed.data.access_token, {
-        ...BASE_COOKIE_OPTIONS,
-        maxAge: refreshed.data.expires_in,
-      })
-      response.cookies.set('refresh_token', refreshed.data.refresh_token, {
-        ...BASE_COOKIE_OPTIONS,
-        maxAge: refreshed.data.refresh_expires_in,
-      })
-
-      return response
-    } catch {
-      const response = NextResponse.json(
-        {
-          success: false,
-          data: null,
-          error: {
-            code: 'NOT_AUTHENTICATED',
-            message: '인증이 필요합니다.',
-          },
-        },
-        { status: 401 }
-      )
-      clearAuthCookies(response)
-      return response
-    }
-  } catch (error) {
-    console.error('Nickname update API error:', error)
+    return proxyWithRefresh({
+      requestWithAccessToken: (accessToken) =>
+        fetchNicknameUpdate(baseUrl, accessToken, requestBody),
+      fallbackError: {
+        code: 'NICKNAME_UPDATE_FAILED',
+        message: '닉네임 변경에 실패했습니다.',
+      },
+    })
+  } catch {
     return NextResponse.json(
       {
         success: false,

--- a/src/app/api/v1/users/me/route.ts
+++ b/src/app/api/v1/users/me/route.ts
@@ -1,23 +1,5 @@
-import { cookies } from 'next/headers'
 import { NextRequest, NextResponse } from 'next/server'
-import { postTokenRefresh } from '@/lib/api/auth'
-import type { ApiResponse, User } from '@/types'
-
-const BASE_COOKIE_OPTIONS = {
-  httpOnly: true,
-  secure: process.env.NODE_ENV === 'production',
-  sameSite: 'lax' as const,
-  path: '/',
-}
-
-const clearAuthCookies = (response: NextResponse) => {
-  response.cookies.set('access_token', '', { maxAge: 0, path: '/' })
-  response.cookies.set('refresh_token', '', { maxAge: 0, path: '/' })
-}
-
-const parseJsonSafely = async <T>(response: Response): Promise<T | null> => {
-  return response.json().catch(() => null)
-}
+import { getApiBaseUrl, proxyWithRefresh } from '@/lib/auth/serverAuthProxy'
 
 const fetchUsersMe = async ({
   method,
@@ -54,7 +36,7 @@ const proxyUsersMe = async ({
   method: 'GET' | 'DELETE'
   requestBody?: string
 }) => {
-  const baseUrl = process.env.NEXT_PUBLIC_API_URL?.trim()
+  const baseUrl = getApiBaseUrl()
 
   if (!baseUrl) {
     return NextResponse.json(
@@ -70,132 +52,28 @@ const proxyUsersMe = async ({
     )
   }
 
-  const cookieStore = await cookies()
-  let accessToken = cookieStore.get('access_token')?.value
-  const refreshToken = cookieStore.get('refresh_token')?.value
-
-  if (!accessToken && !refreshToken) {
-    return NextResponse.json(
-      {
-        success: false,
-        data: null,
-        error: {
-          code: 'NOT_AUTHENTICATED',
-          message: '인증이 필요합니다.',
-        },
-      },
-      { status: 401 }
-    )
-  }
-
-  if (accessToken) {
-    const upstream = await fetchUsersMe({
-      method,
-      accessToken,
-      baseUrl,
-      requestBody,
-    })
-
-    if (upstream.ok) {
-      const body = await parseJsonSafely<ApiResponse<User | null>>(upstream)
-      return NextResponse.json(body, { status: upstream.status })
-    }
-
-    if (upstream.status !== 401) {
-      const errorBody =
-        await parseJsonSafely<ApiResponse<User | null>>(upstream)
-      return NextResponse.json(
-        errorBody ?? {
-          success: false,
-          data: null,
-          error: {
-            code: 'USERS_ME_FETCH_FAILED',
-            message:
-              method === 'GET'
-                ? 'Failed to fetch user profile.'
-                : 'Failed to withdraw user account.',
-          },
-        },
-        { status: upstream.status }
-      )
-    }
-  }
-
-  if (!refreshToken) {
-    const response = NextResponse.json(
-      {
-        success: false,
-        data: null,
-        error: {
-          code: 'NOT_AUTHENTICATED',
-          message: '인증이 필요합니다.',
-        },
-      },
-      { status: 401 }
-    )
-    clearAuthCookies(response)
-    return response
-  }
-
-  try {
-    const refreshed = await postTokenRefresh(refreshToken)
-    accessToken = refreshed.data.access_token
-
-    const upstream = await fetchUsersMe({
-      method,
-      accessToken,
-      baseUrl,
-      requestBody,
-    })
-    const body = await parseJsonSafely<ApiResponse<User | null>>(upstream)
-
-    const response = NextResponse.json(
-      body ?? {
-        success: false,
-        data: null,
-        error: {
-          code: 'USERS_ME_FETCH_FAILED',
-          message:
-            method === 'GET'
-              ? 'Failed to fetch user profile.'
-              : 'Failed to withdraw user account.',
-        },
-      },
-      { status: upstream.status }
-    )
-
-    response.cookies.set('access_token', refreshed.data.access_token, {
-      ...BASE_COOKIE_OPTIONS,
-      maxAge: refreshed.data.expires_in,
-    })
-    response.cookies.set('refresh_token', refreshed.data.refresh_token, {
-      ...BASE_COOKIE_OPTIONS,
-      maxAge: refreshed.data.refresh_expires_in,
-    })
-
-    return response
-  } catch {
-    const response = NextResponse.json(
-      {
-        success: false,
-        data: null,
-        error: {
-          code: 'NOT_AUTHENTICATED',
-          message: '인증이 필요합니다.',
-        },
-      },
-      { status: 401 }
-    )
-    clearAuthCookies(response)
-    return response
-  }
+  return proxyWithRefresh({
+    requestWithAccessToken: (accessToken) =>
+      fetchUsersMe({
+        method,
+        accessToken,
+        baseUrl,
+        requestBody,
+      }),
+    fallbackError: {
+      code: 'USERS_ME_FETCH_FAILED',
+      message:
+        method === 'GET'
+          ? 'Failed to fetch user profile.'
+          : 'Failed to withdraw user account.',
+    },
+  })
 }
 
 export async function GET() {
   try {
     return proxyUsersMe({ method: 'GET' })
-  } catch (error) {
-    console.error('Users me API error:', error)
+  } catch {
     return NextResponse.json(
       {
         success: false,
@@ -242,8 +120,7 @@ export async function DELETE(request: NextRequest) {
       method: 'DELETE',
       requestBody: JSON.stringify({ confirm_text: confirmText }),
     })
-  } catch (error) {
-    console.error('Users withdraw API error:', error)
+  } catch {
     return NextResponse.json(
       {
         success: false,

--- a/src/app/login/callback/CallbackClient.tsx
+++ b/src/app/login/callback/CallbackClient.tsx
@@ -3,31 +3,9 @@
 import { useEffect, useRef } from 'react'
 import { useSearchParams, useRouter } from 'next/navigation'
 import { LoadingSpinner } from '@/components/common/LoadingSpinner'
+import { fetchLatestUserProfile, writeStoredUser } from '@/lib/auth/userClient'
 import { loginWithKakaoAction } from '@/lib/auth/sessionActions'
 import { useAuthStore } from '@/store/useAuthStore'
-import type { User } from '@/types'
-
-async function fetchLatestUserProfile(): Promise<User | null> {
-  try {
-    const response = await fetch('/api/v1/users/me', {
-      credentials: 'include',
-      headers: { Accept: 'application/json' },
-    })
-
-    const body = (await response.json().catch(() => null)) as {
-      success?: boolean
-      data?: User
-    } | null
-
-    if (response.ok && body?.success && body.data) {
-      return body.data
-    }
-  } catch {
-    // 프로필 동기화 실패 시 콜백 응답 user를 fallback으로 사용
-  }
-
-  return null
-}
 
 export default function CallbackClient() {
   const searchParams = useSearchParams()
@@ -58,7 +36,7 @@ export default function CallbackClient() {
           const userToStore = latestUser ?? result.user
 
           // user 정보는 UI 표시용으로 localStorage에 저장
-          localStorage.setItem('user', JSON.stringify(userToStore))
+          writeStoredUser(userToStore)
           login(userToStore)
 
           alert(`${userToStore.nickname}님, 환영합니다!`)
@@ -66,8 +44,12 @@ export default function CallbackClient() {
         } else {
           throw new Error(result.error)
         }
-      } catch (error: any) {
-        alert(error.message || '로그인 처리 중 오류가 발생했습니다.')
+      } catch (error: unknown) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : '로그인 처리 중 오류가 발생했습니다.'
+        alert(message)
         router.replace('/login')
       }
     }

--- a/src/app/profile/profileModal/NicknameModal.tsx
+++ b/src/app/profile/profileModal/NicknameModal.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react'
 import ManageProfileIcon from '@/assets/icons/manageProfile.svg'
 import Input from '@/components/common/Input'
 import Button from '@/components/common/Button'
+import { writeStoredUser } from '@/lib/auth/userClient'
 import { useAuthStore } from '@/store/useAuthStore'
 import { useModalStore } from '@/store/useModalStore'
 
@@ -28,7 +29,10 @@ export type NicknameModalProps = {
   onClose: () => void
 }
 
-export default function NicknameModal({ isOpen, onClose }: NicknameModalProps) {
+export default function NicknameModal({
+  isOpen: _isOpen,
+  onClose,
+}: NicknameModalProps) {
   const user = useAuthStore((state) => state.user)
   const [newNickname, setNewNickname] = useState('')
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
@@ -84,7 +88,7 @@ export default function NicknameModal({ isOpen, onClose }: NicknameModalProps) {
           : state.user
 
         if (nextUser) {
-          localStorage.setItem('user', JSON.stringify(nextUser))
+          writeStoredUser(nextUser)
         }
 
         return { user: nextUser }

--- a/src/app/profile/profileModal/WithdrawModal.tsx
+++ b/src/app/profile/profileModal/WithdrawModal.tsx
@@ -21,7 +21,10 @@ export type WithdrawModalProps = {
   onClose: () => void
 }
 
-export default function WithdrawModal({ isOpen, onClose }: WithdrawModalProps) {
+export default function WithdrawModal({
+  isOpen: _isOpen,
+  onClose,
+}: WithdrawModalProps) {
   const router = useRouter()
   const logout = useAuthStore((state) => state.logout)
   const openAlert = useModalStore((state) => state.openAlert)

--- a/src/app/profile/profileModal/profileModal.tsx
+++ b/src/app/profile/profileModal/profileModal.tsx
@@ -10,8 +10,8 @@ type ProfileModalProps = {
 }
 
 export default function ProfileModal({
-  isOpen,
-  onClose,
+  isOpen: _isOpen,
+  onClose: _onClose,
   onNicknameClick,
   onWithdrawClick,
 }: ProfileModalProps) {

--- a/src/app/profile/storage/page.tsx
+++ b/src/app/profile/storage/page.tsx
@@ -33,6 +33,20 @@ const TAB_TO_INPUT_TYPES: Record<TabKey, AnalysisInputDataType[]> = {
   ai_interior: ['INTERIOR'],
 }
 
+const ALL_INPUT_TYPES: AnalysisInputDataType[] = [
+  'PREFERENCE',
+  'HEALTH',
+  'OOTD',
+  'INTERIOR',
+]
+
+const INPUT_TYPE_TO_TAB: Record<AnalysisInputDataType, TabKey> = {
+  PREFERENCE: 'preference',
+  HEALTH: 'wellness',
+  OOTD: 'ai_ootd',
+  INTERIOR: 'ai_interior',
+}
+
 const toAccordId = (raw: string | undefined): string => {
   if (!raw) return 'base'
   return raw.trim().toLowerCase()
@@ -96,6 +110,31 @@ const requestAnalysisResults = async (params: {
   return data
 }
 
+const fetchResultsByInputTypes = async (
+  inputTypes: AnalysisInputDataType[],
+  size: number
+) => {
+  const responses = await Promise.all(
+    inputTypes.map((inputType) =>
+      requestAnalysisResults({
+        input_data_type: inputType,
+        sort: DEFAULT_SORT,
+        page: DEFAULT_PAGE,
+        size,
+      })
+    )
+  )
+
+  return responses
+}
+
+const emptyTabCounts: Record<TabKey, number> = {
+  preference: 0,
+  wellness: 0,
+  ai_ootd: 0,
+  ai_interior: 0,
+}
+
 export default function ProfileStoragePage() {
   const [activeTab, setActiveTab] = useState<TabKey>('preference')
   const [storageData, setStorageData] = useState<AnalysisResultItem[]>([])
@@ -106,66 +145,51 @@ export default function ProfileStoragePage() {
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
+    let cancelled = false
+
     async function fetchTabCounts() {
       try {
-        const [preferenceRes, healthRes, ootdRes, interiorRes] =
-          await Promise.all([
-            requestAnalysisResults({
-              input_data_type: 'PREFERENCE',
-              sort: DEFAULT_SORT,
-              page: DEFAULT_PAGE,
-              size: 1,
-            }),
-            requestAnalysisResults({
-              input_data_type: 'HEALTH',
-              sort: DEFAULT_SORT,
-              page: DEFAULT_PAGE,
-              size: 1,
-            }),
-            requestAnalysisResults({
-              input_data_type: 'OOTD',
-              sort: DEFAULT_SORT,
-              page: DEFAULT_PAGE,
-              size: 1,
-            }),
-            requestAnalysisResults({
-              input_data_type: 'INTERIOR',
-              sort: DEFAULT_SORT,
-              page: DEFAULT_PAGE,
-              size: 1,
-            }),
-          ])
+        const responses = await fetchResultsByInputTypes(ALL_INPUT_TYPES, 1)
 
-        setTabCounts({
-          preference: preferenceRes.data?.count ?? 0,
-          wellness: healthRes.data?.count ?? 0,
-          ai_ootd: ootdRes.data?.count ?? 0,
-          ai_interior: interiorRes.data?.count ?? 0,
-        })
+        if (cancelled) return
+
+        const nextCounts = responses.reduce<Record<TabKey, number>>(
+          (acc, response, index) => {
+            const inputType = ALL_INPUT_TYPES[index]
+            const tabKey = INPUT_TYPE_TO_TAB[inputType]
+            acc[tabKey] = response.data?.count ?? 0
+            return acc
+          },
+          { ...emptyTabCounts }
+        )
+
+        setTabCounts(nextCounts)
       } catch {
-        setTabCounts({ preference: 0, wellness: 0, ai_ootd: 0, ai_interior: 0 })
+        if (!cancelled) setTabCounts({ ...emptyTabCounts })
       }
     }
 
-    fetchTabCounts()
+    void fetchTabCounts()
+
+    return () => {
+      cancelled = true
+    }
   }, [])
 
   useEffect(() => {
+    let cancelled = false
+
     async function fetchStorageByTab() {
-      setLoading(true)
-      setError(null)
+      if (!cancelled) {
+        setLoading(true)
+        setError(null)
+      }
 
       try {
         const inputTypes = TAB_TO_INPUT_TYPES[activeTab]
-        const responses = await Promise.all(
-          inputTypes.map((inputType) =>
-            requestAnalysisResults({
-              input_data_type: inputType,
-              sort: DEFAULT_SORT,
-              page: DEFAULT_PAGE,
-              size: DEFAULT_SIZE,
-            })
-          )
+        const responses = await fetchResultsByInputTypes(
+          inputTypes,
+          DEFAULT_SIZE
         )
 
         const mergedResults = responses
@@ -176,16 +200,26 @@ export default function ProfileStoragePage() {
               new Date(a.created_at).getTime()
           )
 
-        setStorageData(mergedResults)
-      } catch (e: any) {
-        setError(e?.message || '데이터를 불러오지 못했습니다')
+        if (!cancelled) setStorageData(mergedResults)
+      } catch (error: unknown) {
+        if (cancelled) return
+
+        const message =
+          error instanceof Error
+            ? error.message
+            : '데이터를 불러오지 못했습니다'
+        setError(message)
         setStorageData([])
       } finally {
-        setLoading(false)
+        if (!cancelled) setLoading(false)
       }
     }
 
-    fetchStorageByTab()
+    void fetchStorageByTab()
+
+    return () => {
+      cancelled = true
+    }
   }, [activeTab])
 
   return (
@@ -237,7 +271,7 @@ export default function ProfileStoragePage() {
               elementCategory={getElementCategory(item)}
               blendCategory={mapBlendCategories(item)}
               createdAt={item.created_at ?? ''}
-              onDetail={() => console.log('자세히 보기 클릭')}
+              onDetail={() => undefined}
             />
           ))}
       </div>

--- a/src/components/common/ClientLayoutInitializer.tsx
+++ b/src/components/common/ClientLayoutInitializer.tsx
@@ -1,35 +1,30 @@
 'use client'
 
 import { useEffect } from 'react'
+import {
+  clearStoredUser,
+  fetchLatestUserProfileResult,
+  writeStoredUser,
+} from '@/lib/auth/userClient'
 import { useAuthStore } from '@/store/useAuthStore'
-import type { User } from '@/types'
 
 /** 쿠키 기준 최신 프로필(is_admin 등) 동기화 — same-origin /api/v1/users/me */
 async function syncUserProfileFromApi(): Promise<void> {
-  try {
-    const res = await fetch('/api/v1/users/me', {
-      credentials: 'include',
-      headers: { Accept: 'application/json' },
-    })
-    const body = (await res.json()) as {
-      success?: boolean
-      data?: User
-    }
-    if (res.status === 401) {
-      localStorage.removeItem('user')
-      useAuthStore.setState({ isLoggedIn: false, user: null })
-      return
-    }
-    if (res.ok && body.success && body.data) {
-      localStorage.setItem('user', JSON.stringify(body.data))
-      useAuthStore.setState({
-        isLoggedIn: true,
-        user: body.data,
-      })
-    }
-  } catch {
-    // 네트워크 오류 시 localStorage 사용자 유지
+  const result = await fetchLatestUserProfileResult()
+
+  if (result.status === 401) {
+    clearStoredUser()
+    useAuthStore.setState({ isLoggedIn: false, user: null })
+    return
   }
+
+  if (!result.user) return
+
+  writeStoredUser(result.user)
+  useAuthStore.setState({
+    isLoggedIn: true,
+    user: result.user,
+  })
 }
 
 export default function ClientLayoutInitializer({
@@ -42,6 +37,8 @@ export default function ClientLayoutInitializer({
     const run = async () => {
       useAuthStore.getState().initialize()
       if (!useAuthStore.getState().isLoggedIn) {
+        clearStoredUser()
+        useAuthStore.setState({ isLoggedIn: false, user: null })
         if (!cancelled) useAuthStore.setState({ userProfileLoaded: true })
         return
       }

--- a/src/lib/auth/serverAuthProxy.ts
+++ b/src/lib/auth/serverAuthProxy.ts
@@ -1,0 +1,122 @@
+import { cookies } from 'next/headers'
+import { NextResponse } from 'next/server'
+import { postTokenRefresh } from '@/lib/api/auth'
+
+const BASE_COOKIE_OPTIONS = {
+  httpOnly: true,
+  secure: process.env.NODE_ENV === 'production',
+  sameSite: 'lax' as const,
+  path: '/',
+}
+
+type ProxyError = {
+  code: string
+  message: string
+  details?: unknown
+}
+
+type ProxyFallback = {
+  success: false
+  data: null
+  error: ProxyError
+}
+
+type AuthProxyOptions = {
+  requestWithAccessToken: (accessToken: string) => Promise<Response>
+  fallbackError: ProxyError
+  unauthenticatedError?: ProxyError
+}
+
+const DEFAULT_UNAUTHENTICATED_ERROR: ProxyError = {
+  code: 'NOT_AUTHENTICATED',
+  message: '인증이 필요합니다.',
+}
+
+const asFallback = (error: ProxyError): ProxyFallback => ({
+  success: false,
+  data: null,
+  error,
+})
+
+export const clearAuthCookies = (response: NextResponse) => {
+  response.cookies.set('access_token', '', { maxAge: 0, path: '/' })
+  response.cookies.set('refresh_token', '', { maxAge: 0, path: '/' })
+}
+
+export const parseJsonSafely = async <T>(
+  response: Response
+): Promise<T | null> => {
+  return response.json().catch(() => null)
+}
+
+export const getApiBaseUrl = (): string | null => {
+  const baseUrl = process.env.NEXT_PUBLIC_API_URL?.trim()
+  return baseUrl || null
+}
+
+export async function proxyWithRefresh({
+  requestWithAccessToken,
+  fallbackError,
+  unauthenticatedError = DEFAULT_UNAUTHENTICATED_ERROR,
+}: AuthProxyOptions): Promise<NextResponse> {
+  const cookieStore = await cookies()
+  let accessToken = cookieStore.get('access_token')?.value
+  const refreshToken = cookieStore.get('refresh_token')?.value
+
+  if (!accessToken && !refreshToken) {
+    return NextResponse.json(asFallback(unauthenticatedError), { status: 401 })
+  }
+
+  if (accessToken) {
+    const upstream = await requestWithAccessToken(accessToken)
+
+    if (upstream.ok) {
+      const body = await parseJsonSafely<unknown>(upstream)
+      return NextResponse.json(body, { status: upstream.status })
+    }
+
+    if (upstream.status !== 401) {
+      const body = await parseJsonSafely<unknown>(upstream)
+      return NextResponse.json(body ?? asFallback(fallbackError), {
+        status: upstream.status,
+      })
+    }
+  }
+
+  if (!refreshToken) {
+    const response = NextResponse.json(asFallback(unauthenticatedError), {
+      status: 401,
+    })
+    clearAuthCookies(response)
+    return response
+  }
+
+  try {
+    const refreshed = await postTokenRefresh(refreshToken)
+    accessToken = refreshed.data.access_token
+
+    const upstream = await requestWithAccessToken(accessToken)
+    const body = await parseJsonSafely<unknown>(upstream)
+
+    const response = NextResponse.json(body ?? asFallback(fallbackError), {
+      status: upstream.status,
+    })
+
+    response.cookies.set('access_token', refreshed.data.access_token, {
+      ...BASE_COOKIE_OPTIONS,
+      maxAge: refreshed.data.expires_in,
+    })
+    response.cookies.set('refresh_token', refreshed.data.refresh_token, {
+      ...BASE_COOKIE_OPTIONS,
+      maxAge: refreshed.data.refresh_expires_in,
+    })
+
+    return response
+  } catch {
+    const response = NextResponse.json(asFallback(unauthenticatedError), {
+      status: 401,
+    })
+    clearAuthCookies(response)
+    return response
+  }
+}

--- a/src/lib/auth/sessionActions.ts
+++ b/src/lib/auth/sessionActions.ts
@@ -10,7 +10,7 @@ type LoginResult =
 
 const BASE_COOKIE_OPTIONS = {
   httpOnly: true,
-  secure: false,
+  secure: process.env.NODE_ENV === 'production',
   maxAge: 3600,
   sameSite: 'lax' as const,
   path: '/',
@@ -49,7 +49,7 @@ export async function loginWithKakaoAction(
     cookieStore.set('access_token', access_token, BASE_COOKIE_OPTIONS)
     cookieStore.set('refresh_token', refresh_token, REFRESH_COOKIE_OPTIONS)
     return { success: true, user }
-  } catch (error) {
+  } catch (error: unknown) {
     return {
       success: false,
       error:

--- a/src/lib/auth/userClient.ts
+++ b/src/lib/auth/userClient.ts
@@ -1,0 +1,60 @@
+import type { ApiResponse, User } from '@/types'
+
+const USER_STORAGE_KEY = 'user'
+
+export const readStoredUser = (): User | null => {
+  if (typeof window === 'undefined') return null
+
+  const raw = localStorage.getItem(USER_STORAGE_KEY)
+  if (!raw) return null
+
+  try {
+    return JSON.parse(raw) as User
+  } catch {
+    localStorage.removeItem(USER_STORAGE_KEY)
+    return null
+  }
+}
+
+export const writeStoredUser = (user: User) => {
+  if (typeof window === 'undefined') return
+  localStorage.setItem(USER_STORAGE_KEY, JSON.stringify(user))
+}
+
+export const clearStoredUser = () => {
+  if (typeof window === 'undefined') return
+  localStorage.removeItem(USER_STORAGE_KEY)
+}
+
+export type LatestUserProfileResult = {
+  user: User | null
+  status: number | null
+}
+
+export async function fetchLatestUserProfileResult(): Promise<LatestUserProfileResult> {
+  try {
+    const response = await fetch('/api/v1/users/me', {
+      credentials: 'include',
+      headers: { Accept: 'application/json' },
+      cache: 'no-store',
+    })
+
+    const body = (await response
+      .json()
+      .catch(() => null)) as ApiResponse<User | null> | null
+
+    if (response.ok && body?.success && body.data) {
+      return { user: body.data, status: response.status }
+    }
+
+    return { user: null, status: response.status }
+  } catch {
+    // 네트워크 실패 시 null 반환 (호출부에서 fallback 처리)
+    return { user: null, status: null }
+  }
+}
+
+export async function fetchLatestUserProfile(): Promise<User | null> {
+  const result = await fetchLatestUserProfileResult()
+  return result.user
+}

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import { logoutAction } from '@/lib/auth/sessionActions'
+import { clearStoredUser, readStoredUser } from '@/lib/auth/userClient'
 import type { User } from '@/types'
 
 interface AuthState {
@@ -28,7 +29,7 @@ export const useAuthStore = create<AuthState>((set) => ({
   logout: async () => {
     // httpOnly 쿠키 삭제는 Server Action에서만 가능
     await logoutAction()
-    localStorage.removeItem('user')
+    clearStoredUser()
     set({
       isInitialized: true,
       isLoggedIn: false,
@@ -37,18 +38,7 @@ export const useAuthStore = create<AuthState>((set) => ({
     })
   },
   initialize: () => {
-    if (typeof window !== 'undefined') {
-      // user 정보만 localStorage에 저장
-      const storedUser = localStorage.getItem('user')
-      let user = null
-      try {
-        if (storedUser) {
-          user = JSON.parse(storedUser)
-        }
-      } catch {
-        localStorage.removeItem('user')
-      }
-      set({ isInitialized: true, isLoggedIn: !!user, user })
-    }
+    const user = readStoredUser()
+    set({ isInitialized: true, isLoggedIn: !!user, user })
   },
 }))


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->
로그인/로그아웃/내정보/향기저장소 흐름에서 중복된 인증 처리와 상태 동기화 로직을 삭제, 클라이언트-서버 간 인증/프로필 동기화 안정성을 높이는 리팩토링을 진행했습니다.
기능 동작은 유지하면서 코드 가독성과 유지보수성을 개선했습니다
## 📌 관련 이슈

<!-- Closes #이슈번호 -->

Closes #212 

## 🧩 작업 내용 (주요 변경사항)

- useAuthStore 초기화/로그아웃 로직에서 중복 코드 제거 및 상태 전이 일관성 개선
- 로그인 콜백, 프로필 동기화, 닉네임 변경에서 사용자 저장/복구(localStorage) 처리 로직을 공통 유틸로 정리
- 인증 프록시 라우트(users/me, nickname, analysis-results)의 중복 토큰 갱신 로직을 공통 유틸로 통합
- 기저장소 탭 조회 로직 리팩토링
탭 카운트/목록 요청 중복 제거
비동기 취소 가드 추가로 탭 전환 시 상태 업데이트 안정성 강화
에러 처리 타입 안정화(any 제거)

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트

- [ ] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [ ] 불필요한 console.log 제거
- [ ] 로컬에서 실행 확인 완료
