### PR TITLE
feat: 결과 상세 향기노트 매핑 동기화 및 중복 key 경고 해결 (#227)

### DIFF
--- a/src/app/api/v1/profilings/results/[resultId]/route.ts
+++ b/src/app/api/v1/profilings/results/[resultId]/route.ts
@@ -6,6 +6,7 @@
 import { NextResponse } from 'next/server'
 import { authFetch, FetchError } from '@/lib/api'
 import { mockProfilingResultDetail } from '@/mocks/data/profilingResults'
+import storageMockResults from '@/mocks/data/storage'
 
 const USE_MOCK = process.env.NEXT_PUBLIC_USE_MOCK_API === 'true'
 
@@ -30,9 +31,30 @@ export async function GET(
   }
 
   if (USE_MOCK) {
+    const listItem = storageMockResults.find((item) => item.id === id)
+    const mb = listItem?.matched_blend
+    const base = { ...mockProfilingResultDetail, id }
+    const data =
+      listItem && mb
+        ? {
+            ...base,
+            id: listItem.id,
+            input_data_type: listItem.input_data_type,
+            product_type: listItem.product_type,
+            created_at: listItem.created_at,
+            recommended_blend: {
+              name: mb.name,
+              image_url: mb.image_url,
+              description:
+                mockProfilingResultDetail.recommended_blend?.description ?? '',
+              categories: mb.categories,
+              contained_elements: mb.contained_elements,
+            },
+          }
+        : base
     return NextResponse.json({
       success: true,
-      data: { ...mockProfilingResultDetail, id },
+      data,
     })
   }
 

--- a/src/app/find-my-scent/_api/profilingClient.ts
+++ b/src/app/find-my-scent/_api/profilingClient.ts
@@ -8,6 +8,8 @@
  * - 브라우저: 같은 오리진 + `credentials: 'include'` / RSC: 내부 URL + `Cookie` 헤더
  */
 import { handleResponse } from '@/lib/api/client'
+import { mapBlendCategoryKrLabels } from '@/lib/mapBlendCategoryKrLabels'
+import { scentCategoryKrToId } from '@/app/products/_api/productsClient'
 import type {
   AnswersState,
   ProductTypeChoice,
@@ -175,6 +177,28 @@ export async function fetchProfilingResult(
   )
 }
 
+/** 향기 노트용 카테고리 행 — categories / blend_categories 우선순위 */
+function pickBlendCategoryRows(
+  blend: ProfilingResultBlend | null | undefined
+): { name: { kr: string; en: string } }[] {
+  if (!blend) return []
+  const rows = blend.categories ?? blend.blend_categories
+  return Array.isArray(rows) ? rows : []
+}
+
+/**
+ * 상세 응답에서 향기 노트 라벨용 categories 해석
+ * - recommended_blend.categories / blend_categories
+ * - 누락 시 목록과 동일 필드인 data.matched_blend 쪽 보조 (스키마 불일치 대응)
+ */
+function pickNoteCategoryRowsForDetail(
+  detail: ProfilingResultDetail
+): { name: { kr: string; en: string } }[] {
+  const fromRecommended = pickBlendCategoryRows(detail.recommended_blend)
+  if (fromRecommended.length > 0) return fromRecommended
+  return pickBlendCategoryRows(detail.matched_blend ?? null)
+}
+
 /** 결과 상세 API 응답 → ResultContentBox props (primaryButtonHref = 추천 상품 링크) */
 export function resultDetailToContentBoxProps(detail: ProfilingResultDetail): {
   productImageUrl: string
@@ -206,17 +230,19 @@ export function resultDetailToContentBoxProps(detail: ProfilingResultDetail): {
   }
 
   const scentTypeTags =
-    recommended_blend.contained_elements?.map(
-      (e) => e.category?.en ?? e.category?.kr ?? ''
-    ) ?? []
+    recommended_blend.contained_elements?.map((e) => {
+      const kr = e.category?.kr?.trim()
+      if (kr && scentCategoryKrToId[kr]) return scentCategoryKrToId[kr]
+      const en = e.category?.en?.trim().toLowerCase()
+      return en ?? ''
+    }) ?? []
   const scentTypeLabel =
-    recommended_blend.contained_elements?.[0]?.category?.en ??
-    recommended_blend.contained_elements?.[0]?.category?.kr
+    recommended_blend.contained_elements?.[0]?.category?.kr ??
+    recommended_blend.contained_elements?.[0]?.category?.en
   const primaryButtonHref = recommended_products[0]?.purchase_url ?? ''
-  const noteTags =
-    recommended_blend.contained_elements?.map(
-      (e) => `#${e.category?.en ?? e.name}`
-    ) ?? []
+  const noteRows = pickNoteCategoryRowsForDetail(detail)
+  /** 저장소 목록 카드 blendCategory 와 동일 문자열·순서(중복 제거 규칙 동일) */
+  const noteTags = mapBlendCategoryKrLabels(noteRows)
   return {
     productImageUrl: recommended_blend.image_url ?? '',
     productName: recommended_blend.name ?? '',

--- a/src/app/find-my-scent/_api/profilingClient.ts
+++ b/src/app/find-my-scent/_api/profilingClient.ts
@@ -16,6 +16,7 @@ import type {
   ProfilingFormResponse,
   ProfilingQuestion,
   ProfilingResultDetail,
+  ProfilingResultBlend,
   ProfilingResultDetailResponse,
   ProfilingSubmitRequest,
   ProfilingSubmitResponse,

--- a/src/app/find-my-scent/_components/ResultContentBox.tsx
+++ b/src/app/find-my-scent/_components/ResultContentBox.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
 import {
-  getAccordLabels,
+  getAccordLabelsUnique,
   ACCORD_LABEL_PILL_MD_CLASS,
   SCENT_NOTE_PILL_CLASS,
 } from '@/constants/accordLabelStyles'
@@ -19,9 +19,9 @@ export type ResultContentBoxProps = {
   productName?: string
   scentTypeLabel?: string
   showRecommendLabel?: boolean
-  /** 향조 타입 id 배열 (getAccordLabels용, 예: ['oriental', 'woody']) */
+  /** 향조 타입 id 배열 (getAccordLabelsUnique용, 예: ['oriental', 'woody']) */
   scentTypeTags?: string[]
-  /** 향기 노트 라벨 (예: ['#숙면', '#로맨틱']) */
+  /** 향기 노트 라벨 — 저장소 목록 카드 blendCategory 와 동일(한글 명 그대로) */
   noteTags?: string[]
   description?: string
   /** 하단 버튼 이동 경로/URL */
@@ -135,22 +135,22 @@ export function ResultContentBox({
               <h3 className={styles.sectionTitle}>향조 타입</h3>
               <div className={styles.tagRow}>
                 {scentTypeTags.length > 0 ? (
-                  getAccordLabels(
-                    scentTypeTags.map((id) => id.toLowerCase())
-                  ).map(({ id, label, style }) => (
-                    <span
-                      key={id}
-                      className={ACCORD_LABEL_PILL_MD_CLASS}
-                      style={{
-                        backgroundColor: style.bg,
-                        borderColor: style.border,
-                        color: style.text,
-                        borderWidth: 1,
-                      }}
-                    >
-                      {label}
-                    </span>
-                  ))
+                  getAccordLabelsUnique(scentTypeTags).map(
+                    ({ id, label, style }) => (
+                      <span
+                        key={id}
+                        className={ACCORD_LABEL_PILL_MD_CLASS}
+                        style={{
+                          backgroundColor: style.bg,
+                          borderColor: style.border,
+                          color: style.text,
+                          borderWidth: 1,
+                        }}
+                      >
+                        {label}
+                      </span>
+                    )
+                  )
                 ) : (
                   <span className="text-sm text-neutral-400">—</span>
                 )}

--- a/src/app/find-my-scent/_types/index.ts
+++ b/src/app/find-my-scent/_types/index.ts
@@ -87,6 +87,10 @@ export type ProfilingResultBlend = {
   name: string
   image_url: string
   description: string
+  /** 조합 무드·테마 (향기 노트 UI) — API 필드명: categories */
+  categories?: { name: { kr: string; en: string } }[]
+  /** 백엔드·목록과 필드명이 다를 때 대비 */
+  blend_categories?: { name: { kr: string; en: string } }[]
   contained_elements: {
     name: string
     category: { kr: string; en: string }
@@ -100,6 +104,11 @@ export type ProfilingResultDetail = {
   input_data_summary: string
   /** 분석·추천 파이프라인이 아직 없으면 null 일 수 있음 */
   recommended_blend: ProfilingResultBlend | null
+  /**
+   * 목록 API와 동일하게 matched_blend만 내려주는 경우 향기 노트(categories) 보존용
+   * (recommended_blend.categories 가 비어 있을 때 보조)
+   */
+  matched_blend?: ProfilingResultBlend | null
   recommended_products: { purchase_url: string }[]
   created_at: string
 }

--- a/src/app/profile/storage/page.tsx
+++ b/src/app/profile/storage/page.tsx
@@ -8,6 +8,7 @@ import type {
 } from './_types'
 import { useEffect, useState } from 'react'
 import { LoginRequiredTestModal } from '@/app/find-my-scent/_components/LoginRequiredTestModal'
+import { mapBlendCategoryKrLabels } from '@/lib/mapBlendCategoryKrLabels'
 import { resolveApiMediaUrl } from '@/lib/resolveApiMediaUrl'
 import { useAuthStore } from '@/store/useAuthStore'
 import { useRouter } from 'next/navigation'
@@ -66,16 +67,7 @@ const toAccordId = (raw: string | undefined): string => {
 
 const mapBlendCategories = (item: AnalysisResultItem): string[] => {
   if (!item.matched_blend) return []
-
-  const categories = Array.isArray(item.matched_blend.categories)
-    ? item.matched_blend.categories
-    : []
-
-  const names = categories
-    .map((category) => category.name?.kr?.trim())
-    .filter((name): name is string => Boolean(name))
-
-  return Array.from(new Set(names))
+  return mapBlendCategoryKrLabels(item.matched_blend.categories)
 }
 
 const mapElementCategories = (item: AnalysisResultItem): string[] => {

--- a/src/components/products/ProductCard.tsx
+++ b/src/components/products/ProductCard.tsx
@@ -3,7 +3,7 @@
 import Image from 'next/image'
 import { cn } from '@/lib/cn'
 import {
-  getAccordLabels,
+  getAccordLabelsUnique,
   ACCORD_LABEL_PILL_SM_CLASS,
   SCENT_NOTE_LINE_CLASS,
 } from '@/constants/accordLabelStyles'
@@ -67,7 +67,7 @@ export function ProductCard({
             {name}
           </h3>
           <div className="flex flex-wrap gap-1">
-            {getAccordLabels(accordIds).map(({ id, label, style }) => (
+            {getAccordLabelsUnique(accordIds).map(({ id, label, style }) => (
               <span
                 key={id}
                 className={ACCORD_LABEL_PILL_SM_CLASS}

--- a/src/components/products/ProductDetailModal.tsx
+++ b/src/components/products/ProductDetailModal.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 import Image from 'next/image'
 import { useRouter } from 'next/navigation'
 import {
-  getAccordLabels,
+  getAccordLabelsUnique,
   ACCORD_LABEL_PILL_MD_CLASS,
   SCENT_NOTE_PILL_CLASS,
 } from '@/constants/accordLabelStyles'
@@ -108,7 +108,9 @@ export function ProductDetailModal({
 
   /** 연관 추천 상품 보러가기: 상세의 product_link */
   const productLink = product?.productLink?.trim() ?? ''
-  const accordLabels = product ? getAccordLabels(product.scentFamilyIds) : []
+  const accordLabels = product
+    ? getAccordLabelsUnique(product.scentFamilyIds)
+    : []
 
   return (
     <div className={styles.overlay} onClick={handleOverlayClick}>
@@ -194,7 +196,7 @@ export function ProductDetailModal({
               <div className={styles.section}>
                 <p className={styles.subTitle}>향조</p>
                 <div className="flex flex-wrap gap-2">
-                  {getAccordLabels(product.scentFamilyIds).map(
+                  {getAccordLabelsUnique(product.scentFamilyIds).map(
                     ({ id, label, style }) => (
                       <span
                         key={id}

--- a/src/constants/accordLabelStyles.ts
+++ b/src/constants/accordLabelStyles.ts
@@ -3,6 +3,7 @@
  *
  * [향조 라벨]
  * - getAccordLabels(ids) 로 id 배열 → { id, label, style }[] 변환
+ * - getAccordLabelsUnique(ids) 동일하나 id 중복 제거(첫 등장 순서 유지, 소문자 정규화)
  * - pill: ACCORD_LABEL_PILL_SM_CLASS(카드) / ACCORD_LABEL_PILL_MD_CLASS(모달)
  * - style.bg, style.border, style.text 를 인라인 style 로 넣어서 렌더
  *
@@ -46,6 +47,19 @@ export const getAccordLabel = (id: string): AccordLabel => {
 // 향조 라벨 여러 개 조회
 export const getAccordLabels = (ids: string[]): AccordLabel[] =>
   ids.map(getAccordLabel)
+
+/** React key 충돌 방지·UI 중복 라벨 방지: 동일 향조 id는 한 번만 */
+export const getAccordLabelsUnique = (ids: string[]): AccordLabel[] => {
+  const seen = new Set<string>()
+  const unique: string[] = []
+  for (const raw of ids) {
+    const id = raw.trim().toLowerCase()
+    if (!id || seen.has(id)) continue
+    seen.add(id)
+    unique.push(id)
+  }
+  return getAccordLabels(unique)
+}
 
 // 향조 라벨 스타일 클래스
 export const ACCORD_LABEL_PILL_SM_CLASS =

--- a/src/lib/mapBlendCategoryKrLabels.ts
+++ b/src/lib/mapBlendCategoryKrLabels.ts
@@ -1,0 +1,13 @@
+/**
+ * 향기 저장소 목록 카드(blendCategory)와 동일 규칙:
+ * API `categories[].name.kr` → 트림, 빈 값 제외, 등장 순서 유지하며 중복 제거
+ */
+export function mapBlendCategoryKrLabels(
+  categories: { name?: { kr?: string; en?: string } }[] | null | undefined
+): string[] {
+  if (!Array.isArray(categories) || categories.length === 0) return []
+  const names = categories
+    .map((c) => c.name?.kr?.trim())
+    .filter((name): name is string => Boolean(name))
+  return Array.from(new Set(names))
+}

--- a/src/mocks/data/profilingResults.ts
+++ b/src/mocks/data/profilingResults.ts
@@ -15,6 +15,10 @@ export const mockProfilingResultDetail: ProfilingResultDetail = {
     name: '포근한 숲',
     image_url: '/images/blend_5.jpg',
     description: '따뜻한 우디 향',
+    categories: [
+      { name: { kr: '기분전환', en: 'Refresh' } },
+      { name: { kr: '로맨틱', en: 'Romantic' } },
+    ],
     contained_elements: [
       { name: '시더우드', category: { kr: '우디', en: 'Woody' } },
       { name: '라벤더', category: { kr: '아로마틱', en: 'Aromatic' } },

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -15,6 +15,7 @@ import {
 } from './data/profilingForms'
 import { MOCK_PIPELINE_SNAPSHOT_ID } from './data/profilingConstants'
 import { mockProfilingResultDetail } from './data/profilingResults'
+import storageMockResults from './data/storage'
 import { adminCategoryHandlers } from './handlers/adminCategoryHandlers'
 import {
   IMAGE_FORMATS,
@@ -356,12 +357,31 @@ export const profilingResultDetailHandler = http.get(
       )
     }
 
+    const listItem = storageMockResults.find((item) => item.id === id)
+    const base = { ...mockProfilingResultDetail, id }
+    const mb = listItem?.matched_blend
+    const data =
+      listItem && mb
+        ? {
+            ...base,
+            id: listItem.id,
+            input_data_type: listItem.input_data_type,
+            product_type: listItem.product_type,
+            created_at: listItem.created_at,
+            recommended_blend: {
+              name: mb.name,
+              image_url: mb.image_url,
+              description:
+                mockProfilingResultDetail.recommended_blend?.description ?? '',
+              categories: mb.categories,
+              contained_elements: mb.contained_elements,
+            },
+          }
+        : base
+
     return HttpResponse.json({
       success: true,
-      data: {
-        ...mockProfilingResultDetail,
-        id,
-      },
+      data,
     })
   }
 )


### PR DESCRIPTION
## ✨ PR 개요

향기 저장소(목록 카드)에서 보여주던 “향기 노트(블렌드 카테고리)”와 결과 상세 페이지가 서로 다르게 표시되던 문제를 해결했습니다.
또한 `contained_elements`에 같은 향조 id가 중복으로 들어올 때 React에서 `key` 경고가 발생하던 부분도 함께 정리했습니다.


## 📌 관련 이슈
Closes #227 

## 🧩 작업 내용 (주요 변경사항)
- 결과 상세 응답에서 향기 노트 라벨을 만들 때
  - `recommended_blend.categories`
  - 또는 백엔드/목 응답이 다를 때의 `blend_categories`, `matched_blend` 대체 경로를 함께 고려하도록 매핑 보강
- 향기 노트 라벨 표기 규칙을 저장소 목록 카드와 동일하게 맞춤
  - `categories[].name.kr`을 그대로 트림/중복제거한 값으로 `noteTags` 생성
- React `key` 중복 경고 해결
  - 동일 향조 id가 여러 번 올 수 있어 `getAccordLabelsUnique`로 중복을 제거
  - 결과 상세(`ResultContentBox`)와 상품 UI(`ProductCard`, `ProductDetailModal`)에 동일 로직 적용

## 💬 리뷰 포인트
<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항
<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

## ✅ PR 체크리스트
- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료
