### PR TITLE
[Feat] 메인 페이지 SEO 메타데이터 추가 및 Search Console 연동 (#235)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,7 +14,7 @@ const pretendard = localFont({
   variable: '--font-pretendard',
 })
 
-const BASE_URL = 'https://oz-scent-match.duckdns.org'
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL!
 
 export const metadata: Metadata = {
   metadataBase: new URL(BASE_URL),

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,9 +14,58 @@ const pretendard = localFont({
   variable: '--font-pretendard',
 })
 
+const BASE_URL = 'https://oz-scent-match.duckdns.org'
+
 export const metadata: Metadata = {
-  title: 'Ozent',
-  description: '나의 향기를 찾다.',
+  metadataBase: new URL(BASE_URL),
+  title: {
+    default: 'Ozent | 나의 향기를 찾다',
+    template: '%s | Ozent',
+  },
+  description:
+    '취향 테스트·웰니스 진단·AI 비주얼 분석으로 나에게 꼭 맞는 향기와 제품을 한번에 찾아드립니다.',
+  keywords: [
+    '향기 추천',
+    '향수 추천',
+    '퍼퓸',
+    '향기 테스트',
+    'AI 분석',
+    '웰니스',
+    'Ozent',
+    '향기 플랫폼',
+  ],
+  authors: [{ name: 'Ozent' }],
+  openGraph: {
+    type: 'website',
+    locale: 'ko_KR',
+    url: BASE_URL,
+    siteName: 'Ozent',
+    title: 'Ozent | 나만의 향기 추천 플랫폼',
+    description:
+      '취향 테스트·웰니스 진단·AI 비주얼 분석으로 나에게 꼭 맞는 향기와 제품을 한번에 찾아드립니다.',
+    images: [
+      {
+        url: '/img/landing.jpg',
+        width: 1200,
+        height: 630,
+        alt: 'Ozent — 나만의 향기 추천 플랫폼',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Ozent | 나만의 향기 추천 플랫폼',
+    description:
+      '취향 테스트·웰니스 진단·AI 비주얼 분석으로 나에게 꼭 맞는 향기와 제품을 한번에 찾아드립니다.',
+    images: ['/img/landing.jpg'],
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
+  verification: {
+    google: process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION,
+  },
 }
 
 export default function RootLayout({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,14 @@
+import type { Metadata } from 'next'
 import LandingHero from '@/components/Landing/LandingHero'
 import LandingCarousel from '@/components/Landing/LandingCarousel'
 import LandingCard from '@/components/Landing/LandingCard'
+
+// 웹사이트 중복 문제 해결을 위한 canonical 설정
+export const metadata: Metadata = {
+  alternates: {
+    canonical: 'https://oz-scent-match.duckdns.org',
+  },
+}
 
 export default function Home() {
   return (

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,6 +1,6 @@
 import type { MetadataRoute } from 'next'
 
-const BASE_URL = 'https://oz-scent-match.duckdns.org'
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL!
 
 export default function robots(): MetadataRoute.Robots {
   return {

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,16 @@
+import type { MetadataRoute } from 'next'
+
+const BASE_URL = 'https://oz-scent-match.duckdns.org'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: ['/admin', '/login', '/profile'],
+      },
+    ],
+    sitemap: `${BASE_URL}/sitemap.xml`,
+  }
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,44 @@
+import type { MetadataRoute } from 'next'
+
+const BASE_URL = 'https://oz-scent-match.duckdns.org'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: BASE_URL,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 1.0,
+    },
+    {
+      url: `${BASE_URL}/find-my-scent/taste-test`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 1.0,
+    },
+    {
+      url: `${BASE_URL}/find-my-scent/wellness`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 1.0,
+    },
+    {
+      url: `${BASE_URL}/find-my-scent/ai-visual`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 1.0,
+    },
+    {
+      url: `${BASE_URL}/products/single`,
+      lastModified: new Date(),
+      changeFrequency: 'yearly',
+      priority: 0.7,
+    },
+    {
+      url: `${BASE_URL}/products/combo`,
+      lastModified: new Date(),
+      changeFrequency: 'yearly',
+      priority: 0.7,
+    },
+  ]
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,6 +1,6 @@
 import type { MetadataRoute } from 'next'
 
-const BASE_URL = 'https://oz-scent-match.duckdns.org'
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL!
 
 export default function sitemap(): MetadataRoute.Sitemap {
   return [

--- a/src/components/Landing/LandingHero.tsx
+++ b/src/components/Landing/LandingHero.tsx
@@ -7,7 +7,7 @@ export default function LandingHero() {
     <section className="relative flex min-h-screen w-full items-center justify-center overflow-hidden">
       <Image
         src="/img/landing.jpg"
-        alt="Landing-hero"
+        alt="당신만을 위한 맞춤 향기 추천"
         fill
         priority
         sizes="100vw"
@@ -39,7 +39,7 @@ export default function LandingHero() {
         >
           당신만을 위한
           <br />
-          맞춤 향 추천
+          맞춤 향기 추천
         </motion.h1>
 
         <motion.p


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->

랜딩 페이지 SEO 기본 설정을 추가 하였습니다.
메타데이터, OpenGraph, robots.txt, sitemap.xml,
Google Search Console 인증 태그를 포함 시켰습니다.

## 📌 관련 이슈

<!-- Closes #이슈번호 -->

Closes #235

## 🧩 작업 내용 (주요 변경사항)

- layout.tsx: title template / description / keywords / OpenGraph / Twitter Card / robots 메타데이터 추가
- page.tsx: canonical URL 설정 (`alternates.canonical`)
- robots.ts: 크롤러 규칙 정의
- sitemap.ts: 주요 6개 경로 등록하여  -> XML로 파일 변환하여 검색엔진(구글, 네이버 등)이 읽기 위한 표준 포맷으로 return


## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

robots 차단 경로(`/admin`, `/login`, `/profile`)는 현재 3가지 페이지 입니다
적용된 Google Search Console 인증 태그를 통해 소유권 확인 후 색인 요청 받아야 합니다.

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

OG 이미지는 메인 화면 이미지 입니다.

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
