### PR TITLE
chore: 페이지별 metadata 추가 및 잘못된 환경 변수 설정 수정 (#235)

### DIFF
--- a/src/app/find-my-scent/ai-visual/page.tsx
+++ b/src/app/find-my-scent/ai-visual/page.tsx
@@ -1,5 +1,14 @@
-/** AI 비주얼 분석 — 모달 UI로 진입 */
+import type { Metadata } from 'next'
 import { AIVisualClient } from './AIVisualClient'
+
+export const metadata: Metadata = {
+  title: 'AI 비주얼 분석',
+  description:
+    '인테리어·OOTD 사진을 올리면 AI가 분위기를 읽고 어울리는 향기를 찾아줍니다.',
+  alternates: {
+    canonical: `${process.env.NEXT_PUBLIC_SITE_URL}/find-my-scent/ai-visual`,
+  },
+}
 
 export default function AIVisualPage() {
   return <AIVisualClient />

--- a/src/app/find-my-scent/taste-test/layout.tsx
+++ b/src/app/find-my-scent/taste-test/layout.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: '취향 테스트',
+  description:
+    '생활 방식과 취향을 분석해 나의 일상에 꼭 맞는 향기를 추천합니다.',
+  alternates: {
+    canonical: `${process.env.NEXT_PUBLIC_SITE_URL}/find-my-scent/taste-test`,
+  },
+}
+
+export default function TasteTestLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return children
+}

--- a/src/app/find-my-scent/wellness/layout.tsx
+++ b/src/app/find-my-scent/wellness/layout.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: '웰니스 케어 진단',
+  description:
+    '현재 컨디션과 건강 상태를 체크해 심신 안정에 도움이 되는 아로마를 제안합니다.',
+  alternates: {
+    canonical: `${process.env.NEXT_PUBLIC_SITE_URL}/find-my-scent/wellness`,
+  },
+}
+
+export default function WellnessLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return children
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,7 +14,7 @@ const pretendard = localFont({
   variable: '--font-pretendard',
 })
 
