### PR TITLE
[feat] 비로그인 유저 향기저장소 진입 금지 처리 (#216)

### DIFF
--- a/src/app/profile/storage/page.tsx
+++ b/src/app/profile/storage/page.tsx
@@ -7,7 +7,9 @@ import type {
   AnalysisResultListApiResponse,
 } from './_types'
 import { useEffect, useState } from 'react'
+import { LoginRequiredTestModal } from '@/app/find-my-scent/_components/LoginRequiredTestModal'
 import { resolveApiMediaUrl } from '@/lib/resolveApiMediaUrl'
+import { useAuthStore } from '@/store/useAuthStore'
 import HeartIcon from '@/assets/icons/heart.svg'
 import AdminTestIcon from '@/assets/icons/adminTest.svg'
 import AdminRecommendationIcon from '@/assets/icons/adminRecommendation.svg'
@@ -136,6 +138,7 @@ const emptyTabCounts: Record<TabKey, number> = {
 }
 
 export default function ProfileStoragePage() {
+  const { isInitialized, isLoggedIn } = useAuthStore()
   const [activeTab, setActiveTab] = useState<TabKey>('preference')
   const [storageData, setStorageData] = useState<AnalysisResultItem[]>([])
   const [tabCounts, setTabCounts] = useState<Record<TabKey, number> | null>(
@@ -145,6 +148,8 @@ export default function ProfileStoragePage() {
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
+    if (!isInitialized || isLoggedIn !== true) return
+
     let cancelled = false
 
     async function fetchTabCounts() {
@@ -174,9 +179,11 @@ export default function ProfileStoragePage() {
     return () => {
       cancelled = true
     }
-  }, [])
+  }, [isInitialized, isLoggedIn])
 
   useEffect(() => {
+    if (!isInitialized || isLoggedIn !== true) return
+
     let cancelled = false
 
     async function fetchStorageByTab() {
@@ -220,7 +227,15 @@ export default function ProfileStoragePage() {
     return () => {
       cancelled = true
     }
-  }, [activeTab])
+  }, [activeTab, isInitialized, isLoggedIn])
+
+  if (!isInitialized) {
+    return null
+  }
+
+  if (isLoggedIn !== true) {
+    return <LoginRequiredTestModal isOpen onClose={() => undefined} />
+  }
 
   return (
     <div className="mb-6 flex flex-col items-center text-2xl">


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->
비로그인 유저가 향기 저장소 진입 시 모달을 띄우고 로그인 창으로 가도록 설정
## 📌 관련 이슈

<!-- Closes #이슈번호 -->

Closes #216 

## 🧩 작업 내용 (주요 변경사항)

-LoginRequiredTestModal을 사용해 비로그인 유저가 향기 저장소 진입 시 모달을 띄우고 로그인 창으로 가도록 설정
-

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->
소연님이 만들어두신 모달 재사용 했습니다! 잘쓸게요! 
## ✅ PR 체크리스트

- [ ] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [ ] 불필요한 console.log 제거
- [ ] 로컬에서 실행 확인 완료