-const BASE_URL = process.env.NEXT_PUBLIC_API_URL!
+const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL!
 
 export const metadata: Metadata = {
   metadataBase: new URL(BASE_URL),
@@ -40,7 +40,7 @@ export const metadata: Metadata = {
     locale: 'ko_KR',
     url: BASE_URL,
     siteName: 'Ozent',
-    title: 'Ozent | 나만의 향기 추천 플랫폼',
+    title: 'Ozent | 나의 향기를 찾다',
     description:
       '취향 테스트·웰니스 진단·AI 비주얼 분석으로 나에게 꼭 맞는 향기와 제품을 한번에 찾아드립니다.',
     images: [
@@ -54,7 +54,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Ozent | 나만의 향기 추천 플랫폼',
+    title: 'Ozent | 나의 향기를 찾다',
     description:
       '취향 테스트·웰니스 진단·AI 비주얼 분석으로 나에게 꼭 맞는 향기와 제품을 한번에 찾아드립니다.',
     images: ['/img/landing.jpg'],
@@ -66,6 +66,9 @@ export const metadata: Metadata = {
   verification: {
     google: process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION,
   },
+  icons: {
+    icon: [{ url: '/favicon.ico', sizes: 'any', type: 'image/x-icon' }],
+  },
 }
 
 export default function RootLayout({
@@ -73,8 +76,33 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode
 }>) {
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    name: 'Ozent',
+    url: BASE_URL,
+    description:
+      '취향 테스트·웰니스 진단·AI 비주얼 분석으로 나에게 꼭 맞는 향기와 제품을 한번에 찾아드립니다.',
+    inLanguage: 'ko-KR',
+    publisher: {
+      '@type': 'Organization',
+      name: 'Ozent',
+      url: BASE_URL,
+      logo: {
+        '@type': 'ImageObject',
+        url: `${BASE_URL}/logo.svg`,
+      },
+    },
+  }
+
   return (
     <html lang="ko">
+      <head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
+      </head>
       <body
         className={`${pretendard.variable} flex min-h-screen flex-col antialiased`}
       >

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,7 @@ import LandingCard from '@/components/Landing/LandingCard'
 // 웹사이트 중복 문제 해결을 위한 canonical 설정
 export const metadata: Metadata = {
   alternates: {
-    canonical: 'https://oz-scent-match.duckdns.org',
+    canonical: process.env.NEXT_PUBLIC_SITE_URL,
   },
 }
 

--- a/src/app/products/combo/page.tsx
+++ b/src/app/products/combo/page.tsx
@@ -1,5 +1,14 @@
-/** 조합 향기 목록: 서버에서 목록 조회 후 클라이언트에 전달 */
+import type { Metadata } from 'next'
 import { FetchError } from '@/lib/api'
+
+export const metadata: Metadata = {
+  title: '조합 향기',
+  description:
+    '여러 향기를 조합한 블렌드 제품을 탐색하세요. AI 추천과 향조 필터로 나만의 완벽한 향기 조합을 찾아드립니다.',
+  alternates: {
+    canonical: `${process.env.NEXT_PUBLIC_SITE_URL}/products/combo`,
+  },
+}
 import { SkeletonDelay } from '@/components/products/ScentListSkeleton'
 import {
   enrichBlendListItemsWithContainedElements,

--- a/src/app/products/single/page.tsx
+++ b/src/app/products/single/page.tsx
@@ -1,5 +1,14 @@
-/** 단품 향기 목록: 서버에서 목록 조회 후 클라이언트에 전달 */
+import type { Metadata } from 'next'
 import { FetchError } from '@/lib/api'
+
+export const metadata: Metadata = {
+  title: '단품 향기',
+  description:
+    '취향에 맞는 단품 향기 제품을 한번에 찾아보세요. 향조 필터로 나만의 시그니처 향을 탐색할 수 있습니다.',
+  alternates: {
+    canonical: `${process.env.NEXT_PUBLIC_SITE_URL}/products/single`,
+  },
+}
 import { SkeletonDelay } from '@/components/products/ScentListSkeleton'
 import { fetchElements } from '../_api/productsClient'
 import { ProductsListError } from '../_components/ProductsListError'

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,6 +1,6 @@
 import type { MetadataRoute } from 'next'
 
-const BASE_URL = process.env.NEXT_PUBLIC_API_URL!
+const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL!
 
 export default function robots(): MetadataRoute.Robots {
   return {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,6 +1,6 @@
 import type { MetadataRoute } from 'next'
 
-const BASE_URL = process.env.NEXT_PUBLIC_API_URL!
+const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL!
 
 export default function sitemap(): MetadataRoute.Sitemap {
   return [


### PR DESCRIPTION
## ✨ PR 개요

<!-- 어떤 작업을 했는지 간략히 요약 -->

주요 페이지들에도 metadata를 추가 
잘못된 환경변수 불러오고 있던 부분을 수정

## 📌 관련 이슈

<!-- Closes #이슈번호 -->

Closes #235 

## 🧩 작업 내용 (주요 변경사항)

- process.env.NEXT_PUBLIC_API_URL -> process.env.NEXT_PUBLIC_SITE_URL 잘못된 경로로 불러오고 있었던 부분을 수정
- sitemap.ts에 존재하는 페이지들에 모두 metadata추가 title , description 값 추가

## 💬 리뷰 포인트

<!-- 특히 봐줬으면 하는 부분 (예: 상태관리 로직 구조 괜찮은지 봐주세요) -->

```
export const metadata: Metadata = {
  title: '제목',
  description:
    '내용',
  alternates: {
    canonical: `${process.env.NEXT_PUBLIC_SITE_URL}/페이지 경로`,
  },
}
```

추가하여 각 페이지에 metadata가 적용될 수 있도록 추가 하였습니다.

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 캡처나 GIF 첨부 -->

## 🧠 기타 참고사항

<!-- 추가로 알아야 할 점 (예: 임시로 넣은 더미 데이터 있음) -->

실제 OG 사진이 넘어가는지 테스트 해보겠습니다
OG 이미지의 src는 웹에서도 띄워짐을 확인하였음

## ✅ PR 체크리스트

- [x] 커밋 컨벤션 준수 (예: `feat: 로그인 구현`)
- [x] 불필요한 console.log 제거
- [x] 로컬에서 실행 확인 완료
